### PR TITLE
Rework connection re-establishment with streams, add Client.disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.6
+
+- @yurii-prykhodko-solid reworked connection recovery with streams, added Client().disconnect()
+
 ### 2.0.5
 
 - @yurii-prykhodko-solid enhanced external logging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.0.6
+### 2.1.0
 
 - @yurii-prykhodko-solid reworked connection recovery with streams, added Client().disconnect()
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -70,6 +70,8 @@ void main() async {
     // close both clients after everything is done
     unawaited(session1.close());
     unawaited(session2.close());
+    unawaited(client1.disconnect());
+    unawaited(client2.disconnect());
   } on Abort catch (abort) {
     print(abort.message!.message);
   }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -14,7 +14,7 @@ import 'protocol/session.dart';
 export 'package:logging/logging.dart' show Level;
 
 enum _ClientState {
-  /// Client is idle and not connected / connecting
+  /// Client is idle and not connected
   none,
 
   /// Client is connecting and waiting for a session

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,8 +11,6 @@ import 'transport/abstract_transport.dart';
 import 'message/uri_pattern.dart';
 import 'protocol/session.dart';
 
-export 'package:logging/logging.dart' show Level;
-
 enum _ClientState {
   /// Client is idle and not connected
   none,

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -153,7 +153,7 @@ class Client {
     _changeState(_ClientState.waiting);
 
     if (duration != null) {
-      _logger.info('Waiting for (overriden) $duration before reconnecting');
+      _logger.info('Waiting for (overridden) $duration before reconnecting');
       await Future.delayed(duration);
     } else {
       _logger.info('Waiting for ${options.reconnectTime!} before reconnecting');
@@ -161,7 +161,7 @@ class Client {
     }
     if (localReconnectWatcher != _reconnectWatcher) {
       return _logger.warning(
-        'Cancelling reconnect becase a newer one was requested while waiting',
+        'Cancelling reconnect because a newer one was requested while waiting',
       );
     }
     return _connectStreamController.add(options);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,7 +11,31 @@ import 'transport/abstract_transport.dart';
 import 'message/uri_pattern.dart';
 import 'protocol/session.dart';
 
+export 'package:logging/logging.dart' show Level;
+
+enum _ClientState {
+  /// Client is idle and not connected / connecting
+  none,
+
+  /// Client is connecting and waiting for a session
+  waiting,
+
+  /// Client has connected and session is active, transport is open
+  active,
+
+  /// Client has finished or is in process of disconnecting, cleaning up, closing transports etc
+  done,
+}
+
 class Client {
+  static const _abortReasons = [
+    Error.notAuthorized,
+    Error.noPrincipal,
+    Error.authorizationFailed,
+    Error.noSuchRealm,
+    Error.protocolViolation,
+  ];
+
   static final Logger _logger = Logger('Client');
 
   String? authId;
@@ -19,13 +43,17 @@ class Client {
   String? realm;
   Map<String, dynamic>? authExtra;
   int isolateCount;
-  final StreamController<ClientConnectOptions> _reconnectStreamController =
-      StreamController<ClientConnectOptions>();
+  int _reconnectCount = 0;
+  _ClientState _state = _ClientState.none;
+
+  final StreamController<ClientConnectOptions> _connectStreamController =
+      StreamController<ClientConnectOptions>.broadcast();
   AbstractTransport transport;
   List<AbstractAuthentication>? authenticationMethods;
 
-  int _reconnectCount = 3;
   final StreamController<Session> _controller = StreamController<Session>();
+
+  StreamSubscription<ClientConnectOptions>? _connectStreamSubscription;
 
   /// The client connects to the wamp server by using the given [transport] and
   /// the given [authenticationMethods]. Passing more then one [AbstractAuthentication]
@@ -57,7 +85,10 @@ class Client {
       this.authenticationMethods,
       this.authExtra,
       this.isolateCount = 1})
-      : assert(realm == null || UriPattern.match(realm));
+      : assert(realm == null || UriPattern.match(realm)) {
+    _connectStreamSubscription =
+        _connectStreamController.stream.listen(_connect);
+  }
 
   /// if listened to this stream you will be noticed about reconnect tries. The passed
   /// integer will be the current retry counted down from where you started in the configured
@@ -65,7 +96,7 @@ class Client {
   /// before the [connect] streams [onError] will raise the abort message. So 0 means
   /// that the reconnect failed.
   Stream<ClientConnectOptions> get onNextTryToReconnect =>
-      _reconnectStreamController.stream;
+      _connectStreamController.stream;
 
   /// Calling this method will start the authentication process and result into
   /// a [Session] object on success. If a [pingInterval] is given and the underlying transport
@@ -77,68 +108,135 @@ class Client {
   /// times reconnect the client or until the stack overflows
   Stream<Session> connect({ClientConnectOptions? options}) {
     options ??= ClientConnectOptions();
-    _reconnectCount = options.reconnectCount;
-    _connect(options);
+
+    _changeState(_ClientState.waiting);
+
+    /// Increment reconnectCount by 1 because we use one for initial connect
+    options.reconnectCount =
+        options.reconnectCount == -1 ? -1 : options.reconnectCount + 1;
+    _connectStreamController.add(options);
+
     return _controller.stream;
   }
 
-  void _connect(ClientConnectOptions options) async {
-    await transport.open(pingInterval: options.pingInterval);
-    if (transport.isOpen && transport.onConnectionLost != null) {
-      unawaited(transport.onConnectionLost!.future.then((_) async {
-        await Future.delayed(options.reconnectTime!);
-        options.reconnectCount = _reconnectCount;
-        _reconnectStreamController.add(options);
-        _connect(options);
-      }));
-      try {
-        var session = await Session.start(realm, transport,
-            authId: authId,
-            authRole: authRole,
-            authMethods: authenticationMethods,
-            authExtra: authExtra,
-            reconnect: options.reconnectTime);
-        _controller.add(session);
-      } on Abort catch (abort) {
-        if (![
-              Error.notAuthorized,
-              Error.noPrincipal,
-              Error.authorizationFailed,
-              Error.noSuchRealm,
-              Error.protocolViolation
-            ].contains(abort.reason) &&
-            options.reconnectTime != null) {
-          // if the router restarts we should wait until it has been initialized
-          await Future.delayed(Duration(seconds: 2));
-          options.reconnectCount = 0;
-          _connect(options);
-        } else {
-          _controller.addError(abort);
-        }
-      } on Goodbye catch (goodbye) {
-        _logger.shout(goodbye.reason);
-        unawaited(_controller.close());
-      }
-    } else {
-      if (options.reconnectTime != null &&
-          transport.onConnectionLost!.isCompleted) {
-        _reconnectStreamController.add(options);
-        if (options.reconnectCount == 0) {
-          _controller.addError(Abort(Error.authorizationFailed,
-              message:
-                  'Could not connect to server. Please configure reconnectTime to retry automatically.'));
-        } else {
-          await Future.delayed(options.reconnectTime!);
-          options.reconnectCount =
-              options.reconnectCount == -1 ? -1 : options.reconnectCount - 1;
-          _connect(options);
-        }
-      } else {
-        _controller.addError(Abort(Error.authorizationFailed,
-            message:
-                'Could not connect to server. Please configure reconnectTime to retry automatically.'));
-      }
+  /// Close connection.
+  ///
+  /// After calling the method, this instance of Client can no longer be used.
+  Future<void> disconnect() async {
+    _logger.shout('Disconnecting');
+    _changeState(_ClientState.done);
+    await _connectStreamSubscription?.cancel();
+    await _connectStreamController.close();
+    await _controller.close();
+    await transport.close();
+  }
+
+  void _reconnect(ClientConnectOptions options, {Duration? duration}) async {
+    if (options.reconnectCount == 0) {
+      _controller.addError(
+        Abort(
+          Error.authorizationFailed,
+          message: 'Could not connect to server. Ran out of reconnect attempts',
+        ),
+      );
+      return await disconnect();
     }
+    _reconnectCount++;
+
+    // localReconnectCount is used to avoid race condition between simultaneous reconnects requested by different parties (transport, session)
+    final localReconnectCount = _reconnectCount;
+    _logger.info('Internal reconnect count: $_reconnectCount');
+
+    _changeState(_ClientState.waiting);
+
+    if (duration != null) {
+      _logger.info('Waiting for (overriden) $duration before reconnecting');
+      await Future.delayed(duration);
+    } else {
+      _logger.info('Waiting for ${options.reconnectTime!} before reconnecting');
+      await Future.delayed(options.reconnectTime!);
+    }
+    if (localReconnectCount != _reconnectCount) {
+      return _logger.warning(
+        'Cancelling reconnect becase a newer one was requested while waiting',
+      );
+    }
+    return _connectStreamController.add(options);
+  }
+
+  void _changeState(_ClientState newState) {
+    if (_state != newState) {
+      _logger.info('Changed state: $_state -> $newState');
+    }
+    _state = newState;
+  }
+
+  void _connect(ClientConnectOptions options) async {
+    _logger.info('Connecting, attempts remaining: ${options.reconnectCount}');
+    await transport.open(pingInterval: options.pingInterval);
+
+    /// Transport failed opening / initializing
+    if (!transport.isOpen || transport.onConnectionLost == null) {
+      if (options.reconnectTime == null || options.reconnectCount == 0) {
+        _logger.shout(
+          'Unable to reconnect - reconnectTime is null or reconnectCount is 0',
+        );
+        _controller.addError(
+          Abort(
+            Error.authorizationFailed,
+            message:
+                'Could not connect to server. Please configure reconnectTime to retry automatically.',
+          ),
+        );
+        return await disconnect();
+      }
+
+      return _reconnect(options.minusReconnectRetry());
+    }
+
+    /// Listen to on connection lost
+    transport.onConnectionLost!.future.then((_) async {
+      _logger.info('Transport connection lost, client state is: $_state');
+
+      if (_state != _ClientState.done) {
+        _reconnect(options.minusReconnectRetry());
+      }
+    });
+
+    try {
+      final session = await Session.start(
+        realm,
+        transport,
+        authId: authId,
+        authRole: authRole,
+        authMethods: authenticationMethods,
+        reconnect: options.reconnectTime,
+      );
+      _controller.add(session);
+      _changeState(_ClientState.active);
+    } on Abort catch (abort) {
+      _onSessionAbort(abort, options);
+    } on Goodbye catch (goodbye) {
+      _onSessionGoodbye(goodbye);
+    }
+  }
+
+  void _onSessionAbort(Abort abort, ClientConnectOptions options) async {
+    _logger.shout('Abort reason: ${abort.reason}');
+    _controller.addError(abort);
+
+    if (_abortReasons.contains(abort.reason) || options.reconnectTime == null) {
+      _logger.info('Disconnecting because of reason received: ${abort.reason}');
+      return await disconnect();
+    }
+
+    // if the router restarts we should wait until it has been initialized, hence custom duration
+    _reconnect(options.minusReconnectRetry(), duration: Duration(seconds: 2));
+  }
+
+  void _onSessionGoodbye(Goodbye goodbye) async {
+    _logger.shout('Goodbye reason: ${goodbye.reason}');
+    await disconnect();
   }
 }
 
@@ -147,6 +245,14 @@ class ClientConnectOptions {
   Duration? reconnectTime;
   Duration? pingInterval;
 
-  ClientConnectOptions(
-      {this.reconnectCount = 3, this.reconnectTime, this.pingInterval});
+  ClientConnectOptions({
+    this.reconnectCount = 3,
+    this.reconnectTime,
+    this.pingInterval,
+  });
+
+  ClientConnectOptions minusReconnectRetry() {
+    reconnectCount = reconnectCount == -1 ? -1 : reconnectCount - 1;
+    return this;
+  }
 }

--- a/lib/src/message/error.dart
+++ b/lib/src/message/error.dart
@@ -21,16 +21,17 @@ class Error extends AbstractMessageWithPayload {
   static final String unknown = 'wamp.error.unknown';
 
   // AUTHORIZATION ERRORS
-  static final String notAuthorized = 'wamp.error.not_authorized';
-  static final String noPrincipal = 'wamp.error.no_such_principal';
-  static final String authorizationFailed = 'wamp.error.authorization_failed';
-  static final String noSuchRealm = 'wamp.error.no_such_realm';
-  static final String noSuchRole = 'wamp.error.no_such_role';
-  static final String noSuchTopic = 'wamp.error.no_such_topic';
-  static final String noSuchSession = 'wamp.error.no_such_session';
-  static final String protocolViolation = 'wamp.error.protocol_violation';
+  static const String notAuthorized = 'wamp.error.not_authorized';
+  static const String noPrincipal = 'wamp.error.no_such_principal';
+  static const String authorizationFailed = 'wamp.error.authorization_failed';
+  static const String noSuchRealm = 'wamp.error.no_such_realm';
+  static const String noSuchRole = 'wamp.error.no_such_role';
+  static const String noSuchTopic = 'wamp.error.no_such_topic';
+  static const String noSuchSession = 'wamp.error.no_such_session';
+  static const String protocolViolation = 'wamp.error.protocol_violation';
+  static const String authenticationFailed = 'wamp.error.authentication_failed';
 
-  static final String hiddenErrorMessage = 'unknown';
+  static const String hiddenErrorMessage = 'unknown';
 
   int requestTypeId;
   int requestId;

--- a/lib/src/message/error.dart
+++ b/lib/src/message/error.dart
@@ -3,22 +3,23 @@ import 'message_types.dart';
 
 /// The WAMP Error massage
 class Error extends AbstractMessageWithPayload {
-  static final String errorInvocationCanceled =
+  static const String errorInvocationCanceled =
       'wamp.error.invocation_canceled';
 
   // INTERACTION ERRORS
-  static final String errorInvalidUri = 'wamp.error.invalid_uri';
-  static final String invalidMessageId = 'wamp.error.invalid_message_id';
-  static final String wrongMessageStructure =
+  static const String errorInvalidUri = 'wamp.error.invalid_uri';
+  static const String invalidMessageId = 'wamp.error.invalid_message_id';
+  static const String wrongMessageStructure =
       'wamp.error.wrong_message_structure';
-  static final String noSuchProcedure = 'wamp.error.no_such_procedure';
-  static final String procedureAlreadyExists =
+  static const String noSuchProcedure = 'wamp.error.no_such_procedure';
+  static const String procedureAlreadyExists =
       'wamp.error.procedure_already_exists';
-  static final String noSuchRegistration = 'wamp.error.no_such_registration';
-  static final String noSuchSubscription = 'wamp.error.no_such_subscription';
-  static final String invalidArgument = 'wamp.error.invalid_argument';
-  static final String notConnected = 'wamp.error.not_connected';
-  static final String unknown = 'wamp.error.unknown';
+  static const String noSuchRegistration = 'wamp.error.no_such_registration';
+  static const String noSuchSubscription = 'wamp.error.no_such_subscription';
+  static const String invalidArgument = 'wamp.error.invalid_argument';
+  static const String notConnected = 'wamp.error.not_connected';
+  static const String couldNotConnect = 'wamp.error.could_not_connect';
+  static const String unknown = 'wamp.error.unknown';
 
   // AUTHORIZATION ERRORS
   static const String notAuthorized = 'wamp.error.not_authorized';

--- a/lib/src/transport/websocket/websocket_transport_io.dart
+++ b/lib/src/transport/websocket/websocket_transport_io.dart
@@ -39,7 +39,7 @@ class WebSocketTransport extends AbstractTransport {
   /// Calling close will close the underlying socket connection
   @override
   Future<void> close({error}) {
-    _socket!.close();
+    _socket?.close();
     complete(_onDisconnect, error);
     return Future.value();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectanum
 homepage: https://github.com/konsultaner/connectanum-dart
-version: 2.0.4
+version: 2.1.0
 description: >-
   This is a WAMP client (Web Application Messaging Protocol) implementation for the dart language and flutter projects.
 dependencies:

--- a/test/client_on_transport_io_events_test.dart
+++ b/test/client_on_transport_io_events_test.dart
@@ -480,8 +480,8 @@ class WebSocketTestSuite {
   }
 
   openTransport() async {
-    final transport = WebSocketTransport('ws://localhost:$port/wamp',
-        Serializer(), WebSocketSerialization.serializationJson);
+    final transport =
+        WebSocketTransport.withJsonSerializer('ws://localhost:$port/wamp');
     client = Client(realm: 'com.connectanum', transport: transport);
   }
 }

--- a/test/client_on_transport_io_events_test.dart
+++ b/test/client_on_transport_io_events_test.dart
@@ -13,7 +13,6 @@ import 'package:connectanum/src/transport/socket/socket_helper.dart';
 import 'package:connectanum/src/transport/socket/socket_transport.dart';
 import 'package:connectanum/src/transport/websocket/websocket_transport_io.dart';
 import 'package:connectanum/src/transport/websocket/websocket_transport_serialization.dart';
-import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/client_on_transport_io_events_test.dart
+++ b/test/client_on_transport_io_events_test.dart
@@ -99,7 +99,7 @@ void main() {
       await closeCompleter.future;
 
       expect(abort, isA<Abort>());
-      expect(abort!.reason, equals(Error.authorizationFailed));
+      expect(abort!.reason, equals(Error.couldNotConnect));
       expect(hitConnectionLostEvent, isTrue);
       expect(reconnects, equals(2));
       expect(client.transport.isOpen, isFalse);
@@ -167,7 +167,7 @@ void main() {
         closeCompleter.complete(abort);
       });
       Abort abort = await closeCompleter.future;
-      expect(abort.reason, equals(Error.authorizationFailed));
+      expect(abort.reason, equals(Error.couldNotConnect));
       expect(abort.message!.message, startsWith('Could not connect to server'));
       expect(client.transport.isOpen, isFalse);
     });
@@ -286,7 +286,7 @@ void main() {
       await closeCompleter.future;
 
       expect(abort, isA<Abort>());
-      expect(abort!.reason, equals(Error.authorizationFailed));
+      expect(abort!.reason, equals(Error.couldNotConnect));
       expect(hitConnectionLostEvent, isTrue);
       expect(reconnects, equals(2));
       expect(client.transport.isOpen, isFalse);
@@ -368,7 +368,7 @@ void main() {
         closeCompleter.complete(abort);
       });
       Abort abort = await closeCompleter.future;
-      expect(abort.reason, equals(Error.authorizationFailed));
+      expect(abort.reason, equals(Error.couldNotConnect));
       expect(abort.message!.message, startsWith('Could not connect to server'));
       expect(client.transport.isOpen, isFalse);
     });

--- a/test/client_on_transport_io_events_test.dart
+++ b/test/client_on_transport_io_events_test.dart
@@ -1,9 +1,11 @@
 @TestOn('vm')
+import 'dart:convert';
 import 'dart:io';
 import 'dart:async';
 
 import 'package:connectanum/src/client.dart';
 import 'package:connectanum/src/message/abort.dart';
+import 'package:connectanum/src/message/abstract_message.dart';
 import 'package:connectanum/src/message/error.dart';
 import 'package:connectanum/src/message/message_types.dart';
 import 'package:connectanum/src/serializer/json/serializer.dart';
@@ -11,6 +13,7 @@ import 'package:connectanum/src/transport/socket/socket_helper.dart';
 import 'package:connectanum/src/transport/socket/socket_transport.dart';
 import 'package:connectanum/src/transport/websocket/websocket_transport_io.dart';
 import 'package:connectanum/src/transport/websocket/websocket_transport_serialization.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -78,9 +81,10 @@ void main() {
       var hitConnectionLostEvent = false;
       Abort? abort;
       var options = ClientConnectOptions(
-          pingInterval: Duration(seconds: 1),
-          reconnectTime: Duration(seconds: 1),
-          reconnectCount: 2);
+        pingInterval: Duration(seconds: 1),
+        reconnectTime: Duration(seconds: 1),
+        reconnectCount: 2,
+      );
       client.connect(options: options).listen((session) {
         session.onConnectionLost.then((_) {
           hitConnectionLostEvent = true;
@@ -99,7 +103,7 @@ void main() {
       expect(abort, isA<Abort>());
       expect(abort!.reason, equals(Error.authorizationFailed));
       expect(hitConnectionLostEvent, isTrue);
-      expect(reconnects, equals(4));
+      expect(reconnects, equals(2));
       expect(client.transport.isOpen, isFalse);
       expect(options.reconnectTime!.inMilliseconds, equals(800));
     });
@@ -129,9 +133,10 @@ void main() {
       client
           .connect(
               options: ClientConnectOptions(
-                  pingInterval: Duration(seconds: 1),
-                  reconnectTime: Duration(seconds: 1),
-                  reconnectCount: 2))
+        pingInterval: Duration(seconds: 1),
+        reconnectTime: Duration(seconds: 1),
+        reconnectCount: 3,
+      ))
           .listen((session) {
         if (reconnects < 3) {
           reconnects++;
@@ -285,7 +290,7 @@ void main() {
       expect(abort, isA<Abort>());
       expect(abort!.reason, equals(Error.authorizationFailed));
       expect(hitConnectionLostEvent, isTrue);
-      expect(reconnects, equals(4));
+      expect(reconnects, equals(2));
       expect(client.transport.isOpen, isFalse);
     });
 
@@ -331,7 +336,7 @@ void main() {
               options: ClientConnectOptions(
                   pingInterval: Duration(seconds: 1),
                   reconnectTime: Duration(seconds: 1),
-                  reconnectCount: 2))
+                  reconnectCount: 3))
           .listen((session) {
         if (reconnects < 3) {
           reconnects++;
@@ -370,4 +375,115 @@ void main() {
       expect(client.transport.isOpen, isFalse);
     });
   });
+
+  group('Reconnection testing', () {
+    test('WebSocket - stop on authorization error', () async {
+      final suite = WebSocketTestSuite((msgType) {
+        if (msgType == MessageTypes.codeHello) {
+          return Abort(
+            Error.notAuthorized,
+            message: 'The given realm is not valid',
+          );
+        }
+
+        return null;
+      });
+      await suite.open();
+
+      final options = ClientConnectOptions(
+        pingInterval: Duration(seconds: 1),
+        reconnectTime: Duration(seconds: 1),
+        reconnectCount: 2,
+      );
+
+      var closeCompleter = Completer();
+      var errors = 0;
+      suite.client.connect(options: options).listen(
+            (_) {},
+            onError: (_) => errors++,
+            onDone: () => closeCompleter.complete(),
+          );
+      await closeCompleter.future;
+
+      expect(errors, equals(1));
+      expect(suite.client.transport.isOpen, isTrue);
+    }, timeout: const Timeout(Duration(seconds: 5)));
+
+    test('WebSocket - retry on invalid argument error', () async {
+      final suite = WebSocketTestSuite((msgType) {
+        if (msgType == MessageTypes.codeHello) {
+          return Abort(
+            Error.invalidArgument,
+            message: 'Invalid argument',
+          );
+        }
+
+        return null;
+      });
+      await suite.open();
+
+      final options = ClientConnectOptions(
+        pingInterval: Duration(seconds: 1),
+        reconnectTime: Duration(seconds: 1),
+        reconnectCount: 2,
+      );
+
+      var closeCompleter = Completer();
+      var errors = 0;
+      suite.client.connect(options: options).listen(
+            (_) {},
+            onError: (_) => errors++,
+            onDone: () => closeCompleter.complete(),
+          );
+      await closeCompleter.future;
+
+      expect(errors, equals(3));
+      expect(suite.client.transport.isOpen, isTrue);
+    }, timeout: const Timeout(Duration(seconds: 15)));
+  });
+}
+
+int webSocketTestSuitePort = 9300;
+
+class WebSocketTestSuite {
+  late WebSocket socket;
+  late HttpServer server;
+  late Client client;
+  final port = webSocketTestSuitePort++;
+
+  final AbstractMessage? Function(int msgType) onServerMessage;
+
+  WebSocketTestSuite(this.onServerMessage);
+
+  Future<void> open() async {
+    await openServer();
+    openTransport();
+  }
+
+  openServer() async {
+    server = await HttpServer.bind('localhost', port);
+
+    serverListenHandler(HttpRequest req) async {
+      if (req.uri.path == '/wamp') {
+        socket = await WebSocketTransformer.upgrade(req);
+        socket.listen((message) {
+          final msg = jsonDecode(message);
+          final msgType = msg[0];
+
+          final response = onServerMessage(msgType);
+          if (response != null) {
+            socket.add(Serializer().serializeToString(response));
+          }
+        });
+      }
+    }
+
+    server.listen(serverListenHandler);
+  }
+
+  openTransport() async {
+    final transport = WebSocketTransport('ws://localhost:$port/wamp',
+        Serializer(), WebSocketSerialization.serializationJson);
+    client = Client(realm: 'com.connectanum', transport: transport);
+  }
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -990,7 +990,7 @@ void main() {
       expect(session.isConnected(), isFalse);
       expect(session.onDisconnect, completes);
     });
-    test('client reconnect race condition', () async {
+    test('client reconnect race condition', () {
       expect(
           rootLogger.onRecord,
           emitsThrough(isA<LogRecord>().having(
@@ -1078,7 +1078,7 @@ class _MockTransport extends AbstractTransport {
   }
 
   @override
-  Future<void> open({Duration? pingInterval}) async {
+  Future<void> open({Duration? pingInterval}) {
     if (failToOpen) return Future.value();
     _open = true;
     _onDisconnect = Completer();

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1003,8 +1003,6 @@ void main() {
       final client = Client(realm: 'test.realm', transport: transport);
       transport.outbound.stream.listen((message) {
         if (message.id == MessageTypes.codeHello) {
-          // Fire two connection closure notifications at once;
-          // This should trigger the race condition.
           transport.receiveMessage(Abort('no good reason'));
           transport.onConnectionLost?.complete();
         }
@@ -1012,12 +1010,10 @@ void main() {
       client
           .connect(
               options: ClientConnectOptions(
-                  reconnectTime: const Duration(milliseconds: 200)))
+                  reconnectTime: const Duration(milliseconds: 100)))
           .drain()
           .ignore();
-      // The test relies on the behavior of an unawaited future within the
-      // implementation of Client, which can behave non-deterministically.
-      }, retry: 3, timeout: Timeout(const Duration(seconds: 5)));
+    });
   });
 }
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 
 import 'package:connectanum/authentication.dart';
 import 'package:connectanum/connectanum.dart';
-import 'package:connectanum/src/logging.dart';
 import 'package:connectanum/src/message/authenticate.dart';
 import 'package:connectanum/src/message/hello.dart';
 import 'package:connectanum/src/message/message_types.dart';

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -933,7 +933,7 @@ void main() {
           abort,
           isA<Abort>()
               .having(
-                  (a) => a.reason, 'reason', equals(Error.authorizationFailed))
+                  (a) => a.reason, 'reason', equals(Error.couldNotConnect))
               .having(
                   (a) => a.message?.message,
                   'message',

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 
 import 'package:connectanum/authentication.dart';
 import 'package:connectanum/connectanum.dart';
-import 'package:connectanum/logging.dart';
 import 'package:connectanum/src/message/authenticate.dart';
 import 'package:connectanum/src/message/hello.dart';
 import 'package:connectanum/src/message/message_types.dart';

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1003,6 +1003,8 @@ void main() {
       final client = Client(realm: 'test.realm', transport: transport);
       transport.outbound.stream.listen((message) {
         if (message.id == MessageTypes.codeHello) {
+          // Fire two connection closure notifications at once;
+          // This should trigger the race condition.
           transport.receiveMessage(Abort('no good reason'));
           transport.onConnectionLost?.complete();
         }
@@ -1010,10 +1012,12 @@ void main() {
       client
           .connect(
               options: ClientConnectOptions(
-                  reconnectTime: const Duration(milliseconds: 100)))
+                  reconnectTime: const Duration(milliseconds: 200)))
           .drain()
           .ignore();
-    });
+      // The test relies on the behavior of an unawaited future within the
+      // implementation of Client, which can behave non-deterministically.
+      }, retry: 3, timeout: Timeout(const Duration(seconds: 5)));
   });
 }
 


### PR DESCRIPTION
- Re-implement connection recovery logic to use Streams instead of unawaited Futures. This prevents uncontrolled connection establishment retries.
- Add `Client().disconnect()` method, which will properly dispose of class' resources and close the underlying transport.
- Add tests around connection recovery and connection closure.