### PR TITLE
feat(wamp-app): configure local router endpoint

### DIFF
--- a/bin/test-wamp-app
+++ b/bin/test-wamp-app
@@ -101,6 +101,9 @@ run_wamp_app_browser_tests() {
   dart format --output=none --set-exit-if-changed benchmark lib test
   flutter analyze
   flutter test
+  flutter test test/widget_test.dart \
+    --plain-name 'registers and opens the authenticated shell' \
+    --dart-define=WAMP_APP_SERVER_ADDRESS=ws://localhost:18080/ws
   if ensure_chrome_env; then
     run_wamp_app_browser_tests
   else

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -692,3 +692,17 @@ integration without private project assumptions.
   isolated Chrome tests plus Dart2Wasm and release web; the full 48-test Chrome
   controller suite and repository-wide `bin/verify` also pass. Exact-head
   hosted evidence remains pending.
+- 2026-08-26: PR #80 is merged to `master` as `85fef3a4` on both maintained
+  remotes. Exact-head GitHub CI run `32978290002`, package dry run
+  `32978290044`, WAMP profile benchmark run `32978289970`, and WampApp artifact
+  run `32978290182` pass; the artifact run includes the production benchmark
+  gate and all seven beta bundles. Native-artifact dry run `32980789298` also
+  passes at the merged head. A configurable `WAMP_APP_SERVER_ADDRESS`
+  compile-time default now lets emulator, integration, and packaged test builds
+  target an alternate local router without source edits while preserving the
+  editable onboarding field and standard `ws://localhost:8080/ws` default.
+  Live Android and iOS clients render against a headless router on port `18080`.
+  Both endpoint variants, static checks, and all 177 non-router client tests
+  pass. The matching router-image dry run remains in progress, and canonical
+  router-owning verification waits until the live manual environment releases
+  the native-runtime lock.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,8 +1,22 @@
 # Project State
 
 Last updated: 2026-08-26
-Current branch: `codex/wamp-app`
+Current branch: `codex/wamp-app-local-endpoint`
 Current milestone: continue the standalone WampApp Flutter consumer example.
+PR #80 is merged to `master` as `85fef3a4` on both maintained remotes.
+Exact-head GitHub CI run `32978290002`, package dry run `32978290044`, WAMP
+profile benchmark run `32978289970`, and WampApp artifact run `32978290182`
+pass; the artifact run includes the production benchmark gate and all seven
+beta bundles. Native-artifact dry run `32980789298` also passes at the merged
+head, while the matching router-image dry run is still in progress.
+WampApp emulator builds can now select their initial onboarding endpoint with
+the compile-time `WAMP_APP_SERVER_ADDRESS` value while keeping the field
+editable and preserving `ws://localhost:8080/ws` as the normal default. A live
+headless router plus Android and iOS clients render the registration flow at
+`ws://localhost:18080/ws`. Both default and overridden widget checks, static
+analysis, and all 177 client tests that do not start a competing router pass;
+canonical router-owning verification remains deferred while that manual
+environment intentionally owns the native-runtime lock.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -117,6 +117,17 @@ flutter pub get
 flutter run -d chrome
 ```
 
+When another local service owns port `8080`, start the client with the server
+address selected at build time:
+
+```bash
+flutter run -d <device-id> \
+  --dart-define=WAMP_APP_SERVER_ADDRESS=ws://localhost:18080/ws
+```
+
+The onboarding field remains editable, so one build can still connect to a
+different local or remote endpoint at runtime.
+
 Keep the default local endpoint, create a username with at least three valid
 characters, and use a password with at least twelve characters. Cleartext
 `ws://` credentials are accepted only for loopback development. Remote

--- a/examples/wamp_app/client/README.md
+++ b/examples/wamp_app/client/README.md
@@ -15,6 +15,17 @@ Cloud Messaging token acquisition starts only after authenticated device
 enrollment, follows token refreshes, and unregisters before sign-out or session
 replacement.
 
+## Configure The Server Address
+
+The onboarding form defaults to `ws://localhost:8080/ws` and remains editable.
+Local emulator, integration, and packaged test builds can select another
+initial value without changing source:
+
+```bash
+flutter run -d <device-id> \
+  --dart-define=WAMP_APP_SERVER_ADDRESS=ws://localhost:18080/ws
+```
+
 ## Configure FCM
 
 FCM is disabled when no Firebase compile-time values are present. Supply the

--- a/examples/wamp_app/client/lib/src/ui/onboarding_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/onboarding_page.dart
@@ -5,6 +5,11 @@ import 'backup_passphrase_dialog.dart';
 
 enum _AccountMode { register, login }
 
+const _defaultServerAddress = String.fromEnvironment(
+  'WAMP_APP_SERVER_ADDRESS',
+  defaultValue: 'ws://localhost:8080/ws',
+);
+
 class OnboardingPage extends StatefulWidget {
   const OnboardingPage({super.key, required this.controller});
 
@@ -15,7 +20,7 @@ class OnboardingPage extends StatefulWidget {
 }
 
 class _OnboardingPageState extends State<OnboardingPage> {
-  final _server = TextEditingController(text: 'ws://localhost:8080/ws');
+  final _server = TextEditingController(text: _defaultServerAddress);
   final _username = TextEditingController();
   final _displayName = TextEditingController();
   final _password = TextEditingController();

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -52,6 +52,16 @@ void main() {
       find.text('Your conversations.\nYour keys. Your server.'),
       findsOneWidget,
     );
+    expect(
+      tester
+          .widget<TextField>(find.byKey(const Key('server-address')))
+          .controller!
+          .text,
+      const String.fromEnvironment(
+        'WAMP_APP_SERVER_ADDRESS',
+        defaultValue: 'ws://localhost:8080/ws',
+      ),
+    );
     await tester.enterText(find.byKey(const Key('username')), 'alice');
     await tester.enterText(
       find.byKey(const Key('display-name')),


### PR DESCRIPTION
## Summary
- allow WampApp builds to select the initial onboarding router with `WAMP_APP_SERVER_ADDRESS`
- preserve the editable field and standard localhost:8080 default
- cover default and overridden endpoints in the canonical WampApp test command
- document emulator and packaged-test usage

## Verification
- `flutter analyze`
- default and overridden focused widget tests
- 177 non-router Flutter client tests
- shared endpoint security tests
- formatting, shell syntax, and `git diff --check`

Canonical router-owning verification is deferred only while the requested live Android/iOS manual environment owns the native runtime lock.