### PR TITLE
Add documentation for more message utilities

### DIFF
--- a/lib/src/message/abort.dart
+++ b/lib/src/message/abort.dart
@@ -1,7 +1,7 @@
 import 'message_types.dart';
 import 'abstract_message.dart';
 
-/// The WAMP Abort massage
+/// The WAMP Abort message.
 class Abort extends AbstractMessage {
   Message? message;
   String reason;

--- a/lib/src/message/abstract_message_with_payload.dart
+++ b/lib/src/message/abstract_message_with_payload.dart
@@ -2,12 +2,14 @@ import 'dart:typed_data';
 
 import 'abstract_message.dart';
 
-/// CALL,EVENT,RESULT,ERROR,PUBLISH,INVOCATION,YIELD may have a transparent payload
+/// Base class for messages that carry positional and keyword arguments.
+/// CALL, EVENT, RESULT, ERROR, PUBLISH, INVOCATION and YIELD extend this.
 abstract class AbstractMessageWithPayload extends AbstractMessage {
   Uint8List? transparentBinaryPayload;
   List<dynamic>? arguments;
   Map<String, dynamic>? argumentsKeywords;
 
+  /// Construct a message with optional [arguments] and [argumentsKeywords].
   AbstractMessageWithPayload({this.arguments, this.argumentsKeywords});
 
   /// Transfers the message payload to another message

--- a/lib/src/message/call.dart
+++ b/lib/src/message/call.dart
@@ -47,6 +47,7 @@ class CallOptions extends PPTOptions {
   }
 
   @override
+  /// Validate that all option values are within allowed ranges.
   bool verify() {
     if (timeout! < 0) {
       throw RangeError.value(timeout!, 'timeoutError', 'timeout must be >= 0');

--- a/lib/src/message/cancel.dart
+++ b/lib/src/message/cancel.dart
@@ -1,7 +1,7 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
-/// The WAMP Call massage
+/// Cancel a pending call issued via [Call].
 class Cancel extends AbstractMessage {
   int requestId;
   CancelOptions? options;
@@ -13,10 +13,13 @@ class Cancel extends AbstractMessage {
   }
 }
 
+/// Options that control how the router should cancel the call.
 class CancelOptions {
   static final String modeSkip = 'skip';
   static final String modeKill = 'kill';
   static final String modeKillNoWait = 'killnowait';
 
+  /// Specifies how the invocation is cancelled. See WAMP spec for allowed
+  /// values [modeSkip], [modeKill] and [modeKillNoWait].
   String? mode;
 }

--- a/lib/src/message/details.dart
+++ b/lib/src/message/details.dart
@@ -1,3 +1,4 @@
+/// Container for additional details sent with WAMP messages.
 class Details {
   String? agent;
   String? realm;
@@ -18,6 +19,8 @@ class Details {
   int? trustlevel;
   Roles? roles;
 
+  /// Create a [Details] object prefilled for HELLO messages with all default
+  /// role information present.
   static Details forHello() {
     final details = Details();
     var roles = Roles();
@@ -43,6 +46,9 @@ class Details {
     return details;
   }
 
+  /// Create a [Details] object prefilled for WELCOME messages.
+  /// Various authentication information may be supplied via the optional
+  /// parameters.
   static Details forWelcome({
     String? realm,
     String? authId,
@@ -77,6 +83,7 @@ class Details {
   }
 }
 
+/// Holds feature descriptions for the various WAMP roles.
 class Roles {
   Publisher? publisher;
   Broker? broker;
@@ -86,10 +93,12 @@ class Roles {
   Caller? caller;
 }
 
+/// Features supported by the publisher role.
 class Publisher {
   PublisherFeatures? features;
 }
 
+/// Capabilities a router advertises for its publisher role.
 class PublisherFeatures {
   bool publisherIdentification = true;
   bool subscriberBlackWhiteListing = true;
@@ -97,11 +106,13 @@ class PublisherFeatures {
   bool payloadPassThruMode = true;
 }
 
+/// Features supported by the broker role.
 class Broker {
   bool? reflection;
   BrokerFeatures? features;
 }
 
+/// Capabilities a router advertises for its broker role.
 class BrokerFeatures {
   bool publisherIdentification = false;
   bool publicationTrustLevels = false;
@@ -114,10 +125,12 @@ class BrokerFeatures {
   bool payloadPassThruMode = false;
 }
 
+/// Features supported by the subscriber role.
 class Subscriber {
   SubscriberFeatures? features;
 }
 
+/// Capabilities a router advertises for its subscriber role.
 class SubscriberFeatures {
   bool callTimeout = false;
   bool callCanceling = false;
@@ -126,11 +139,13 @@ class SubscriberFeatures {
   bool payloadPassThruMode = true;
 }
 
+/// Features supported by the dealer role.
 class Dealer {
   bool? reflection;
   DealerFeatures? features;
 }
 
+/// Capabilities a router advertises for its dealer role.
 class DealerFeatures {
   bool callerIdentification = false;
   bool callTrustLevels = false;
@@ -144,10 +159,12 @@ class DealerFeatures {
   bool payloadPassThruMode = false;
 }
 
+/// Features supported by the callee role.
 class Callee {
   CalleeFeatures? features;
 }
 
+/// Capabilities a router advertises for its callee role.
 class CalleeFeatures {
   bool callerIdentification = true;
   bool callTrustlevels = false;
@@ -159,10 +176,12 @@ class CalleeFeatures {
   bool payloadPassThruMode = true;
 }
 
+/// Features supported by the caller role.
 class Caller {
   CallerFeatures? features;
 }
 
+/// Capabilities a router advertises for its caller role.
 class CallerFeatures {
   bool callerIdentification = true;
   bool callTimeout = false;

--- a/lib/src/message/e2ee_payload.dart
+++ b/lib/src/message/e2ee_payload.dart
@@ -2,20 +2,24 @@ import 'abstract_ppt_options.dart';
 import '../message/ppt_payload.dart';
 
 // TODO implement End-to-End Encryption
+/// Placeholder for end-to-end encrypted payload handling.
 class E2EEPayload extends PPTPayload {
+  /// Encryption key identifier or URI.
   String? uri;
 
+  /// Create an encrypted payload container.
   E2EEPayload({this.uri, arguments, argumentsKeywords}) {
     this.arguments = arguments;
     this.argumentsKeywords = argumentsKeywords;
   }
 
-  /// Packs E2EE Payload and returns 1-item array for WAMP message arguments
+  /// Packs E2EE Payload and returns a single item array for WAMP message arguments.
   static List<dynamic> packE2EEPayload(List<dynamic>? arguments,
       Map<String, dynamic>? argumentsKeywords, PPTOptions options) {
     return [];
   }
 
+  /// Unpack an encrypted payload into its original form.
   static E2EEPayload unpackE2EEPayload(
       List<dynamic>? arguments, PPTOptions options) {
     return E2EEPayload();

--- a/lib/src/message/event.dart
+++ b/lib/src/message/event.dart
@@ -2,6 +2,7 @@ import 'abstract_message_with_payload.dart';
 import 'abstract_ppt_options.dart';
 import 'message_types.dart';
 
+/// Event message delivered by the broker to subscribers.
 class Event extends AbstractMessageWithPayload {
   /// The ID for the subscription under which the Subscriber receives the event.
   /// The ID for the subscription originally handed out by the Broker to the Subscriber.
@@ -9,8 +10,11 @@ class Event extends AbstractMessageWithPayload {
 
   /// The ID of the publication of the published event.
   int publicationId;
+  /// Additional information about this event.
   EventDetails details;
 
+  /// Create an event for a given [subscriptionId] and [publicationId].
+  /// Optional [arguments] and [argumentsKeywords] carry the event payload.
   Event(this.subscriptionId, this.publicationId, this.details,
       {List<dynamic>? arguments, Map<String, dynamic>? argumentsKeywords}) {
     id = MessageTypes.codeEvent;
@@ -19,7 +23,7 @@ class Event extends AbstractMessageWithPayload {
   }
 }
 
-/// Options used influence the event behavior
+/// Options influencing how an event is delivered to the subscriber.
 class EventDetails extends PPTOptions {
   // publisher_identification == true
   int? publisher;
@@ -30,6 +34,7 @@ class EventDetails extends PPTOptions {
   // for pattern-matching
   String? topic;
 
+  /// Create an instance configuring publisher information and PPT options.
   EventDetails(
       {this.publisher,
       this.trustlevel,
@@ -45,6 +50,7 @@ class EventDetails extends PPTOptions {
   }
 
   @override
+  /// Validate the PPT settings for this event.
   bool verify() {
     return verifyPPT();
   }

--- a/lib/src/message/goodbye.dart
+++ b/lib/src/message/goodbye.dart
@@ -1,21 +1,30 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// Sent by either peer to close the session.
 class Goodbye extends AbstractMessage {
   static final String reasonGoodbyeAndOut = 'wamp.error.goodbye_and_out';
   static final String reasonCloseRealm = 'wamp.error.close_realm';
   static final String reasonTimeout = 'wamp.error.timeout';
   static final String reasonSystemShutdown = 'wamp.error.system_shutdown';
 
+  /// Optional human readable farewell message.
   GoodbyeMessage? message;
+
+  /// The reason code for closing the session.
   String reason;
 
+  /// Create a [Goodbye] message with an optional [message] and [reason].
   Goodbye(this.message, this.reason) {
     id = MessageTypes.codeGoodbye;
   }
 }
 
+/// Additional message details for a [Goodbye] frame.
 class GoodbyeMessage {
+  /// Optional textual goodbye message.
   String? message;
+
+  /// Create an instance containing a goodbye [message].
   GoodbyeMessage(this.message);
 }

--- a/lib/src/message/hello.dart
+++ b/lib/src/message/hello.dart
@@ -3,10 +3,15 @@ import 'details.dart';
 import 'message_types.dart';
 import 'uri_pattern.dart';
 
+/// Initial message sent to open a WAMP session.
 class Hello extends AbstractMessage {
+  /// The realm to join on the router.
   String? realm;
+
+  /// Client and authentication details.
   Details details;
 
+  /// Create a [Hello] message for the given [realm] and [details].
   Hello(this.realm, this.details)
       : assert(realm == null || UriPattern.match(realm)) {
     id = MessageTypes.codeHello;

--- a/lib/src/message/interrupt.dart
+++ b/lib/src/message/interrupt.dart
@@ -3,13 +3,19 @@ import 'abstract_message.dart';
 import 'cancel.dart';
 import 'message_types.dart';
 
+/// Sent by a caller to interrupt a pending invocation.
 class Interrupt extends AbstractMessage {
+  /// ID of the call or invocation to cancel.
   int requestId;
+
+  /// Additional cancellation options.
   InterruptOptions? options;
 
+  /// Create an interrupt message for the given [requestId].
   Interrupt(this.requestId, {this.options}) {
     id = MessageTypes.codeInterrupt;
   }
 }
 
+/// Options for cancelling an invocation.
 class InterruptOptions extends CancelOptions {}

--- a/lib/src/message/invocation.dart
+++ b/lib/src/message/invocation.dart
@@ -10,12 +10,20 @@ import 'uri_pattern.dart';
 import 'error.dart';
 import 'yield.dart';
 
+/// Represents an invocation of a registered procedure.
 class Invocation extends AbstractMessageWithPayload {
+  /// The ID used to match requests and responses.
   int requestId;
+
+  /// The registration ID of the invoked procedure.
   int registrationId;
+
+  /// Additional invocation details provided by the router.
   InvocationDetails details;
+
   late StreamController<AbstractMessageWithPayload> _responseStreamController;
 
+  /// Respond to this invocation either with a [Yield] or [Error] message.
   void respondWith(
       {List<dynamic>? arguments,
       Map<String, dynamic>? argumentsKeywords,
@@ -58,6 +66,7 @@ class Invocation extends AbstractMessageWithPayload {
     }
   }
 
+  /// Create an [Invocation] referencing a [requestId] and [registrationId].
   Invocation(this.requestId, this.registrationId, this.details,
       {List<dynamic>? arguments, Map<String, dynamic>? argumentsKeywords}) {
     id = MessageTypes.codeInvocation;
@@ -65,10 +74,12 @@ class Invocation extends AbstractMessageWithPayload {
     this.argumentsKeywords = argumentsKeywords;
   }
 
+  /// True if the caller requested progressive results.
   bool isProgressive() {
     return details.receiveProgress ?? false;
   }
 
+  /// Listen for responses (either [Yield] or [Error]) for this invocation.
   void onResponse(
       void Function(AbstractMessageWithPayload invocationResultMessage)
           onData) {
@@ -99,6 +110,7 @@ class InvocationDetails extends PPTOptions {
   }
 
   @override
+  /// Validates PPT parameters provided with this invocation.
   bool verify() {
     return verifyPPT();
   }

--- a/lib/src/message/message_types.dart
+++ b/lib/src/message/message_types.dart
@@ -1,3 +1,4 @@
+/// Numeric codes used for the various WAMP messages.
 class MessageTypes {
   static final int codeHello = 1;
   static final int codeWelcome = 2;

--- a/lib/src/message/ppt_payload.dart
+++ b/lib/src/message/ppt_payload.dart
@@ -4,13 +4,17 @@ import '../serializer/cbor/serializer.dart' as cbor_serializer;
 import '../serializer/json/serializer.dart' as json_serializer;
 import '../serializer/msgpack/serializer.dart' as msgpack_serializer;
 
+/// Container for payloads transmitted using Payload PassThru (PPT).
 class PPTPayload {
+  /// Positional arguments contained in the payload.
   List<dynamic>? arguments;
+  /// Keyword arguments contained in the payload.
   Map<String, dynamic>? argumentsKeywords;
 
+  /// Create a PPT payload with optional [arguments] and [argumentsKeywords].
   PPTPayload({this.arguments, this.argumentsKeywords});
 
-  /// Packs PPT Payload and returns 1-item array for WAMP message arguments
+  /// Serialize this payload as a single item according to the PPT options.
   static List<dynamic> packPPTPayload(List<dynamic>? arguments,
       Map<String, dynamic>? argumentsKeywords, PPTOptions options) {
     if (options.pptSerializer != null && options.pptSerializer != 'native') {
@@ -42,6 +46,7 @@ class PPTPayload {
     }
   }
 
+  /// Deserialize a PPT payload from WAMP message arguments.
   static PPTPayload unpackPPTPayload(
       List<dynamic>? arguments, PPTOptions details) {
     if (arguments == null) {

--- a/lib/src/message/publish.dart
+++ b/lib/src/message/publish.dart
@@ -2,11 +2,22 @@ import 'abstract_message_with_payload.dart';
 import 'abstract_ppt_options.dart';
 import 'message_types.dart';
 
+/// A WAMP publish message used to notify subscribers about an event.
 class Publish extends AbstractMessageWithPayload {
+  /// Unique identifier used to correlate a publish request and the routers
+  /// response.
   int requestId;
+
+  /// Options influencing the publish behaviour such as acknowledgement or
+  /// publisher disclosure.
   PublishOptions? options;
+
+  /// The topic URI the event should be published to.
   String topic;
 
+  /// Creates a publish message that will publish to [topic]. Optional
+  /// [arguments] and [argumentsKeywords] are forwarded to the subscribers.
+  /// The [options] parameter configures additional publish features.
   Publish(this.requestId, this.topic,
       {this.options,
       List<dynamic>? arguments,
@@ -17,26 +28,43 @@ class Publish extends AbstractMessageWithPayload {
   }
 }
 
+/// Configuration options used while publishing an event.
 class PublishOptions extends PPTOptions {
+  /// Request a publish acknowledgement from the router.
   bool? acknowledge;
 
   // subscriber_blackwhite_listing == true
+  /// Exclude the given session ids from receiving the event.
   List<int>? exclude;
+
+  /// Exclude sessions with one of these authentication ids.
   List<String>? excludeAuthId;
+
+  /// Exclude sessions with one of these authentication roles.
   List<String>? excludeAuthRole;
+
+  /// Only allow these session ids to receive the event.
   List<int>? eligible;
+
+  /// Only allow these authentication ids to receive the event.
   List<String>? eligibleAuthId;
+
+  /// Only allow these authentication roles to receive the event.
   List<String>? eligibleAuthRole;
 
   // publisher_exclusion == true
+  /// If true the publishing session will not receive the event itself.
   bool? excludeMe;
 
   // publisher_identification == true
+  /// If true the publisher identity will be disclosed to receivers.
   bool? discloseMe;
 
   // event_retention == true
+  /// Instruct the broker to retain the event for new subscribers.
   bool? retain;
 
+  /// Creates a set of options for publishing events.
   PublishOptions(
       {this.acknowledge,
       this.exclude,
@@ -59,6 +87,7 @@ class PublishOptions extends PPTOptions {
   }
 
   @override
+  /// Validate PPT options supplied for this publish request.
   bool verify() {
     return verifyPPT();
   }

--- a/lib/src/message/published.dart
+++ b/lib/src/message/published.dart
@@ -1,12 +1,15 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// Acknowledges a [Publish] request.
 class Published extends AbstractMessage {
+  /// The request ID that initiated the publication.
   int publishRequestId;
 
-  /// A Id chosen by the broker
+  /// Identifier assigned by the broker to the publication event.
   int publicationId;
 
+  /// Create an instance referencing the [publishRequestId] and [publicationId].
   Published(this.publishRequestId, this.publicationId) {
     id = MessageTypes.codePublished;
   }

--- a/lib/src/message/register.dart
+++ b/lib/src/message/register.dart
@@ -1,21 +1,30 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// Sent by a client to register an RPC endpoint.
 class Register extends AbstractMessage {
+  /// Unique ID for this register request.
   int requestId;
+
+  /// Optional registration options such as invocation policy.
   RegisterOptions? options;
+
+  /// The URI of the procedure to register.
   String procedure;
 
+  /// Create a register request for [procedure].
   Register(this.requestId, this.procedure, {this.options}) {
     id = MessageTypes.codeRegister;
   }
 }
 
+/// Options that influence procedure registration.
 class RegisterOptions {
   static final String? matchExact = null;
   static final String matchPrefix = 'prefix';
   static final String matchWildcard = 'wildcard';
 
+  /// Procedure is handled by a single callee.
   static final String invocationPolicySingle = 'single';
   static final String invocationPolicyFirst = 'first';
   static final String invocationPolicyLast = 'last';
@@ -23,13 +32,17 @@ class RegisterOptions {
   static final String invocationPolicyRandom = 'random';
 
   // caller_identification == true
+  /// Request the router to disclose caller identity.
   bool? discloseCaller;
 
   // pattern_based_registration == true
+  /// Matching policy for the procedure URI.
   String? match;
 
   // shared_registration
+  /// Invocation distribution policy when multiple callees are registered.
   String? invoke;
 
+  /// Create a set of options for registering a procedure.
   RegisterOptions({this.discloseCaller, this.match, this.invoke});
 }

--- a/lib/src/message/registered.dart
+++ b/lib/src/message/registered.dart
@@ -5,19 +5,27 @@ import 'message_types.dart';
 import 'abstract_message.dart';
 import 'invocation.dart';
 
+/// Sent by the router to acknowledge a [Register] request.
 class Registered extends AbstractMessage {
+  /// The request ID that initiated the registration.
   int registerRequestId;
+
+  /// The router assigned registration ID.
   int registrationId;
+
+  /// The procedure URI that was registered.
   String? procedure;
 
   Stream<Invocation>? _invocationStream;
 
+  /// Set the stream that delivers invocation requests from the router.
   set invocationStream(Stream<Invocation> invocationStream) {
     _invocationStream = invocationStream;
   }
 
-  /// sets the invocation handler, if an error is thrown within the handler this
-  /// method will result an error message to the transport or router respectively
+  /// Register a callback that is executed whenever this procedure is invoked.
+  /// If the callback throws an error the invocation is answered with an
+  /// [Error] message.
   void onInvoke(void Function(Invocation invocation) onInvoke) {
     if (_invocationStream != null) {
       _invocationStream!.listen((Invocation invocation) {
@@ -51,6 +59,7 @@ class Registered extends AbstractMessage {
     }
   }
 
+  /// Create a [Registered] message for the given request and registration IDs.
   Registered(this.registerRequestId, this.registrationId) {
     id = MessageTypes.codeRegistered;
   }

--- a/lib/src/message/result.dart
+++ b/lib/src/message/result.dart
@@ -2,6 +2,7 @@ import 'abstract_ppt_options.dart';
 import 'message_types.dart';
 import 'abstract_message_with_payload.dart';
 
+/// Result message returned from a remote procedure call.
 class Result extends AbstractMessageWithPayload {
   /// The ID for the subscription under which the Subscriber receives the event.
   /// The ID for the subscription originally handed out by the Broker to the Subscriber.
@@ -10,6 +11,8 @@ class Result extends AbstractMessageWithPayload {
   /// The ID of the publication of the published event.
   ResultDetails details;
 
+  /// Create a result referencing the original [callRequestId]. Optional
+  /// [arguments] and [argumentsKeywords] contain the RPC result payload.
   Result(this.callRequestId, this.details,
       {List<dynamic>? arguments, Map<String, dynamic>? argumentsKeywords}) {
     id = MessageTypes.codeResult;
@@ -17,15 +20,18 @@ class Result extends AbstractMessageWithPayload {
     this.argumentsKeywords = argumentsKeywords;
   }
 
+  /// Indicates whether this result is part of a progressive sequence.
   bool isProgressive() {
     return details.progress != null && details.progress!;
   }
 }
 
+/// Additional information returned with a [Result].
 class ResultDetails extends PPTOptions {
   // progressive_call_results == true
   bool? progress;
 
+  /// Create a set of result details describing PPT options and progression.
   ResultDetails(
       {bool? progress,
       String? pptScheme,
@@ -40,6 +46,7 @@ class ResultDetails extends PPTOptions {
   }
 
   @override
+  /// Validate that the PPT options are correct.
   bool verify() {
     return verifyPPT();
   }

--- a/lib/src/message/unregister.dart
+++ b/lib/src/message/unregister.dart
@@ -1,10 +1,15 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// WAMP message used to unregister a previously registered procedure.
 class Unregister extends AbstractMessage {
+  /// Unique id of the unregister request.
   int requestId;
+
+  /// The registration id that should be removed from the router.
   int registrationId;
 
+  /// Creates an unregister message for the given [registrationId].
   Unregister(this.requestId, this.registrationId) {
     id = MessageTypes.codeUnregister;
   }

--- a/lib/src/message/unregistered.dart
+++ b/lib/src/message/unregistered.dart
@@ -1,9 +1,12 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// Sent by the router as confirmation that a procedure was unregistered.
 class Unregistered extends AbstractMessage {
+  /// Identifier of the original unregister request.
   int unregisterRequestId;
 
+  /// Creates an unregistered message for the given [unregisterRequestId].
   Unregistered(this.unregisterRequestId) {
     id = MessageTypes.codeUnregistered;
   }

--- a/lib/src/message/unsubscribe.dart
+++ b/lib/src/message/unsubscribe.dart
@@ -1,10 +1,15 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// Remove a previously established subscription.
 class Unsubscribe extends AbstractMessage {
+  /// Unique ID for the unsubscribe request.
   int requestId;
+
+  /// The subscription ID to cancel.
   int subscriptionId;
 
+  /// Create an unsubscribe request.
   Unsubscribe(this.requestId, this.subscriptionId) {
     id = MessageTypes.codeUnsubscribe;
   }

--- a/lib/src/message/unsubscribed.dart
+++ b/lib/src/message/unsubscribed.dart
@@ -1,18 +1,28 @@
 import 'abstract_message.dart';
 import 'message_types.dart';
 
+/// Confirmation that a subscription was successfully cancelled.
 class Unsubscribed extends AbstractMessage {
+  /// Identifier of the original unsubscribe request.
   int unsubscribeRequestId;
+
+  /// Additional unsubscribe details provided by the router.
   UnsubscribedDetails? details;
 
+  /// Creates an unsubscribed message for the given [unsubscribeRequestId].
   Unsubscribed(this.unsubscribeRequestId, this.details) {
     id = MessageTypes.codeUnsubscribed;
   }
 }
 
+/// Optional details returned with an [Unsubscribed] message.
 class UnsubscribedDetails {
+  /// The subscription id that was revoked.
   int? subscription;
+
+  /// The reason given by the router for the unsubscription.
   String? reason;
 
+  /// Creates an instance with an optional [subscription] id and [reason].
   UnsubscribedDetails(this.subscription, this.reason);
 }

--- a/lib/src/message/yield.dart
+++ b/lib/src/message/yield.dart
@@ -2,10 +2,15 @@ import 'abstract_ppt_options.dart';
 import 'message_types.dart';
 import 'abstract_message_with_payload.dart';
 
+/// Reply from the callee with the result of an invocation.
 class Yield extends AbstractMessageWithPayload {
+  /// The invocation request this yield answers to.
   int invocationRequestId;
+
+  /// Additional return options.
   YieldOptions? options;
 
+  /// Create a [Yield] message with an optional result payload.
   Yield(this.invocationRequestId,
       {this.options,
       List<dynamic>? arguments,
@@ -16,9 +21,12 @@ class Yield extends AbstractMessageWithPayload {
   }
 }
 
+/// Options influencing how invocation results are transmitted.
 class YieldOptions extends PPTOptions {
+  /// Whether more results will follow.
   bool progress = false;
 
+  /// Create a set of yield options.
   YieldOptions(
       {bool? progress,
       String? pptScheme,
@@ -33,6 +41,7 @@ class YieldOptions extends PPTOptions {
   }
 
   @override
+  /// Validate the PPT options associated with this yield message.
   bool verify() {
     return verifyPPT();
   }


### PR DESCRIPTION
## Summary
- document remaining message methods like Cancel, Event and Result
- add base class docs for messages with payloads
- clarify PPT payload handling
- fix minor wording

## Testing
- `dart pub get` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687114a894d8832585b0078c7946a017