### PR TITLE
Add external logging controls

### DIFF
--- a/lib/logging.dart
+++ b/lib/logging.dart
@@ -1,0 +1,2 @@
+export 'src/logging.dart';
+export 'package:logging/logging.dart' show Level;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -12,7 +12,7 @@ import 'message/uri_pattern.dart';
 import 'protocol/session.dart';
 
 class Client {
-  static final Logger _logger = Logger('Client');
+  static final Logger _logger = Logger('Connectanum.Client');
 
   String? authId;
   String? authRole;

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -1,0 +1,3 @@
+import 'package:logging/logging.dart';
+
+final rootLogger = Logger('Connectanum');

--- a/lib/src/protocol/session.dart
+++ b/lib/src/protocol/session.dart
@@ -35,7 +35,7 @@ import '../message/e2ee_payload.dart';
 import '../message/ppt_payload.dart';
 
 class Session {
-  static final Logger _logger = Logger('Session');
+  static final Logger _logger = Logger('Connectanum.Session');
 
   /// The sessions [id]
   int? id;

--- a/lib/src/serializer/cbor/serializer.dart
+++ b/lib/src/serializer/cbor/serializer.dart
@@ -15,7 +15,7 @@ import '../../message/ppt_payload.dart';
 /// This is a seralizer for msgpack messages.
 /// It is used to initialize an [AbstractTransport] object.
 class Serializer extends AbstractSerializer {
-  static final Logger _logger = Logger('Serializer');
+  static final Logger _logger = Logger('Connectanum.Serializer');
 
   @override
   AbstractMessage? deserialize(Uint8List? message) {

--- a/lib/src/serializer/json/serializer.dart
+++ b/lib/src/serializer/json/serializer.dart
@@ -38,7 +38,7 @@ import '../abstract_serializer.dart';
 /// object.
 class Serializer extends AbstractSerializer {
   static final RegExp _binaryPrefix = RegExp('\x00');
-  static final Logger _logger = Logger('Serializer');
+  static final Logger _logger = Logger('Connectanum.Serializer');
 
   /// Converts a uint8 JSON message into a WAMP message object
   @override

--- a/lib/src/serializer/msgpack/serializer.dart
+++ b/lib/src/serializer/msgpack/serializer.dart
@@ -36,7 +36,7 @@ import '../abstract_serializer.dart';
 /// This is a seralizer for msgpack messages.
 /// It is used to initialize an [AbstractTransport] object.
 class Serializer extends AbstractSerializer {
-  static final Logger _logger = Logger('Serializer');
+  static final Logger _logger = Logger('Connectanum.Serializer');
 
   /// Converts a uint8 msgpack message into a WAMP message object
   @override

--- a/lib/src/transport/socket/socket_transport.dart
+++ b/lib/src/transport/socket/socket_transport.dart
@@ -15,7 +15,7 @@ import '../abstract_transport.dart';
 /// capable of using connectanums own upgrade method to allow more then 16MB of
 /// payload.
 class SocketTransport extends AbstractTransport {
-  static final _logger = Logger('SocketTransport');
+  static final _logger = Logger('Connectanum.SocketTransport');
 
   late bool _ssl;
   late bool _allowInsecureCertificates;

--- a/lib/src/transport/websocket/websocket_transport_html.dart
+++ b/lib/src/transport/websocket/websocket_transport_html.dart
@@ -12,7 +12,7 @@ import '../../serializer/abstract_serializer.dart';
 import '../../transport/abstract_transport.dart';
 
 class WebSocketTransport extends AbstractTransport {
-  static final Logger _logger = Logger('WebSocketTransport');
+  static final Logger _logger = Logger('Connectanum.WebSocketTransport');
 
   final String _url;
   final AbstractSerializer _serializer;

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:connectanum/authentication.dart';
 import 'package:connectanum/connectanum.dart';
+import 'package:connectanum/src/logging.dart';
 import 'package:connectanum/src/message/authenticate.dart';
 import 'package:connectanum/src/message/hello.dart';
 import 'package:connectanum/src/message/message_types.dart';
@@ -30,7 +31,7 @@ void main() {
         }
       });
       late LogRecord measuredRecord;
-      Logger.root.onRecord.listen((record) {
+      rootLogger.onRecord.listen((record) {
         measuredRecord = record;
       });
       final session = await client.connect().first;
@@ -910,7 +911,7 @@ void main() {
         }
       });
       late LogRecord measuredRecord;
-      Logger.root.onRecord.listen((record) {
+      rootLogger.onRecord.listen((record) {
         measuredRecord = record;
       });
       final session = await client.connect().first;


### PR DESCRIPTION
Using Logger.root goes around the hierarchy of loggers the users of the library might want to enforce.
This PR creates a library root logger, that the users of the library can interact with and process logs in their own way.