### PR TITLE
Fix typos in PKCS#8 documentation

### DIFF
--- a/lib/src/authentication/cryptosign/pkcs8.dart
+++ b/lib/src/authentication/cryptosign/pkcs8.dart
@@ -14,7 +14,7 @@ class Pkcs8 {
   ///       algorithm               OBJECT IDENTIFIER (1.3.101.112),
   ///       parameters              (ABSENT oder NULL)
   ///   },
-  ///   privateKey                OCTET STRING  -- th eseed
+  ///   privateKey                OCTET STRING  -- the seed
   /// }
   static String fromEd25519Seed(Uint8List seed) {
     if (seed.length != 32) {
@@ -67,7 +67,7 @@ class Pkcs8 {
   ///       algorithm               OBJECT IDENTIFIER (1.3.101.112),
   ///       parameters              (ABSENT oder NULL)
   ///   },
-  ///   privateKey                OCTET STRING  -- th eseed
+  ///   privateKey                OCTET STRING  -- the seed
   /// }
   static Uint8List loadPrivateKeyFromPKCS8Ed25519(String pem) {
     const header = '-----BEGIN PRIVATE KEY-----';


### PR DESCRIPTION
## Summary
- correct 'the seed' typos in PKCS#8 documentation comments

## Testing
- `dart format -o none --set-exit-if-changed lib/src/authentication/cryptosign/pkcs8.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7965d070832599c14125b9fea1ac