### PR TITLE
Add repeatable WampApp two-device lab

### DIFF
--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: bin/run-wamp-app-lab [options]
+
+Starts one isolated loopback WampApp router and installs the Flutter client on
+one Android emulator and one iOS simulator.
+
+Options:
+  --android-device <id>    Use an already-running Android emulator.
+  --android-emulator <id>  Boot this Android AVD when no Android emulator runs.
+  --ios-device <id>        Use an already-running iOS simulator.
+  --port <port>            Router port (default: 18080).
+  --state-dir <path>       Persistent lab state (default: .dart_tool/wamp_app_lab).
+  --dry-run                Print the resolved plan without changing the machine.
+  -h, --help               Show this help.
+EOF
+}
+
+fail() {
+  printf 'WampApp lab: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+shell_join() {
+  local argument
+  printf '  '
+  for argument in "$@"; do
+    printf '%q ' "$argument"
+  done
+  printf '\n'
+}
+
+devices_json() {
+  flutter devices --machine
+}
+
+find_emulator_device() {
+  local requested_id="$1"
+  local target_platform="$2"
+
+  devices_json | python3 -c '
+import json
+import sys
+
+target_platform = sys.argv[1]
+requested_id = sys.argv[2]
+devices = json.load(sys.stdin)
+for device in devices:
+    platform = device.get("targetPlatform", "")
+    if platform != target_platform and not platform.startswith(f"{target_platform}-"):
+        continue
+    if requested_id and device.get("id") != requested_id:
+        continue
+    if not device.get("isSupported") or not device.get("emulator"):
+        continue
+    print(device["id"])
+    break
+' "$target_platform" "$requested_id"
+}
+
+find_android_avd() {
+  flutter emulators | awk -F ' *• *' '$4 == "android" {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $1); print $1; exit}'
+}
+
+launch_emulator_detached() {
+  local emulator_id="$1"
+  local log_path="$2"
+
+  python3 - "$emulator_id" "$log_path" <<'PY'
+import subprocess
+import sys
+
+with open(sys.argv[2], "ab", buffering=0) as log:
+    subprocess.Popen(
+        ["flutter", "emulators", "--launch", sys.argv[1]],
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+        close_fds=True,
+    )
+PY
+}
+
+wait_for_emulator() {
+  local requested_id="$1"
+  local target_platform="$2"
+  local timeout_seconds="$3"
+  local deadline=$((SECONDS + timeout_seconds))
+  local device_id
+
+  while ((SECONDS < deadline)); do
+    device_id="$(find_emulator_device "$requested_id" "$target_platform")"
+    if [[ -n "$device_id" ]]; then
+      printf '%s\n' "$device_id"
+      return 0
+    fi
+    sleep 2
+  done
+
+  return 1
+}
+
+port_is_available() {
+  python3 - "$1" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+    listener.bind(("127.0.0.1", port))
+PY
+}
+
+wait_for_router() {
+  local port="$1"
+  local server_pid="$2"
+  local deadline=$((SECONDS + 180))
+
+  while ((SECONDS < deadline)); do
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+      return 1
+    fi
+    if python3 - "$port" <<'PY'
+import socket
+import sys
+
+try:
+    with socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=0.5):
+        pass
+except OSError:
+    raise SystemExit(1)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+write_lab_config() {
+  local destination="$1"
+  local port="$2"
+  local source_config="$3"
+
+  python3 - "$source_config" "$destination" "$port" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+updated, count = re.subn(
+    r"(?m)^(listen:\n  host: 127\.0\.0\.1\n  port:) [0-9]+$",
+    rf"\g<1> {sys.argv[3]}",
+    source,
+)
+if count != 1:
+    raise SystemExit("expected one loopback listen block in WampApp config")
+Path(sys.argv[2]).write_text(updated, encoding="utf-8")
+PY
+}
+
+android_device=""
+android_emulator=""
+dry_run=false
+ios_device=""
+port=18080
+state_dir=""
+
+while (($# > 0)); do
+  case "$1" in
+    --android-device)
+      (($# >= 2)) || fail '--android-device requires a value.' 2
+      android_device="$2"
+      shift 2
+      ;;
+    --android-emulator)
+      (($# >= 2)) || fail '--android-emulator requires a value.' 2
+      android_emulator="$2"
+      shift 2
+      ;;
+    --ios-device)
+      (($# >= 2)) || fail '--ios-device requires a value.' 2
+      ios_device="$2"
+      shift 2
+      ;;
+    --port)
+      (($# >= 2)) || fail '--port requires a value.' 2
+      port="$2"
+      shift 2
+      ;;
+    --state-dir)
+      (($# >= 2)) || fail '--state-dir requires a value.' 2
+      state_dir="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1" 2
+      ;;
+  esac
+done
+
+[[ "$port" =~ ^[0-9]+$ ]] || fail "port must be an integer, got $port." 2
+((port >= 1024 && port <= 65535)) || fail "port must be between 1024 and 65535, got $port." 2
+[[ -z "$android_device" || -z "$android_emulator" ]] || \
+  fail '--android-device and --android-emulator are mutually exclusive.' 2
+
+cd_repo_root
+require_command flutter
+require_command python3
+
+if [[ -z "$state_dir" ]]; then
+  state_dir="$(repo_root)/.dart_tool/wamp_app_lab"
+elif [[ "$state_dir" != /* ]]; then
+  state_dir="$(repo_root)/$state_dir"
+fi
+
+resolved_android="$(find_emulator_device "$android_device" android)"
+if [[ -n "$android_device" && -z "$resolved_android" ]]; then
+  fail "Android device $android_device is not a running supported emulator."
+fi
+
+if [[ -z "$resolved_android" ]]; then
+  if [[ -z "$android_emulator" ]]; then
+    android_emulator="$(find_android_avd)"
+  fi
+  [[ -n "$android_emulator" ]] || fail 'no Android emulator or AVD is available.'
+fi
+
+resolved_ios="$(find_emulator_device "$ios_device" ios)"
+if [[ -n "$ios_device" && -z "$resolved_ios" ]]; then
+  fail "iOS device $ios_device is not a running supported simulator."
+fi
+
+endpoint="ws://localhost:$port/ws"
+config_path="$state_dir/wamp_app_server.yaml"
+server_log="$state_dir/server.log"
+android_emulator_log="$state_dir/android-emulator.log"
+ios_emulator_log="$state_dir/ios-emulator.log"
+
+if [[ "$dry_run" == true ]]; then
+  printf 'WampApp two-device lab dry run\n'
+  printf '  endpoint: %s\n' "$endpoint"
+  printf '  state: %s\n' "$state_dir"
+  if [[ -n "$resolved_android" ]]; then
+    printf '  Android emulator: %s\n' "$resolved_android"
+  else
+    printf '  Android AVD to boot: %s\n' "$android_emulator"
+  fi
+  if [[ -n "$resolved_ios" ]]; then
+    printf '  iOS simulator: %s\n' "$resolved_ios"
+  else
+    printf '  iOS simulator: boot the default simulator\n'
+  fi
+  printf 'Router command:\n'
+  shell_join dart run wamp_app_server --config "$config_path"
+  if [[ -n "$resolved_android" ]]; then
+    printf 'Android client command:\n'
+    shell_join flutter run -d "$resolved_android" --no-resident \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
+  fi
+  if [[ -n "$resolved_ios" ]]; then
+    printf 'iOS client command:\n'
+    shell_join flutter run -d "$resolved_ios" --no-resident \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
+  fi
+  exit 0
+fi
+
+require_command dart
+require_command adb
+[[ "$(uname -s)" == Darwin ]] || fail 'the Android + iOS lab requires macOS.'
+port_is_available "$port" || fail "127.0.0.1:$port is already in use."
+
+mkdir -p "$state_dir"
+write_lab_config \
+  "$config_path" \
+  "$port" \
+  "$(repo_root)/examples/wamp_app/server/wamp_app_server.yaml"
+
+if [[ -z "$resolved_android" ]]; then
+  printf 'Booting Android AVD %s...\n' "$android_emulator"
+  launch_emulator_detached "$android_emulator" "$android_emulator_log"
+  if ! resolved_android="$(wait_for_emulator '' android 240)"; then
+    tail -n 40 "$android_emulator_log" >&2 || true
+    fail "Android AVD $android_emulator did not become ready."
+  fi
+fi
+
+if [[ -z "$resolved_ios" ]]; then
+  printf 'Booting the default iOS simulator...\n'
+  launch_emulator_detached apple_ios_simulator "$ios_emulator_log"
+  if ! resolved_ios="$(wait_for_emulator '' ios 180)"; then
+    tail -n 40 "$ios_emulator_log" >&2 || true
+    fail 'the iOS simulator did not become ready.'
+  fi
+fi
+
+android_reverse_installed=false
+server_pid=""
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ "$android_reverse_installed" == true ]]; then
+    adb -s "$resolved_android" reverse --remove "tcp:$port" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+printf 'Resolving standalone WampApp packages...\n'
+(
+  cd "$(repo_root)/examples/wamp_app/server"
+  dart pub get
+)
+(
+  cd "$(repo_root)/examples/wamp_app/client"
+  flutter pub get
+)
+
+printf 'Starting isolated router at %s...\n' "$endpoint"
+(
+  cd "$(repo_root)/examples/wamp_app/server"
+  exec dart run wamp_app_server --config "$config_path"
+) >"$server_log" 2>&1 &
+server_pid=$!
+
+if ! wait_for_router "$port" "$server_pid"; then
+  printf 'WampApp router failed to become ready. Last log lines:\n' >&2
+  tail -n 40 "$server_log" >&2 || true
+  exit 1
+fi
+
+adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
+android_reverse_installed=true
+
+printf 'Installing Android client on %s...\n' "$resolved_android"
+(
+  cd "$(repo_root)/examples/wamp_app/client"
+  flutter run -d "$resolved_android" --no-resident --no-pub \
+    --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
+)
+
+printf 'Installing iOS client on %s...\n' "$resolved_ios"
+(
+  cd "$(repo_root)/examples/wamp_app/client"
+  flutter run -d "$resolved_ios" --no-resident --no-pub \
+    --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
+)
+
+cat <<EOF
+
+WampApp lab is ready.
+  Router:  $endpoint
+  Android: $resolved_android
+  iOS:     $resolved_ios
+  State:   $state_dir
+  Log:     $server_log
+
+Register one account in each app, then use the usernames to start a direct or
+group chat. Press Ctrl+C here to stop the router; installed apps remain open.
+EOF
+
+wait "$server_pid"

--- a/bin/test-all
+++ b/bin/test-all
@@ -165,6 +165,7 @@ build_native_ffi_test_release
 
 python3 tool/test_package_native_artifact.py
 python3 tool/test_package_wamp_app.py
+python3 tool/test_run_wamp_app_lab.py
 python3 tool/test_check_wamp_app_benchmarks.py
 python3 tool/test_verification_scripts.py
 python3 tool/check_public_artifact_references.py

--- a/bin/test-fast
+++ b/bin/test-fast
@@ -53,6 +53,7 @@ run_bench_vm_tests() {
 dart analyze
 python3 tool/test_package_native_artifact.py
 python3 tool/test_package_wamp_app.py
+python3 tool/test_run_wamp_app_lab.py
 python3 tool/test_check_wamp_app_benchmarks.py
 python3 tool/test_verification_scripts.py
 python3 tool/check_public_artifact_references.py

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -706,3 +706,16 @@ integration without private project assumptions.
   pass. The matching router-image dry run remains in progress, and canonical
   router-owning verification waits until the live manual environment releases
   the native-runtime lock.
+- 2026-08-28: The repeatable native acceptance gap is closed locally with
+  `bin/run-wamp-app-lab`. One command now selects or boots supported Android and
+  iOS emulators, starts an isolated persistent router on loopback, installs a
+  temporary Android reverse tunnel, builds both clients with the same editable
+  endpoint, and stays attached for registration and cross-device messaging.
+  Auto-booted emulators are detached from the launcher so Ctrl+C removes only
+  the router and tunnel; both emulators and installed apps remain available.
+  A non-mutating dry run and seven command-contract tests cover realistic
+  Flutter Android platform identifiers, physical-device rejection,
+  empty-device boot planning, path and selector handling, and invalid ports.
+  Live Android API 35 plus iOS 26.4 acceptance proves both registration screens,
+  the `127.0.0.1:18080` listener, the `adb reverse`, and cleanup semantics.
+  Repository-wide `bin/verify` passes; hosted evidence remains next.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,22 +1,26 @@
 # Project State
 
-Last updated: 2026-08-26
-Current branch: `codex/wamp-app-local-endpoint`
-Current milestone: continue the standalone WampApp Flutter consumer example.
-PR #80 is merged to `master` as `85fef3a4` on both maintained remotes.
-Exact-head GitHub CI run `32978290002`, package dry run `32978290044`, WAMP
-profile benchmark run `32978289970`, and WampApp artifact run `32978290182`
-pass; the artifact run includes the production benchmark gate and all seven
-beta bundles. Native-artifact dry run `32980789298` also passes at the merged
-head, while the matching router-image dry run is still in progress.
-WampApp emulator builds can now select their initial onboarding endpoint with
-the compile-time `WAMP_APP_SERVER_ADDRESS` value while keeping the field
-editable and preserving `ws://localhost:8080/ws` as the normal default. A live
-headless router plus Android and iOS clients render the registration flow at
-`ws://localhost:18080/ws`. Both default and overridden widget checks, static
-analysis, and all 177 client tests that do not start a competing router pass;
-canonical router-owning verification remains deferred while that manual
-environment intentionally owns the native-runtime lock.
+Last updated: 2026-08-28
+Current branch: `codex/wamp-app-two-device-lab`
+Current milestone: make standalone WampApp two-device native acceptance
+repeatable. PR #81 is merged to `master` as `ea36a398` on both maintained
+remotes. Exact-head GitHub CI run `33164645535`, WampApp artifact run
+`33164645503`, and native-artifact dry run `33162601850` pass; the artifact run
+includes the production benchmark gate and all seven beta bundles, and the
+strict deployment audit passes.
+`bin/run-wamp-app-lab` now provides one supported macOS command for an isolated
+loopback router plus Android and iOS clients. It selects only emulators,
+detaches any emulator it boots, gives the router an isolated persistent state
+directory, installs a temporary Android `adb reverse`, builds both clients with
+the same editable `ws://localhost:18080/ws` endpoint, and remains attached to
+the router. A non-mutating dry run and seven fail-first command-contract tests
+cover realistic Flutter platform identifiers, physical-device rejection,
+empty-device boot planning, path resolution, selector validation, and port
+validation. Live acceptance on Android API 35 and iOS 26.4 proves both apps
+render the registration flow, the router listens, the reverse tunnel is active,
+and Ctrl+C removes the router and tunnel while both emulators and installed apps
+remain running. Repository-wide `bin/verify` passes for this branch; hosted
+evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -94,6 +94,23 @@ picker without requesting contact properties. macOS, Linux, Windows, and web
 use an explicit `.vcf`/`.vcard` file picker; selected bytes are wiped from
 WampApp memory after only `FN`/`N` display names have been extracted.
 
+On macOS, the supported two-device lab starts an isolated loopback router,
+boots an Android emulator when needed, reuses or boots an iOS simulator,
+installs the client on both, and keeps the router attached to the terminal:
+
+```bash
+bin/run-wamp-app-lab
+```
+
+Use `bin/run-wamp-app-lab --dry-run` to inspect device selection and commands
+without changing the machine. Lab account, mailbox, attachment, backup, call,
+push, and MCP-consent state persists under `.dart_tool/wamp_app_lab`; it never
+uses the example server's normal `data` directory. Android reaches the same
+`localhost` endpoint through a temporary `adb reverse`, which is removed with
+the router when Ctrl+C is pressed. Router output and auto-boot diagnostics are
+retained in that state directory. The emulators and installed apps remain open
+for UI inspection.
+
 Start the server:
 
 ```bash

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -1,0 +1,149 @@
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "bin" / "run-wamp-app-lab"
+
+
+class RunWampAppLabTests(unittest.TestCase):
+    def run_script(self, *arguments: str, devices: list[dict] | None = None):
+        if devices is None:
+            devices = [
+                {
+                    "name": "Android Emulator",
+                    "id": "emulator-5554",
+                    "isSupported": True,
+                    "targetPlatform": "android-arm64",
+                    "emulator": True,
+                },
+                {
+                    "name": "iPhone Simulator",
+                    "id": "ios-simulator",
+                    "isSupported": True,
+                    "targetPlatform": "ios",
+                    "emulator": True,
+                },
+            ]
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = pathlib.Path(temporary_directory)
+            flutter = temporary / "flutter"
+            flutter.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"$1\" == devices && \"$2\" == --machine ]]; then\n"
+                f"  printf '%s\\n' '{json.dumps(devices)}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [[ \"$1\" == emulators ]]; then\n"
+                "  printf '%s\\n' 'fake_android • Fake Android • Google • android'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 99\n",
+                encoding="utf-8",
+            )
+            flutter.chmod(flutter.stat().st_mode | stat.S_IXUSR)
+            environment = os.environ.copy()
+            environment["PATH"] = f"{temporary}:{environment['PATH']}"
+            return subprocess.run(
+                [str(SCRIPT), *arguments],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_dry_run_resolves_router_and_both_emulators(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            state = pathlib.Path(temporary_directory) / "does-not-exist"
+            result = self.run_script(
+                "--dry-run",
+                "--port",
+                "18081",
+                "--state-dir",
+                str(state),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(state.exists())
+        self.assertIn("endpoint: ws://localhost:18081/ws", result.stdout)
+        self.assertIn("Android emulator: emulator-5554", result.stdout)
+        self.assertIn("iOS simulator: ios-simulator", result.stdout)
+        self.assertIn("--no-resident", result.stdout)
+        self.assertEqual(result.stdout.count("WAMP_APP_SERVER_ADDRESS="), 2)
+
+    def test_dry_run_rejects_physical_devices(self):
+        result = self.run_script(
+            "--dry-run",
+            "--android-device",
+            "physical-android",
+            devices=[
+                {
+                    "name": "Phone",
+                    "id": "physical-android",
+                    "isSupported": True,
+                    "targetPlatform": "android-arm64",
+                    "emulator": False,
+                }
+            ],
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not a running supported emulator", result.stderr)
+
+    def test_dry_run_plans_boot_when_no_emulator_is_running(self):
+        result = self.run_script("--dry-run", devices=[])
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Android AVD to boot: fake_android", result.stdout)
+        self.assertIn("iOS simulator: boot the default simulator", result.stdout)
+
+    def test_relative_state_directory_is_resolved_from_repo_root(self):
+        result = self.run_script(
+            "--dry-run",
+            "--state-dir",
+            ".dart_tool/custom-wamp-app-lab",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(
+            f"state: {ROOT}/.dart_tool/custom-wamp-app-lab",
+            result.stdout,
+        )
+
+    def test_android_selector_cannot_resolve_an_ios_device(self):
+        result = self.run_script(
+            "--dry-run",
+            "--android-device",
+            "ios-simulator",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("not a running supported emulator", result.stderr)
+
+    def test_invalid_port_fails_before_device_discovery(self):
+        result = self.run_script("--dry-run", "--port", "80")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("between 1024 and 65535", result.stderr)
+
+    def test_android_selectors_are_mutually_exclusive(self):
+        result = self.run_script(
+            "--dry-run",
+            "--android-device",
+            "emulator-5554",
+            "--android-emulator",
+            "fake_android",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("mutually exclusive", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a macOS launcher for one isolated WampApp router plus Android and iOS emulators
- keep both clients on the same loopback endpoint using Android adb reverse
- add fail-first launcher contract tests to fast and full verification
- document the repeatable native acceptance workflow

## Verification
- bin/test-fast
- bin/verify
- python3 tool/test_run_wamp_app_lab.py
- live Android API 35 and iOS 26.4 registration-screen acceptance against ws://localhost:18080/ws
- Ctrl+C cleanup proves router and adb reverse stop while emulators and installed apps remain open