### PR TITLE
Fix isValidMessage logic

### DIFF
--- a/lib/src/transport/socket/socket_helper.dart
+++ b/lib/src/transport/socket/socket_helper.dart
@@ -121,10 +121,14 @@ class SocketHelper {
 
   /// Checks if the given [message] is a valid wamp message
   static bool isValidMessage(Uint8List message) {
-    var messageType = message[0];
-    return messageType != messageWamp ||
-        messageType != messagePing ||
-        messageType != messagePong;
+    switch (message[0]) {
+      case messageWamp:
+      case messagePing:
+      case messagePong:
+        return true;
+      default:
+        return false;
+    }
   }
 
   /// Gets the message type for the given [message].

--- a/test/transport/socket/socket_helper_test.dart
+++ b/test/transport/socket/socket_helper_test.dart
@@ -1,0 +1,32 @@
+@TestOn('vm')
+library;
+
+import 'dart:typed_data';
+
+import 'package:connectanum/src/transport/socket/socket_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SocketHelper.isValidMessage', () {
+    test('accepts valid message types', () {
+      expect(
+          SocketHelper.isValidMessage(
+              Uint8List.fromList([SocketHelper.messageWamp])),
+          isTrue);
+      expect(
+          SocketHelper.isValidMessage(
+              Uint8List.fromList([SocketHelper.messagePing])),
+          isTrue);
+      expect(
+          SocketHelper.isValidMessage(
+              Uint8List.fromList([SocketHelper.messagePong])),
+          isTrue);
+    });
+
+    test('rejects invalid message types', () {
+      expect(SocketHelper.isValidMessage(Uint8List.fromList([3])), isFalse);
+      expect(SocketHelper.isValidMessage(Uint8List.fromList([0x7F])), isFalse);
+      expect(SocketHelper.isValidMessage(Uint8List.fromList([0x3F])), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- fix `isValidMessage` so it accepts only WAMP, ping and pong messages
- test `SocketHelper.isValidMessage`

## Testing
- `dart test` *(fails: `dart: command not found`)*
- `pub run test` *(fails: `pub: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686f791735cc83259d50e322b8f708c6