### PR TITLE
fix: correct min sdk

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
   stream_channel: ^2.1.4
   lints: ^6.0.0
 environment:
-  sdk: '>=3.4.0 <4.0.0'
+  sdk: '>=3.8.0 <4.0.0'


### PR DESCRIPTION
`lints: ^6.0.0` requires dart sdk of at least 3.8.0 (see [CHANGELOG](https://pub.dev/packages/lints/changelog)). Thus bumping min sdk requirement.