### PR TITLE
Prove native WampApp encrypted chat

### DIFF
--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -16,7 +16,8 @@ Options:
   --android-emulator <id>  Boot this Android AVD when no Android emulator runs.
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
-  --state-dir <path>       Persistent lab state (default: .dart_tool/wamp_app_lab).
+  --state-dir <path>       Override the run state and evidence directory.
+  --smoke                  Register both clients and verify encrypted chat.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -146,6 +147,25 @@ PY
   return 1
 }
 
+stop_process() {
+  local pid="$1"
+  local attempt
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    for attempt in 1 2 3 4 5; do
+      if ! kill -0 "$pid" 2>/dev/null; then
+        break
+      fi
+      sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  fi
+  wait "$pid" 2>/dev/null || true
+}
+
 write_lab_config() {
   local destination="$1"
   local port="$2"
@@ -173,6 +193,7 @@ android_emulator=""
 dry_run=false
 ios_device=""
 port=18080
+smoke=false
 state_dir=""
 
 while (($# > 0)); do
@@ -202,6 +223,10 @@ while (($# > 0)); do
       state_dir="$2"
       shift 2
       ;;
+    --smoke)
+      smoke=true
+      shift
+      ;;
     --dry-run)
       dry_run=true
       shift
@@ -225,8 +250,17 @@ cd_repo_root
 require_command flutter
 require_command python3
 
+smoke_run_id="run-id"
+if [[ "$smoke" == true && "$dry_run" == false ]]; then
+  smoke_run_id="$(date -u +%Y%m%d%H%M%S)-$$"
+fi
+
 if [[ -z "$state_dir" ]]; then
-  state_dir="$(repo_root)/.dart_tool/wamp_app_lab"
+  if [[ "$smoke" == true ]]; then
+    state_dir="$(repo_root)/.dart_tool/wamp_app_smoke/$smoke_run_id"
+  else
+    state_dir="$(repo_root)/.dart_tool/wamp_app_lab"
+  fi
 elif [[ "$state_dir" != /* ]]; then
   state_dir="$(repo_root)/$state_dir"
 fi
@@ -253,9 +287,20 @@ config_path="$state_dir/wamp_app_server.yaml"
 server_log="$state_dir/server.log"
 android_emulator_log="$state_dir/android-emulator.log"
 ios_emulator_log="$state_dir/ios-emulator.log"
+android_smoke_log="$state_dir/android-smoke.log"
+ios_smoke_log="$state_dir/ios-smoke.log"
+
+android_smoke_username="android-$smoke_run_id"
+ios_smoke_username="ios-$smoke_run_id"
+android_smoke_message="from-android-$smoke_run_id"
+ios_smoke_message="from-ios-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
-  printf 'WampApp two-device lab dry run\n'
+  if [[ "$smoke" == true ]]; then
+    printf 'WampApp Two-device UI smoke dry run\n'
+  else
+    printf 'WampApp two-device lab dry run\n'
+  fi
   printf '  endpoint: %s\n' "$endpoint"
   printf '  state: %s\n' "$state_dir"
   if [[ -n "$resolved_android" ]]; then
@@ -270,12 +315,30 @@ if [[ "$dry_run" == true ]]; then
   fi
   printf 'Router command:\n'
   shell_join dart run wamp_app_server --config "$config_path"
-  if [[ -n "$resolved_android" ]]; then
+  if [[ "$smoke" == true && -n "$resolved_android" ]]; then
+    printf 'Android smoke command:\n'
+    shell_join flutter test -d "$resolved_android" --no-pub --timeout 6m \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
+      --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_OUTBOUND=$android_smoke_message" \
+      --dart-define="WAMP_APP_SMOKE_INBOUND=$ios_smoke_message" \
+      integration_test/two_device_smoke_test.dart
+  elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
     shell_join flutter run -d "$resolved_android" --no-resident \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
   fi
-  if [[ -n "$resolved_ios" ]]; then
+  if [[ "$smoke" == true && -n "$resolved_ios" ]]; then
+    printf 'iOS smoke command:\n'
+    shell_join flutter test -d "$resolved_ios" --no-pub --timeout 6m \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
+      --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_OUTBOUND=$ios_smoke_message" \
+      --dart-define="WAMP_APP_SMOKE_INBOUND=$android_smoke_message" \
+      integration_test/two_device_smoke_test.dart
+  elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
     shell_join flutter run -d "$resolved_ios" --no-resident \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
@@ -313,16 +376,23 @@ if [[ -z "$resolved_ios" ]]; then
 fi
 
 android_reverse_installed=false
+android_smoke_pid=""
+ios_smoke_pid=""
 server_pid=""
 cleanup() {
   local status=$?
   trap - EXIT INT TERM
+  if [[ -n "$android_smoke_pid" ]]; then
+    stop_process "$android_smoke_pid"
+  fi
+  if [[ -n "$ios_smoke_pid" ]]; then
+    stop_process "$ios_smoke_pid"
+  fi
   if [[ "$android_reverse_installed" == true ]]; then
     adb -s "$resolved_android" reverse --remove "tcp:$port" >/dev/null 2>&1 || true
   fi
-  if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
-    kill "$server_pid" 2>/dev/null || true
-    wait "$server_pid" 2>/dev/null || true
+  if [[ -n "$server_pid" ]]; then
+    stop_process "$server_pid"
   fi
   exit "$status"
 }
@@ -355,6 +425,68 @@ fi
 
 adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
+
+if [[ "$smoke" == true ]]; then
+  printf 'Running Android and iOS registration/message smoke concurrently...\n'
+  (
+    cd "$(repo_root)/examples/wamp_app/client"
+    exec flutter test -d "$resolved_android" --no-pub --timeout 6m \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
+      --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_OUTBOUND=$android_smoke_message" \
+      --dart-define="WAMP_APP_SMOKE_INBOUND=$ios_smoke_message" \
+      integration_test/two_device_smoke_test.dart
+  ) >"$android_smoke_log" 2>&1 &
+  android_smoke_pid=$!
+  (
+    cd "$(repo_root)/examples/wamp_app/client"
+    exec flutter test -d "$resolved_ios" --no-pub --timeout 6m \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
+      --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_OUTBOUND=$ios_smoke_message" \
+      --dart-define="WAMP_APP_SMOKE_INBOUND=$android_smoke_message" \
+      integration_test/two_device_smoke_test.dart
+  ) >"$ios_smoke_log" 2>&1 &
+  ios_smoke_pid=$!
+
+  set +e
+  wait "$android_smoke_pid"
+  android_smoke_status=$?
+  android_smoke_pid=""
+  wait "$ios_smoke_pid"
+  ios_smoke_status=$?
+  ios_smoke_pid=""
+  set -e
+
+  if ((android_smoke_status != 0 || ios_smoke_status != 0)); then
+    printf 'Android smoke log:\n' >&2
+    tail -n 80 "$android_smoke_log" >&2 || true
+    printf 'iOS smoke log:\n' >&2
+    tail -n 80 "$ios_smoke_log" >&2 || true
+    fail "two-device UI smoke failed (Android $android_smoke_status, iOS $ios_smoke_status)."
+  fi
+
+  message_store="$state_dir/data/messages.json"
+  [[ -f "$message_store" ]] || fail 'the smoke router did not persist its message store.'
+  if grep -Fq -- "$android_smoke_message" "$message_store" || \
+     grep -Fq -- "$ios_smoke_message" "$message_store"; then
+    fail 'the smoke router persisted plaintext message content.'
+  fi
+
+  cat <<EOF
+
+WampApp two-device UI smoke passed.
+  Router:  $endpoint
+  Android: $resolved_android ($android_smoke_username)
+  iOS:     $resolved_ios ($ios_smoke_username)
+  State:   $state_dir
+  Logs:    $android_smoke_log
+           $ios_smoke_log
+EOF
+  exit 0
+fi
 
 printf 'Installing Android client on %s...\n' "$resolved_android"
 (

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -719,3 +719,17 @@ integration without private project assumptions.
   Live Android API 35 plus iOS 26.4 acceptance proves both registration screens,
   the `127.0.0.1:18080` listener, the `adb reverse`, and cleanup semantics.
   Repository-wide `bin/verify` passes; hosted evidence remains next.
+- 2026-08-28: Native acceptance now goes beyond launching two registration
+  screens. `bin/run-wamp-app-lab --smoke` concurrently drives Android API 35
+  and iOS 26.4 through real UI registration, 3-pass/64 MiB Argon2id SCRAM,
+  reciprocal device discovery, UI sends, mailbox pub/sub delivery, local
+  decryption, and rendered direct-message history. The runner also verifies
+  that neither plaintext token exists in the router message store and bounds
+  router/client shutdown after failures. The first live run exposed a compact
+  keyboard overflow that made send controls unhittable; the authenticated shell
+  now collapses secondary account/search/filter/call/expiry controls while the
+  keyboard is visible and preserves recipient, history, errors, attachments,
+  and composer. A fail-first 390x844/500 px keyboard regression, all 18 widget
+  tests, Flutter analysis, nine launcher tests, the real Android+iOS smoke, and
+  canonical repository `bin/verify` pass locally. Exact-head hosted evidence
+  remains pending.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,26 +1,26 @@
 # Project State
 
 Last updated: 2026-08-28
-Current branch: `codex/wamp-app-two-device-lab`
-Current milestone: make standalone WampApp two-device native acceptance
-repeatable. PR #81 is merged to `master` as `ea36a398` on both maintained
-remotes. Exact-head GitHub CI run `33164645535`, WampApp artifact run
-`33164645503`, and native-artifact dry run `33162601850` pass; the artifact run
-includes the production benchmark gate and all seven beta bundles, and the
-strict deployment audit passes.
-`bin/run-wamp-app-lab` now provides one supported macOS command for an isolated
-loopback router plus Android and iOS clients. It selects only emulators,
-detaches any emulator it boots, gives the router an isolated persistent state
-directory, installs a temporary Android `adb reverse`, builds both clients with
-the same editable `ws://localhost:18080/ws` endpoint, and remains attached to
-the router. A non-mutating dry run and seven fail-first command-contract tests
-cover realistic Flutter platform identifiers, physical-device rejection,
-empty-device boot planning, path resolution, selector validation, and port
-validation. Live acceptance on Android API 35 and iOS 26.4 proves both apps
-render the registration flow, the router listens, the reverse tunnel is active,
-and Ctrl+C removes the router and tunnel while both emulators and installed apps
-remain running. Repository-wide `bin/verify` passes for this branch; hosted
-evidence remains next.
+Current branch: `codex/wamp-app-native-ui-smoke`
+Current milestone: prove standalone WampApp registration and encrypted chat
+through concurrent native platform UIs. PR #82 is merged to `master` as
+`48783adf` on both maintained remotes. Exact-head GitHub CI run `33171843544`
+and WampApp artifact run `33171843583` pass; the artifact run includes the
+production benchmark gate and all seven beta bundles, and the strict deployment
+audit passes.
+`bin/run-wamp-app-lab` retains its interactive Android+iOS mode and now adds a
+deterministic `--smoke` mode. Fresh Android API 35 and iOS 26.4 clients register
+unique accounts through the real keyed UI and 3-pass/64 MiB Argon2id SCRAM,
+discover the peer device, send reciprocal direct messages through the UI,
+receive them through mailbox pub/sub, decrypt them locally, and render both
+bubbles. The launcher rejects plaintext tokens in the router message store and
+uses bounded process termination so failed runs cannot leave the router or
+Android reverse tunnel behind. This acceptance exposed and fixed a real mobile
+keyboard overflow: the compact authenticated shell now collapses secondary
+account and conversation controls while preserving recipient, history, errors,
+attachments, and composer. Nine launcher tests, all 18 WampApp widget tests,
+Flutter analysis, the two-device native smoke, and repository-wide `bin/verify`
+pass locally; exact-head hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -111,6 +111,21 @@ the router when Ctrl+C is pressed. Router output and auto-boot diagnostics are
 retained in that state directory. The emulators and installed apps remain open
 for UI inspection.
 
+Run the same lab as a deterministic native acceptance test with:
+
+```bash
+bin/run-wamp-app-lab --smoke
+```
+
+Smoke mode drives the real Android and iOS Flutter UIs concurrently. Each
+client registers a unique account through 64 MiB Argon2id SCRAM, waits for the
+other device directory, sends one encrypted direct message, receives and
+decrypts the peer message through mailbox pub/sub, and renders both bubbles.
+The launcher also rejects the run if either plaintext token appears in the
+router message store. Run-scoped router state and platform logs remain under
+`.dart_tool/wamp_app_smoke` for inspection; the router and Android reverse
+tunnel are removed when the run finishes.
+
 Start the server:
 
 ```bash

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:wamp_app/src/app.dart';
+import 'package:wamp_app/src/application/wamp_app_controller.dart';
+
+const _serverAddress = String.fromEnvironment('WAMP_APP_SERVER_ADDRESS');
+const _username = String.fromEnvironment('WAMP_APP_SMOKE_USERNAME');
+const _peerUsername = String.fromEnvironment('WAMP_APP_SMOKE_PEER');
+const _outboundText = String.fromEnvironment('WAMP_APP_SMOKE_OUTBOUND');
+const _inboundText = String.fromEnvironment('WAMP_APP_SMOKE_INBOUND');
+const _password = 'wamp-app-native-smoke-password';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'registers and exchanges an encrypted message with the peer device',
+    (tester) async {
+      _validateConfiguration();
+      final controller = WampAppController(deviceName: '$_username device');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(WampApp(controller: controller));
+      await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
+        label: 'onboarding form',
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('server-address')),
+        _serverAddress,
+      );
+      await tester.enterText(find.byKey(const Key('username')), _username);
+      await tester.enterText(
+        find.byKey(const Key('display-name')),
+        'Native smoke $_username',
+      );
+      await tester.enterText(find.byKey(const Key('password')), _password);
+      final submit = find.byKey(const Key('submit-account'));
+      await tester.ensureVisible(submit);
+      await tester.tap(submit);
+
+      await _pumpUntil(
+        tester,
+        () =>
+            controller.status == WampAppStatus.connected &&
+            controller.connection?.username == _username &&
+            find.byKey(const Key('message-recipient')).evaluate().isNotEmpty,
+        label: 'authenticated conversation shell',
+        timeout: const Duration(minutes: 2),
+      );
+      await _waitForPeerDevice(tester, controller);
+
+      final recipient = find.byKey(const Key('message-recipient'));
+      final composer = find.byKey(const Key('message-composer'));
+      await tester.ensureVisible(recipient);
+      await tester.enterText(recipient, _peerUsername);
+      await tester.pump();
+      await tester.ensureVisible(composer);
+      await tester.enterText(composer, _outboundText);
+      final send = find.byKey(const Key('message-send'));
+      await tester.ensureVisible(send);
+      await _tapSendUntilOutbound(tester, controller, send);
+      final outbound = controller.messages.singleWhere(
+        (message) =>
+            message.outgoing &&
+            message.peerUsername == _peerUsername &&
+            message.text == _outboundText,
+      );
+      await _pumpUntil(
+        tester,
+        () =>
+            controller.outboundMessageFor(outbound.messageId) == null &&
+            controller.messageError == null,
+        label: 'router acceptance of outbound message',
+      );
+
+      await _pumpUntil(
+        tester,
+        () => controller.messages.any(
+          (message) =>
+              !message.outgoing &&
+              message.peerUsername == _peerUsername &&
+              message.text == _inboundText,
+        ),
+        label: 'mailbox wakeup and decrypted inbound message',
+        timeout: const Duration(minutes: 2),
+      );
+
+      FocusManager.instance.primaryFocus?.unfocus();
+      await _pumpUntil(
+        tester,
+        () =>
+            find.text(_outboundText).evaluate().isNotEmpty ||
+            find.text(_inboundText).evaluate().isNotEmpty,
+        label: 'rendered message history',
+      );
+      final outboundRendered = find.text(_outboundText).evaluate().isNotEmpty;
+      final inboundRendered = find.text(_inboundText).evaluate().isNotEmpty;
+      if (!outboundRendered || !inboundRendered) {
+        final history = find.byKey(const Key('message-history'));
+        final scrollable = find.descendant(
+          of: history,
+          matching: find.byType(Scrollable),
+        );
+        await tester.scrollUntilVisible(
+          find.text(outboundRendered ? _inboundText : _outboundText),
+          100,
+          scrollable: scrollable,
+          maxScrolls: 20,
+        );
+      }
+      expect(controller.messageError, isNull);
+      expect(
+        outboundRendered || find.text(_outboundText).evaluate().isNotEmpty,
+        isTrue,
+      );
+      expect(
+        inboundRendered || find.text(_inboundText).evaluate().isNotEmpty,
+        isTrue,
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}
+
+void _validateConfiguration() {
+  final values = {
+    'WAMP_APP_SERVER_ADDRESS': _serverAddress,
+    'WAMP_APP_SMOKE_USERNAME': _username,
+    'WAMP_APP_SMOKE_PEER': _peerUsername,
+    'WAMP_APP_SMOKE_OUTBOUND': _outboundText,
+    'WAMP_APP_SMOKE_INBOUND': _inboundText,
+  };
+  for (final entry in values.entries) {
+    if (entry.value.trim().isEmpty) {
+      fail('${entry.key} must be provided for the two-device smoke.');
+    }
+  }
+  if (_username == _peerUsername || _outboundText == _inboundText) {
+    fail('The two smoke clients must use distinct identities and messages.');
+  }
+}
+
+Future<void> _tapSendUntilOutbound(
+  WidgetTester tester,
+  WampAppController controller,
+  Finder send,
+) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 1));
+  bool hasOutbound() => controller.messages.any(
+    (message) =>
+        message.outgoing &&
+        message.peerUsername == _peerUsername &&
+        message.text == _outboundText,
+  );
+
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (hasOutbound()) return;
+    if (tester.widget<IconButton>(send).onPressed != null) {
+      await tester.tap(send, warnIfMissed: false);
+    }
+  }
+  fail('Timed out waiting for a successful encrypted-message tap.');
+}
+
+Future<void> _waitForPeerDevice(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 2));
+  Object? lastError;
+  while (DateTime.now().isBefore(deadline)) {
+    final connection = controller.connection;
+    if (connection != null) {
+      try {
+        final directory = await connection.lookupDevices(_peerUsername);
+        if (directory.devices.isNotEmpty) return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+  fail(
+    'Timed out waiting for the peer device directory'
+    '${lastError == null ? '.' : ' (${lastError.runtimeType}).'}',
+  );
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String label,
+  Duration timeout = const Duration(minutes: 1),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (condition()) return;
+  }
+  fail('Timed out waiting for $label.');
+}

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -813,6 +813,7 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     final calls = widget.controller.calls!;
+    final keyboardVisible = MediaQuery.viewInsetsOf(context).bottom > 0;
     return AnimatedBuilder(
       animation: calls,
       builder: (context, _) => Stack(
@@ -846,6 +847,7 @@ class _HomePageState extends State<HomePage> {
                   final conversation = _ConversationPanel(
                     controller: widget.controller,
                     calls: calls,
+                    keyboardVisible: keyboardVisible,
                     recipientController: _recipientController,
                     messageController: _messageController,
                     searchController: _searchController,
@@ -899,7 +901,7 @@ class _HomePageState extends State<HomePage> {
                     stickerBusy: _stickerBusy,
                   );
                   return Padding(
-                    padding: const EdgeInsets.all(18),
+                    padding: EdgeInsets.all(keyboardVisible ? 8 : 18),
                     child: wide
                         ? Row(
                             children: [
@@ -910,8 +912,10 @@ class _HomePageState extends State<HomePage> {
                           )
                         : Column(
                             children: [
-                              account,
-                              const SizedBox(height: 18),
+                              if (!keyboardVisible) ...[
+                                account,
+                                const SizedBox(height: 18),
+                              ],
                               Expanded(child: conversation),
                             ],
                           ),
@@ -1508,6 +1512,7 @@ class _ConversationPanel extends StatelessWidget {
   const _ConversationPanel({
     required this.controller,
     required this.calls,
+    required this.keyboardVisible,
     required this.recipientController,
     required this.messageController,
     required this.searchController,
@@ -1546,6 +1551,7 @@ class _ConversationPanel extends StatelessWidget {
 
   final WampAppController controller;
   final CallController calls;
+  final bool keyboardVisible;
   final TextEditingController recipientController;
   final TextEditingController messageController;
   final TextEditingController searchController;
@@ -1615,169 +1621,180 @@ class _ConversationPanel extends StatelessWidget {
     final compact = MediaQuery.sizeOf(context).width < 760;
     return Card(
       child: Padding(
-        padding: EdgeInsets.all(compact ? 14 : 22),
+        padding: EdgeInsets.all(
+          keyboardVisible
+              ? 8
+              : compact
+              ? 14
+              : 22,
+        ),
         child: Column(
           children: [
-            Row(
-              children: [
-                Icon(
-                  Icons.lock_outline,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-                const SizedBox(width: 9),
-                Expanded(
-                  child: Text(
-                    selectedGroup?.title ?? 'Encrypted messages',
-                    style: Theme.of(context).textTheme.titleLarge,
-                  ),
-                ),
-                IconButton(
-                  key: const Key('conversation-voice-call'),
-                  tooltip: groupMode
-                      ? 'Group calls are not available yet'
-                      : 'Start encrypted voice call',
-                  onPressed: canStartCall ? onStartVoiceCall : null,
-                  icon: const Icon(Icons.call_outlined),
-                ),
-                IconButton(
-                  key: const Key('conversation-video-call'),
-                  tooltip: groupMode
-                      ? 'Group calls are not available yet'
-                      : 'Start encrypted video call',
-                  onPressed: canStartCall ? onStartVideoCall : null,
-                  icon: const Icon(Icons.videocam_outlined),
-                ),
-                if (activeConversationId != null)
-                  IconButton(
-                    key: const Key('conversation-mute'),
-                    tooltip: conversationMuted
-                        ? 'Unmute this chat'
-                        : 'Mute this chat',
-                    onPressed: controller.preferenceBusy
-                        ? null
-                        : () => onMuteChanged(
-                            activeConversationId,
-                            !conversationMuted,
-                          ),
-                    icon: controller.preferenceBusy
-                        ? const SizedBox.square(
-                            dimension: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Icon(
-                            conversationMuted
-                                ? Icons.notifications_off
-                                : Icons.notifications_none,
-                          ),
-                  ),
-                IconButton(
-                  tooltip: 'Sync messages',
-                  onPressed: controller.messageBusy
-                      ? null
-                      : controller.refreshMessages,
-                  icon: const Icon(Icons.sync),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              key: const Key('message-global-search'),
-              controller: searchController,
-              maxLength: LocalMessageQuery.maxQueryLength,
-              maxLengthEnforcement: MaxLengthEnforcement.enforced,
-              buildCounter: (
-                _, {
-                required currentLength,
-                required isFocused,
-                maxLength,
-              }) => null,
-              decoration: InputDecoration(
-                labelText: globalSearch
-                    ? 'Local search · ${visibleMessages.length} result${visibleMessages.length == 1 ? '' : 's'}'
-                    : 'Search local messages · stays on this device',
-                prefixIcon: const Icon(Icons.search),
-                suffixIcon: searchController.text.isEmpty
-                    ? null
-                    : IconButton(
-                        key: const Key('message-search-clear'),
-                        tooltip: 'Clear message search',
-                        onPressed: onClearSearch,
-                        icon: const Icon(Icons.close),
-                      ),
-              ),
-              onChanged: onSearchChanged,
-              onTapOutside: (_) =>
-                  FocusManager.instance.primaryFocus?.unfocus(),
-            ),
-            const SizedBox(height: 10),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
+            if (!keyboardVisible) ...[
+              Row(
                 children: [
-                  ChoiceChip(
-                    key: const Key('conversation-direct'),
-                    selected: !groupMode,
-                    onSelected: controller.messageBusy
-                        ? null
-                        : (_) => onConversationChanged(null),
-                    avatar: const Icon(Icons.person_outline, size: 18),
-                    label: const Text('Direct'),
+                  Icon(
+                    Icons.lock_outline,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
-                  for (final group in controller.groups) ...[
-                    const SizedBox(width: 8),
-                    ChoiceChip(
-                      key: ValueKey(
-                        'conversation-group-${group.conversationId}',
-                      ),
-                      selected: selectedGroupId == group.conversationId,
-                      onSelected: controller.messageBusy
+                  const SizedBox(width: 9),
+                  Expanded(
+                    child: Text(
+                      selectedGroup?.title ?? 'Encrypted messages',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    key: const Key('conversation-voice-call'),
+                    tooltip: groupMode
+                        ? 'Group calls are not available yet'
+                        : 'Start encrypted voice call',
+                    onPressed: canStartCall ? onStartVoiceCall : null,
+                    icon: const Icon(Icons.call_outlined),
+                  ),
+                  IconButton(
+                    key: const Key('conversation-video-call'),
+                    tooltip: groupMode
+                        ? 'Group calls are not available yet'
+                        : 'Start encrypted video call',
+                    onPressed: canStartCall ? onStartVideoCall : null,
+                    icon: const Icon(Icons.videocam_outlined),
+                  ),
+                  if (activeConversationId != null)
+                    IconButton(
+                      key: const Key('conversation-mute'),
+                      tooltip: conversationMuted
+                          ? 'Unmute this chat'
+                          : 'Mute this chat',
+                      onPressed: controller.preferenceBusy
                           ? null
-                          : (_) => onConversationChanged(group.conversationId),
-                      avatar: const Icon(Icons.group_outlined, size: 18),
-                      label: Text(group.title),
+                          : () => onMuteChanged(
+                              activeConversationId,
+                              !conversationMuted,
+                            ),
+                      icon: controller.preferenceBusy
+                          ? const SizedBox.square(
+                              dimension: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Icon(
+                              conversationMuted
+                                  ? Icons.notifications_off
+                                  : Icons.notifications_none,
+                            ),
                     ),
-                  ],
-                  const SizedBox(width: 8),
-                  ActionChip(
-                    key: const Key('conversation-create-group'),
-                    onPressed: controller.messageBusy ? null : onCreateGroup,
-                    avatar: const Icon(Icons.add, size: 18),
-                    label: const Text('New group'),
-                  ),
-                  const SizedBox(width: 16),
-                  FilterChip(
-                    key: const Key('message-filter-all'),
-                    selected: readFilter == LocalMessageReadFilter.all,
-                    onSelected: (_) =>
-                        onReadFilterChanged(LocalMessageReadFilter.all),
-                    label: const Text('All'),
-                  ),
-                  const SizedBox(width: 8),
-                  FilterChip(
-                    key: const Key('message-filter-unread'),
-                    selected: readFilter == LocalMessageReadFilter.unread,
-                    onSelected: (_) =>
-                        onReadFilterChanged(LocalMessageReadFilter.unread),
-                    avatar: const Icon(
-                      Icons.mark_chat_unread_outlined,
-                      size: 18,
-                    ),
-                    label: const Text('Unread received'),
-                  ),
-                  const SizedBox(width: 8),
-                  FilterChip(
-                    key: const Key('message-filter-read'),
-                    selected: readFilter == LocalMessageReadFilter.read,
-                    onSelected: (_) =>
-                        onReadFilterChanged(LocalMessageReadFilter.read),
-                    avatar: const Icon(Icons.done_all, size: 18),
-                    label: const Text('Read received'),
+                  IconButton(
+                    tooltip: 'Sync messages',
+                    onPressed: controller.messageBusy
+                        ? null
+                        : controller.refreshMessages,
+                    icon: const Icon(Icons.sync),
                   ),
                 ],
               ),
-            ),
-            const SizedBox(height: 14),
-            if (!groupMode && controller.contacts.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('message-global-search'),
+                controller: searchController,
+                maxLength: LocalMessageQuery.maxQueryLength,
+                maxLengthEnforcement: MaxLengthEnforcement.enforced,
+                buildCounter: (
+                  _, {
+                  required currentLength,
+                  required isFocused,
+                  maxLength,
+                }) => null,
+                decoration: InputDecoration(
+                  labelText: globalSearch
+                      ? 'Local search · ${visibleMessages.length} result${visibleMessages.length == 1 ? '' : 's'}'
+                      : 'Search local messages · stays on this device',
+                  prefixIcon: const Icon(Icons.search),
+                  suffixIcon: searchController.text.isEmpty
+                      ? null
+                      : IconButton(
+                          key: const Key('message-search-clear'),
+                          tooltip: 'Clear message search',
+                          onPressed: onClearSearch,
+                          icon: const Icon(Icons.close),
+                        ),
+                ),
+                onChanged: onSearchChanged,
+                onTapOutside: (_) =>
+                    FocusManager.instance.primaryFocus?.unfocus(),
+              ),
+              const SizedBox(height: 10),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    ChoiceChip(
+                      key: const Key('conversation-direct'),
+                      selected: !groupMode,
+                      onSelected: controller.messageBusy
+                          ? null
+                          : (_) => onConversationChanged(null),
+                      avatar: const Icon(Icons.person_outline, size: 18),
+                      label: const Text('Direct'),
+                    ),
+                    for (final group in controller.groups) ...[
+                      const SizedBox(width: 8),
+                      ChoiceChip(
+                        key: ValueKey(
+                          'conversation-group-${group.conversationId}',
+                        ),
+                        selected: selectedGroupId == group.conversationId,
+                        onSelected: controller.messageBusy
+                            ? null
+                            : (_) =>
+                                  onConversationChanged(group.conversationId),
+                        avatar: const Icon(Icons.group_outlined, size: 18),
+                        label: Text(group.title),
+                      ),
+                    ],
+                    const SizedBox(width: 8),
+                    ActionChip(
+                      key: const Key('conversation-create-group'),
+                      onPressed: controller.messageBusy ? null : onCreateGroup,
+                      avatar: const Icon(Icons.add, size: 18),
+                      label: const Text('New group'),
+                    ),
+                    const SizedBox(width: 16),
+                    FilterChip(
+                      key: const Key('message-filter-all'),
+                      selected: readFilter == LocalMessageReadFilter.all,
+                      onSelected: (_) =>
+                          onReadFilterChanged(LocalMessageReadFilter.all),
+                      label: const Text('All'),
+                    ),
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      key: const Key('message-filter-unread'),
+                      selected: readFilter == LocalMessageReadFilter.unread,
+                      onSelected: (_) =>
+                          onReadFilterChanged(LocalMessageReadFilter.unread),
+                      avatar: const Icon(
+                        Icons.mark_chat_unread_outlined,
+                        size: 18,
+                      ),
+                      label: const Text('Unread received'),
+                    ),
+                    const SizedBox(width: 8),
+                    FilterChip(
+                      key: const Key('message-filter-read'),
+                      selected: readFilter == LocalMessageReadFilter.read,
+                      onSelected: (_) =>
+                          onReadFilterChanged(LocalMessageReadFilter.read),
+                      avatar: const Icon(Icons.done_all, size: 18),
+                      label: const Text('Read received'),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 14),
+            ],
+            if (!keyboardVisible &&
+                !groupMode &&
+                controller.contacts.isNotEmpty) ...[
               SizedBox(
                 height: 38,
                 child: ListView.separated(
@@ -1842,7 +1859,7 @@ class _ConversationPanel extends StatelessWidget {
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ),
-            const SizedBox(height: 14),
+            SizedBox(height: keyboardVisible ? 6 : 14),
             Expanded(
               child: visibleMessages.isEmpty
                   ? _NoMessages(
@@ -1918,64 +1935,70 @@ class _ConversationPanel extends StatelessWidget {
                 ),
               ),
             ],
-            const SizedBox(height: 14),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: [
-                  FilterChip(
-                    key: const Key('message-one-time'),
-                    selected: !groupMode && oneTime,
-                    onSelected:
-                        controller.messageBusy ||
-                            groupMode ||
-                            selectedAttachments.isNotEmpty
-                        ? null
-                        : onOneTimeChanged,
-                    avatar: const Icon(Icons.visibility_off_outlined, size: 18),
-                    label: const Text('View once'),
-                  ),
-                  const SizedBox(width: 12),
-                  PopupMenuButton<Duration>(
-                    key: const Key('message-expiry'),
-                    enabled:
-                        activeConversationId != null &&
-                        !controller.messageBusy &&
-                        !controller.preferenceBusy,
-                    initialValue: expiresAfter ?? Duration.zero,
-                    onSelected: activeConversationId == null
-                        ? null
-                        : (value) => onExpiresAfterChanged(
-                            activeConversationId,
-                            value == Duration.zero ? null : value,
-                          ),
-                    itemBuilder: (context) => const [
-                      PopupMenuItem(
-                        value: Duration.zero,
-                        child: Text('Keep chat messages'),
+            if (!keyboardVisible) ...[
+              const SizedBox(height: 14),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    FilterChip(
+                      key: const Key('message-one-time'),
+                      selected: !groupMode && oneTime,
+                      onSelected:
+                          controller.messageBusy ||
+                              groupMode ||
+                              selectedAttachments.isNotEmpty
+                          ? null
+                          : onOneTimeChanged,
+                      avatar: const Icon(
+                        Icons.visibility_off_outlined,
+                        size: 18,
                       ),
-                      PopupMenuItem(
-                        value: Duration(hours: 1),
-                        child: Text('Delete after 1 hour'),
-                      ),
-                      PopupMenuItem(
-                        value: Duration(days: 1),
-                        child: Text('Delete after 1 day'),
-                      ),
-                      PopupMenuItem(
-                        value: Duration(days: 7),
-                        child: Text('Delete after 7 days'),
-                      ),
-                    ],
-                    child: Chip(
-                      avatar: const Icon(Icons.timer_outlined, size: 18),
-                      label: Text(_expiryLabel(expiresAfter)),
+                      label: const Text('View once'),
                     ),
-                  ),
-                ],
+                    const SizedBox(width: 12),
+                    PopupMenuButton<Duration>(
+                      key: const Key('message-expiry'),
+                      enabled:
+                          activeConversationId != null &&
+                          !controller.messageBusy &&
+                          !controller.preferenceBusy,
+                      initialValue: expiresAfter ?? Duration.zero,
+                      onSelected: activeConversationId == null
+                          ? null
+                          : (value) => onExpiresAfterChanged(
+                              activeConversationId,
+                              value == Duration.zero ? null : value,
+                            ),
+                      itemBuilder: (context) => const [
+                        PopupMenuItem(
+                          value: Duration.zero,
+                          child: Text('Keep chat messages'),
+                        ),
+                        PopupMenuItem(
+                          value: Duration(hours: 1),
+                          child: Text('Delete after 1 hour'),
+                        ),
+                        PopupMenuItem(
+                          value: Duration(days: 1),
+                          child: Text('Delete after 1 day'),
+                        ),
+                        PopupMenuItem(
+                          value: Duration(days: 7),
+                          child: Text('Delete after 7 days'),
+                        ),
+                      ],
+                      child: Chip(
+                        avatar: const Icon(Icons.timer_outlined, size: 18),
+                        label: Text(_expiryLabel(expiresAfter)),
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            const SizedBox(height: 8),
+              const SizedBox(height: 8),
+            ] else
+              const SizedBox(height: 4),
             if (selectedAttachments.isNotEmpty) ...[
               SizedBox(
                 height: 42,

--- a/examples/wamp_app/client/pubspec.yaml
+++ b/examples/wamp_app/client/pubspec.yaml
@@ -35,6 +35,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   wamp_app_server:
     path: ../server
 

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -334,6 +334,41 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('keeps direct-message controls usable above a compact keyboard', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewInsets = const FakeViewPadding(bottom: 500);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+    final controller = WampAppController(
+      gateway: _FakeGateway(),
+      trustStore: FakeDeviceTrustStore(),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'wss://localhost/ws',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const Key('message-recipient')).hitTestable(),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('message-composer')).hitTestable(),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('message-send')).hitTestable(), findsOneWidget);
+  });
+
   testWidgets('confirms MCP profile sharing and revokes it immediately', (
     tester,
   ) async {

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -201,6 +201,11 @@ class RunWampAppLabTests(unittest.TestCase):
                 },
             ]
             commands = {
+                "uname": (
+                    "#!/usr/bin/env bash\n"
+                    "[[ \"$1\" == -s ]] && printf '%s\\n' Darwin && exit 0\n"
+                    "exit 99\n"
+                ),
                 "flutter": (
                     "#!/usr/bin/env bash\n"
                     "if [[ \"$1\" == devices && \"$2\" == --machine ]]; then\n"

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -1,9 +1,11 @@
 import json
 import os
 import pathlib
+import socket
 import stat
 import subprocess
 import tempfile
+import time
 import unittest
 
 
@@ -77,6 +79,35 @@ class RunWampAppLabTests(unittest.TestCase):
         self.assertIn("--no-resident", result.stdout)
         self.assertEqual(result.stdout.count("WAMP_APP_SERVER_ADDRESS="), 2)
 
+    def test_smoke_dry_run_plans_bidirectional_native_ui_test(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            state = pathlib.Path(temporary_directory) / "does-not-exist"
+            result = self.run_script(
+                "--dry-run",
+                "--smoke",
+                "--port",
+                "18082",
+                "--state-dir",
+                str(state),
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(state.exists())
+        self.assertIn("Two-device UI smoke", result.stdout)
+        self.assertEqual(
+            result.stdout.count("integration_test/two_device_smoke_test.dart"),
+            2,
+        )
+        self.assertIn("WAMP_APP_SMOKE_USERNAME=android-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_PEER=ios-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_USERNAME=ios-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_PEER=android-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_OUTBOUND=from-android-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_INBOUND=from-ios-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_OUTBOUND=from-ios-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_INBOUND=from-android-run-id", result.stdout)
+        self.assertNotIn("--no-resident", result.stdout)
+
     def test_dry_run_rejects_physical_devices(self):
         result = self.run_script(
             "--dry-run",
@@ -143,6 +174,107 @@ class RunWampAppLabTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("mutually exclusive", result.stderr)
+
+    def test_smoke_failure_forces_router_exit_and_removes_reverse(self):
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = reservation.getsockname()[1]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = pathlib.Path(temporary_directory)
+            state = temporary / "state"
+            adb_log = temporary / "adb.log"
+            devices = [
+                {
+                    "name": "Android Emulator",
+                    "id": "emulator-5554",
+                    "isSupported": True,
+                    "targetPlatform": "android-arm64",
+                    "emulator": True,
+                },
+                {
+                    "name": "iPhone Simulator",
+                    "id": "ios-simulator",
+                    "isSupported": True,
+                    "targetPlatform": "ios",
+                    "emulator": True,
+                },
+            ]
+            commands = {
+                "flutter": (
+                    "#!/usr/bin/env bash\n"
+                    "if [[ \"$1\" == devices && \"$2\" == --machine ]]; then\n"
+                    f"  printf '%s\\n' '{json.dumps(devices)}'\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$1\" == pub && \"$2\" == get ]]; then exit 0; fi\n"
+                    "if [[ \"$1\" == test ]]; then\n"
+                    "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "exit 99\n"
+                ),
+                "dart": (
+                    "#!/usr/bin/env bash\n"
+                    "if [[ \"$1\" == pub && \"$2\" == get ]]; then exit 0; fi\n"
+                    "if [[ \"$1\" == run && \"$2\" == wamp_app_server ]]; then\n"
+                    "  config=\"$4\"\n"
+                    "  port=$(awk '/^  port:/ {print $2; exit}' \"$config\")\n"
+                    "  exec python3 - \"$port\" <<'PY'\n"
+                    "import signal\n"
+                    "import socket\n"
+                    "import sys\n"
+                    "import time\n"
+                    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+                    "with socket.socket() as listener:\n"
+                    "    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+                    "    listener.bind(('127.0.0.1', int(sys.argv[1])))\n"
+                    "    listener.listen()\n"
+                    "    while True:\n"
+                    "        time.sleep(1)\n"
+                    "PY\n"
+                    "fi\n"
+                    "exit 99\n"
+                ),
+                "adb": (
+                    "#!/usr/bin/env bash\n"
+                    "printf '%s\\n' \"$*\" >>\"$WAMP_APP_TEST_ADB_LOG\"\n"
+                ),
+            }
+            for name, source in commands.items():
+                command = temporary / name
+                command.write_text(source, encoding="utf-8")
+                command.chmod(command.stat().st_mode | stat.S_IXUSR)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{temporary}:{environment['PATH']}"
+            environment["WAMP_APP_TEST_ADB_LOG"] = str(adb_log)
+            started = time.monotonic()
+            result = subprocess.run(
+                [
+                    str(SCRIPT),
+                    "--smoke",
+                    "--port",
+                    str(port),
+                    "--state-dir",
+                    str(state),
+                ],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=20,
+            )
+
+            self.assertLess(time.monotonic() - started, 15)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("two-device UI smoke failed", result.stderr)
+            adb_calls = adb_log.read_text(encoding="utf-8")
+            self.assertIn("reverse tcp:", adb_calls)
+            self.assertIn("reverse --remove tcp:", adb_calls)
+            with socket.socket() as released:
+                released.bind(("127.0.0.1", port))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a deterministic Android+iOS UI smoke for registration and reciprocal encrypted messaging
- fail closed on plaintext router storage and bound failed-run cleanup
- fix compact keyboard overflow that made mobile send controls unhittable

## Verification
- bin/run-wamp-app-lab --smoke (Android API 35 + iOS 26.4)
- flutter analyze
- flutter test test/widget_test.dart
- python3 -m unittest tool.test_run_wamp_app_lab
- bin/verify