### PR TITLE
fix: io, web consistent Completer.complete

### DIFF
--- a/lib/src/transport/websocket/websocket_transport_io.dart
+++ b/lib/src/transport/websocket/websocket_transport_io.dart
@@ -105,7 +105,7 @@ class WebSocketTransport extends AbstractTransport {
                 milliseconds: (pingInterval.inMilliseconds * 2 / 3).floor()));
       }
     } on SocketException catch (exception) {
-      _onConnectionLost!.complete(exception);
+      complete(_onConnectionLost, exception);
     }
   }
 
@@ -132,13 +132,13 @@ class WebSocketTransport extends AbstractTransport {
       if ((_socket!.closeCode == null || _socket!.closeCode! > 1000) &&
           !_goodbyeSent &&
           !_goodbyeReceived) {
-        _onConnectionLost!.complete();
+        complete(_onConnectionLost, null);
       } else {
-        _onDisconnect!.complete();
+        complete(_onDisconnect, null);
       }
     }, onError: (error) {
       if (!_onDisconnect!.isCompleted) {
-        _onConnectionLost!.complete(error);
+        complete(_onConnectionLost, error);
       }
     });
     return _socket!.map((messageEvent) {


### PR DESCRIPTION
Hi @konsultaner, thanks for creating this package.

I noticed in [`lib/src/transport/websocket/websocket_transport_io.dart`](https://github.com/konsultaner/connectanum-dart/blob/master/lib/src/transport/websocket/websocket_transport_io.dart#L61), `complete` is used from [`lib/src/transport/abstract_transport.dart`](https://github.com/konsultaner/connectanum-dart/blob/master/lib/src/transport/abstract_transport.dart#L19)

```dart
complete(_onDisconnect, error);
```

`complete` is also used in [`lib/src/transport/websocket/websocket_transport_web.dart`](https://github.com/konsultaner/connectanum-dart/blob/master/lib/src/transport/websocket/websocket_transport_web.dart) to close `_onConnectionLost`, `_onDisconnect`.

This PR aligns `websocket_transport_io` to use `complete` over manual completion, e.g.

```diff
-   _onConnectionLost!.complete();
+   complete(_onConnectionLost, null);
```

In the case of `_onConnectionLost!.complete()` being called multiple times, this results in `Unhandled Exception: Bad state: Future already completed` errors as a completer should only be completed once. The existing method `complete` explicitly checks if the completer has already been completed before invoking `complete`. 