### PR TITLE
Shorthand WebSocketTransport factories with serializers

### DIFF
--- a/lib/src/transport/websocket/websocket_transport_html.dart
+++ b/lib/src/transport/websocket/websocket_transport_html.dart
@@ -10,6 +10,9 @@ import '../../message/goodbye.dart';
 import '../../message/abstract_message.dart';
 import '../../serializer/abstract_serializer.dart';
 import '../../transport/abstract_transport.dart';
+import '../../serializer/json/serializer.dart' as serializer_json;
+import '../../serializer/msgpack/serializer.dart' as serializer_msgpack;
+import '../../serializer/cbor/serializer.dart' as serializer_cbor;
 
 class WebSocketTransport extends AbstractTransport {
   static final Logger _logger = Logger('WebSocketTransport');
@@ -31,6 +34,18 @@ class WebSocketTransport extends AbstractTransport {
   ) : assert(_serializerType == WebSocketSerialization.serializationJson ||
             _serializerType == WebSocketSerialization.serializationMsgpack ||
             _serializerType == WebSocketSerialization.serializationCbor);
+
+  factory WebSocketTransport.withJsonSerializer(String url) =>
+      WebSocketTransport(url, serializer_json.Serializer(),
+          WebSocketSerialization.serializationJson);
+
+  factory WebSocketTransport.withMsgpackSerializer(String url) =>
+      WebSocketTransport(url, serializer_msgpack.Serializer(),
+          WebSocketSerialization.serializationMsgpack);
+
+  factory WebSocketTransport.withCborSerializer(String url) =>
+      WebSocketTransport(url, serializer_cbor.Serializer(),
+          WebSocketSerialization.serializationCbor);
 
   /// Calling close will close the underlying socket connection
   @override

--- a/lib/src/transport/websocket/websocket_transport_io.dart
+++ b/lib/src/transport/websocket/websocket_transport_io.dart
@@ -9,6 +9,9 @@ import 'websocket_transport_serialization.dart';
 import '../../message/abstract_message.dart';
 import '../../serializer/abstract_serializer.dart';
 import '../../transport/abstract_transport.dart';
+import '../../serializer/json/serializer.dart' as serializer_json;
+import '../../serializer/msgpack/serializer.dart' as serializer_msgpack;
+import '../../serializer/cbor/serializer.dart' as serializer_cbor;
 
 /// This transport type is used to connect via web sockets
 /// in a dart vm environment. A known issue is that this
@@ -35,6 +38,21 @@ class WebSocketTransport extends AbstractTransport {
       : assert(_serializerType == WebSocketSerialization.serializationJson ||
             _serializerType == WebSocketSerialization.serializationMsgpack ||
             _serializerType == WebSocketSerialization.serializationCbor);
+
+  factory WebSocketTransport.withJsonSerializer(String url,
+          [Map<String, dynamic>? headers]) =>
+      WebSocketTransport(url, serializer_json.Serializer(),
+          WebSocketSerialization.serializationJson, headers);
+
+  factory WebSocketTransport.withMsgpackSerializer(String url,
+          [Map<String, dynamic>? headers]) =>
+      WebSocketTransport(url, serializer_msgpack.Serializer(),
+          WebSocketSerialization.serializationMsgpack, headers);
+
+  factory WebSocketTransport.withCborSerializer(String url,
+          [Map<String, dynamic>? headers]) =>
+      WebSocketTransport(url, serializer_cbor.Serializer(),
+          WebSocketSerialization.serializationCbor, headers);
 
   /// Calling close will close the underlying socket connection
   @override

--- a/lib/src/transport/websocket/websocket_transport_none.dart
+++ b/lib/src/transport/websocket/websocket_transport_none.dart
@@ -2,10 +2,29 @@ import 'dart:async';
 
 import '../abstract_transport.dart';
 import '../../message/abstract_message.dart';
+import '../../serializer/json/serializer.dart' as serializer_json;
+import '../../serializer/msgpack/serializer.dart' as serializer_msgpack;
+import '../../serializer/cbor/serializer.dart' as serializer_cbor;
+import 'websocket_transport_serialization.dart';
 
 /// This is a mock class to provide a unified interface for js and native usage of this package
 class WebSocketTransport extends AbstractTransport {
   WebSocketTransport(url, serializer, serializerType, [additionalHeaders]);
+
+  factory WebSocketTransport.withJsonSerializer(String url,
+          [Map<String, dynamic>? additionalHeaders]) =>
+      WebSocketTransport(url, serializer_json.Serializer(),
+          WebSocketSerialization.serializationJson, additionalHeaders);
+
+  factory WebSocketTransport.withMsgpackSerializer(String url,
+          [Map<String, dynamic>? additionalHeaders]) =>
+      WebSocketTransport(url, serializer_msgpack.Serializer(),
+          WebSocketSerialization.serializationMsgpack, additionalHeaders);
+
+  factory WebSocketTransport.withCborSerializer(String url,
+          [Map<String, dynamic>? additionalHeaders]) =>
+      WebSocketTransport(url, serializer_cbor.Serializer(),
+          WebSocketSerialization.serializationCbor, additionalHeaders);
 
   /// on connection lost will only complete if the other end closes unexpectedly
   @override

--- a/test/client_on_transport_io_events_test.dart
+++ b/test/client_on_transport_io_events_test.dart
@@ -35,8 +35,8 @@ void main() {
       }
 
       server.listen(serverListenHandler);
-      final transport = WebSocketTransport('ws://localhost:9200/wamp',
-          Serializer(), WebSocketSerialization.serializationJson);
+      final transport =
+          WebSocketTransport.withJsonSerializer('ws://localhost:9200/wamp');
       final client = Client(realm: 'com.connectanum', transport: transport);
       var closeCompleter = Completer();
       client
@@ -70,8 +70,8 @@ void main() {
       }
 
       server.listen(serverListenHandler);
-      final transport = WebSocketTransport('ws://localhost:9201/wamp',
-          Serializer(), WebSocketSerialization.serializationJson);
+      final transport =
+          WebSocketTransport.withJsonSerializer('ws://localhost:9201/wamp');
       final client = Client(realm: 'com.connectanum', transport: transport);
       var closeCompleter = Completer();
       var reconnects = 0;
@@ -121,8 +121,8 @@ void main() {
       }
 
       server.listen(serverListenHandler);
-      final transport = WebSocketTransport('ws://localhost:9202/wamp',
-          Serializer(), WebSocketSerialization.serializationJson);
+      final transport =
+          WebSocketTransport.withJsonSerializer('ws://localhost:9202/wamp');
       final client = Client(realm: 'com.connectanum', transport: transport);
       var closeCompleter = Completer();
       var reconnects = 0;
@@ -150,8 +150,8 @@ void main() {
 
     test('test on connect web socket transport and no server available',
         () async {
-      final transport = WebSocketTransport('ws://localhost:9203/wamp',
-          Serializer(), WebSocketSerialization.serializationJson);
+      final transport =
+          WebSocketTransport.withJsonSerializer('ws://localhost:9203/wamp');
       final client = Client(realm: 'com.connectanum', transport: transport);
       var closeCompleter = Completer();
       client

--- a/test/client_on_transport_io_events_test.dart
+++ b/test/client_on_transport_io_events_test.dart
@@ -10,7 +10,6 @@ import 'package:connectanum/src/serializer/json/serializer.dart';
 import 'package:connectanum/src/transport/socket/socket_helper.dart';
 import 'package:connectanum/src/transport/socket/socket_transport.dart';
 import 'package:connectanum/src/transport/websocket/websocket_transport_io.dart';
-import 'package:connectanum/src/transport/websocket/websocket_transport_serialization.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/transport/websocket/websocket_transport_html_test.dart
+++ b/test/transport/websocket/websocket_transport_html_test.dart
@@ -1,16 +1,8 @@
 @TestOn('browser')
-
 import 'package:connectanum/src/message/details.dart';
 import 'package:connectanum/src/message/hello.dart';
 import 'package:connectanum/src/message/welcome.dart';
-import 'package:connectanum/src/serializer/json/serializer.dart'
-    as json_serializer;
-import 'package:connectanum/src/serializer/msgpack/serializer.dart'
-    as msgpack_serializer;
-import 'package:connectanum/src/serializer/cbor/serializer.dart'
-    as cbor_serializer;
 import 'package:connectanum/src/transport/websocket/websocket_transport_html.dart';
-import 'package:connectanum/src/transport/websocket/websocket_transport_serialization.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -20,20 +12,14 @@ void main() {
         () async {
       spawnHybridUri('websocket_transport_html_server.dart');
       var port = 9101;
-      var transportJSON = WebSocketTransport(
-          'ws://localhost:$port/wamp',
-          json_serializer.Serializer(),
-          WebSocketSerialization.serializationJson);
+      var transportJSON =
+          WebSocketTransport.withJsonSerializer('ws://localhost:$port/wamp');
 
-      var transportMsgpack = WebSocketTransport(
-          'ws://localhost:$port/wamp',
-          msgpack_serializer.Serializer(),
-          WebSocketSerialization.serializationMsgpack);
+      var transportMsgpack =
+          WebSocketTransport.withMsgpackSerializer('ws://localhost:$port/wamp');
 
-      var transportCbor = WebSocketTransport(
-          'ws://localhost:$port/wamp',
-          cbor_serializer.Serializer(),
-          WebSocketSerialization.serializationCbor);
+      var transportCbor =
+          WebSocketTransport.withCborSerializer('ws://localhost:$port/wamp');
 
       print('Start opening json server transport');
       await transportJSON.open();

--- a/test/transport/websocket/websocket_transport_io_test.dart
+++ b/test/transport/websocket/websocket_transport_io_test.dart
@@ -1,5 +1,4 @@
 @TestOn('vm')
-
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -7,15 +6,6 @@ import 'package:connectanum/src/message/details.dart';
 import 'package:connectanum/src/message/hello.dart';
 import 'package:connectanum/src/message/message_types.dart';
 import 'package:connectanum/src/message/welcome.dart';
-import 'package:connectanum/src/serializer/json/serializer.dart'
-    // ignore: library_prefixes
-    as jsonSerializer;
-import 'package:connectanum/src/serializer/msgpack/serializer.dart'
-    // ignore: library_prefixes
-    as msgpackSerializer;
-import 'package:connectanum/src/serializer/cbor/serializer.dart'
-    // ignore: library_prefixes
-    as cborSerializer;
 import 'package:connectanum/src/transport/websocket/websocket_transport_io.dart';
 import 'package:connectanum/src/transport/websocket/websocket_transport_serialization.dart';
 import 'package:test/test.dart';
@@ -57,26 +47,19 @@ void main() {
         }
       });
 
-      var transportJSON = WebSocketTransport(
-          'ws://localhost:9100/wamp',
-          jsonSerializer.Serializer(),
-          WebSocketSerialization.serializationJson);
+      var transportJSON =
+          WebSocketTransport.withJsonSerializer('ws://localhost:9100/wamp');
 
-      var transportMsgpack = WebSocketTransport(
-          'ws://localhost:9100/wamp',
-          msgpackSerializer.Serializer(),
-          WebSocketSerialization.serializationMsgpack);
+      var transportMsgpack =
+          WebSocketTransport.withMsgpackSerializer('ws://localhost:9100/wamp');
 
-      var transportCbor = WebSocketTransport(
-          'ws://localhost:9100/wamp',
-          cborSerializer.Serializer(),
-          WebSocketSerialization.serializationCbor);
+      var transportCbor =
+          WebSocketTransport.withCborSerializer('ws://localhost:9100/wamp');
 
-      var transportWithHeaders = WebSocketTransport(
-          'ws://localhost:9100/wamp',
-          jsonSerializer.Serializer(),
-          WebSocketSerialization.serializationJson,
-          {'X_Custom_Header': 'custom_value'});
+      var transportWithHeaders = WebSocketTransport.withJsonSerializer(
+        'ws://localhost:9100/wamp',
+        {'X_Custom_Header': 'custom_value'},
+      );
 
       await transportJSON.open();
       transportJSON.send(Hello('my.realm', Details.forHello()));


### PR DESCRIPTION
Adds shorthand constructors to WebSocketTransport classes, so attaching a serializer to one is now a bit simpler.
The user code will be slightly more concise also.