### PR TITLE
feat(wamp-app): harden native rich-chat and recovery flows

### DIFF
--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Verify peer trust, encrypted chat/media, account controls, backup, and WebRTC calls.
+  --smoke                  Verify peer trust, encrypted chat/media, account controls, backup, MCP, and WebRTC calls.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -544,6 +544,65 @@ if not archive.is_file() or archive.stat().st_size <= 0:
 PY
 }
 
+run_mcp_profile_acceptance() {
+  local mcp_endpoint="$1"
+  local password="$2"
+  local first_username="$3"
+  local first_display_name="$4"
+  local first_status="$5"
+  local second_username="$6"
+  local second_display_name="$7"
+  local second_status="$8"
+
+  if ! (
+    cd "$(repo_root)/examples/wamp_app/server"
+    printf '%s' "$password" |
+      python3 -c '
+import json
+import sys
+
+password = sys.stdin.read()
+(
+    endpoint,
+    first_username,
+    first_display_name,
+    first_status,
+    second_username,
+    second_display_name,
+    second_status,
+) = sys.argv[1:]
+value = {
+    "endpoint": endpoint,
+    "accounts": [
+        {
+            "username": first_username,
+            "password": password,
+            "display_name": first_display_name,
+            "status": first_status,
+        },
+        {
+            "username": second_username,
+            "password": password,
+            "display_name": second_display_name,
+            "status": second_status,
+        },
+    ],
+}
+json.dump(value, sys.stdout, separators=(",", ":"))
+password = ""
+' "$mcp_endpoint" \
+        "$first_username" \
+        "$first_display_name" \
+        "$first_status" \
+        "$second_username" \
+        "$second_display_name" \
+        "$second_status" |
+      dart run tool/mcp_profile_acceptance.dart
+  ); then
+    return 1
+  fi
+}
+
 android_device=""
 android_emulator=""
 dry_run=false
@@ -677,6 +736,7 @@ android_smoke_backup_restored="backup-restored-android-$smoke_run_id"
 ios_smoke_backup_restored="backup-restored-ios-$smoke_run_id"
 smoke_rich_media="rich-media-from-android-$smoke_run_id"
 smoke_rich_media_ack="rich-media-opened-ios-$smoke_run_id"
+smoke_password="wamp-app-native-smoke-password"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -777,6 +837,10 @@ if [[ "$dry_run" == true ]]; then
     printf 'iOS client command:\n'
     shell_join flutter run -d "$resolved_ios" --no-resident \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
+  fi
+  if [[ "$smoke" == true ]]; then
+    printf 'External MCP acceptance command (bounded credentials on stdin after both clients pass):\n'
+    shell_join dart run tool/mcp_profile_acceptance.dart
   fi
   if [[ "$smoke" == false && -n "$resolved_android" && -n "$resolved_ios" ]]; then
     printf 'Interactive display commands (after both clients launch):\n'
@@ -1005,6 +1069,20 @@ if [[ "$smoke" == true ]]; then
     fail "two-device UI smoke failed (Android $android_smoke_status, iOS $ios_smoke_status)."
   fi
 
+  printf 'Running independent authenticated MCP client against UI-granted consent...\n'
+  if ! run_mcp_profile_acceptance \
+    "http://localhost:$port/mcp" \
+    "$smoke_password" \
+    "$android_smoke_username" \
+    "$android_smoke_profile_display_name" \
+    "$android_smoke_profile_status" \
+    "$ios_smoke_username" \
+    "$ios_smoke_profile_display_name" \
+    "$ios_smoke_profile_status"
+  then
+    fail 'the independent MCP client could not use the UI-granted profile access.'
+  fi
+
   message_store="$state_dir/data/messages.json"
   [[ -f "$message_store" ]] || fail 'the smoke router did not persist its message store.'
   call_store="$state_dir/data/calls.json"
@@ -1030,7 +1108,8 @@ if [[ "$smoke" == true ]]; then
     "$android_smoke_backup_restored" \
     "$ios_smoke_backup_restored" \
     "$smoke_rich_media" \
-    "$smoke_rich_media_ack"
+    "$smoke_rich_media_ack" \
+    "$smoke_password"
   then
     fail 'the smoke router persisted plaintext chat, media, or call signaling.'
   fi
@@ -1045,7 +1124,7 @@ if [[ "$smoke" == true ]]; then
 
   cat <<EOF
 
-WampApp two-device peer verification, encrypted chat, rich media, account controls, destructive backup recovery, and WebRTC UI smoke passed.
+WampApp two-device peer verification, encrypted chat, rich media, account controls, destructive backup recovery, external MCP, and WebRTC UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Verify encrypted direct, group, sticker, and view-once chat.
+  --smoke                  Verify encrypted chat plus a native WebRTC voice call.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -108,6 +108,43 @@ wait_for_emulator() {
   return 1
 }
 
+grant_android_call_permissions() {
+  local device_id="$1"
+  local package_id="$2"
+  local deadline=$((SECONDS + 120))
+
+  while ((SECONDS < deadline)); do
+    if adb -s "$device_id" shell pm path "$package_id" >/dev/null 2>&1; then
+      adb -s "$device_id" shell pm grant \
+        "$package_id" android.permission.RECORD_AUDIO
+      adb -s "$device_id" shell pm grant \
+        "$package_id" android.permission.CAMERA
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+grant_ios_call_permissions() {
+  local device_id="$1"
+  local bundle_id="$2"
+  local deadline=$((SECONDS + 120))
+
+  while ((SECONDS < deadline)); do
+    if xcrun simctl get_app_container \
+      "$device_id" "$bundle_id" app >/dev/null 2>&1; then
+      xcrun simctl privacy "$device_id" grant microphone "$bundle_id"
+      xcrun simctl privacy "$device_id" grant camera "$bundle_id"
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
 port_is_available() {
   python3 - "$1" <<'PY'
 import socket
@@ -145,6 +182,35 @@ PY
   done
 
   return 1
+}
+
+wait_for_flutter_test_body() {
+  local log_file="$1"
+  local test_pid="$2"
+  local deadline=$((SECONDS + 180))
+
+  while ((SECONDS < deadline)); do
+    if grep -Fq 'exchanges encrypted chat and completes a WebRTC voice call' \
+      "$log_file" 2>/dev/null; then
+      return 0
+    fi
+    if ! kill -0 "$test_pid" 2>/dev/null; then
+      return 1
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+prepare_smoke_workspace() {
+  local destination="$1"
+
+  mkdir -p "$destination"
+  rsync -a --delete \
+    --exclude '.dart_tool/' \
+    --exclude 'build/' \
+    "$(repo_root)/examples/wamp_app/" "$destination/"
 }
 
 stop_process() {
@@ -199,6 +265,11 @@ import sys
 root = Path(sys.argv[1])
 tokens = [value.encode("utf-8") for value in sys.argv[2:] if value]
 png_signature = b"\x89PNG\r\n\x1a\n"
+call_signaling_markers = (
+    b"\r\nm=audio ",
+    b"\na=ice-ufrag:",
+    b"candidate:",
+)
 for path in root.rglob("*"):
     if not path.is_file():
         continue
@@ -210,6 +281,10 @@ for path in root.rglob("*"):
     if png_signature in payload:
         print(f"raw PNG bytes found in {path}", file=sys.stderr)
         raise SystemExit(1)
+    for marker in call_signaling_markers:
+        if marker in payload:
+            print(f"plaintext WebRTC signaling found in {path}", file=sys.stderr)
+            raise SystemExit(1)
 PY
 }
 
@@ -314,6 +389,8 @@ android_emulator_log="$state_dir/android-emulator.log"
 ios_emulator_log="$state_dir/ios-emulator.log"
 android_smoke_log="$state_dir/android-smoke.log"
 ios_smoke_log="$state_dir/ios-smoke.log"
+android_smoke_workspace="$state_dir/android-workspace"
+ios_smoke_workspace="$state_dir/ios-workspace"
 
 android_smoke_username="android-$smoke_run_id"
 ios_smoke_username="ios-$smoke_run_id"
@@ -323,6 +400,8 @@ smoke_group_title="native-group-$smoke_run_id"
 android_smoke_group_message="group-from-android-$smoke_run_id"
 ios_smoke_group_message="group-from-ios-$smoke_run_id"
 smoke_view_once_message="view-once-from-android-$smoke_run_id"
+android_smoke_call_ready="voice-ready-android-$smoke_run_id"
+ios_smoke_call_ready="voice-ready-ios-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -346,7 +425,12 @@ if [[ "$dry_run" == true ]]; then
   shell_join dart run wamp_app_server --config "$config_path"
   if [[ "$smoke" == true && -n "$resolved_android" ]]; then
     printf 'Android smoke command:\n'
-    shell_join flutter test -d "$resolved_android" --no-pub --timeout 8m \
+    printf 'Android call permission commands (after app install):\n'
+    shell_join adb -s "$resolved_android" shell pm grant \
+      dev.connectanum.wamp_app android.permission.RECORD_AUDIO
+    shell_join adb -s "$resolved_android" shell pm grant \
+      dev.connectanum.wamp_app android.permission.CAMERA
+    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 11m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -357,6 +441,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$android_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$ios_smoke_call_ready" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
@@ -365,7 +451,12 @@ if [[ "$dry_run" == true ]]; then
   fi
   if [[ "$smoke" == true && -n "$resolved_ios" ]]; then
     printf 'iOS smoke command:\n'
-    shell_join flutter test -d "$resolved_ios" --no-pub --timeout 8m \
+    printf 'iOS call permission commands (after app install):\n'
+    shell_join xcrun simctl privacy "$resolved_ios" grant microphone \
+      dev.connectanum.wampApp
+    shell_join xcrun simctl privacy "$resolved_ios" grant camera \
+      dev.connectanum.wampApp
+    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 11m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -376,6 +467,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$ios_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$android_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$ios_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$android_smoke_call_ready" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
@@ -387,6 +480,10 @@ fi
 
 require_command dart
 require_command adb
+require_command xcrun
+if [[ "$smoke" == true ]]; then
+  require_command rsync
+fi
 [[ "$(uname -s)" == Darwin ]] || fail 'the Android + iOS lab requires macOS.'
 port_is_available "$port" || fail "127.0.0.1:$port is already in use."
 
@@ -444,10 +541,45 @@ printf 'Resolving standalone WampApp packages...\n'
   cd "$(repo_root)/examples/wamp_app/server"
   dart pub get
 )
-(
-  cd "$(repo_root)/examples/wamp_app/client"
-  flutter pub get
-)
+if [[ "$smoke" == true ]]; then
+  printf 'Preparing isolated Android and iOS Flutter test workspaces...\n'
+  prepare_smoke_workspace "$android_smoke_workspace"
+  prepare_smoke_workspace "$ios_smoke_workspace"
+  (
+    cd "$android_smoke_workspace/client"
+    flutter pub get
+  )
+  (
+    cd "$ios_smoke_workspace/client"
+    flutter pub get
+  )
+  printf 'Preinstalling the Android smoke app and granting call permissions...\n'
+  (
+    cd "$android_smoke_workspace/client"
+    flutter build apk --debug --no-pub
+  )
+  android_smoke_apk="$android_smoke_workspace/client/build/app/outputs/flutter-apk/app-debug.apk"
+  [[ -f "$android_smoke_apk" ]] || fail 'Android smoke APK was not built.'
+  adb -s "$resolved_android" install -r "$android_smoke_apk"
+  grant_android_call_permissions \
+    "$resolved_android" dev.connectanum.wamp_app || \
+    fail 'Android call permissions could not be granted.'
+  printf 'Preinstalling the iOS smoke app and granting call permissions...\n'
+  (
+    cd "$ios_smoke_workspace/client"
+    flutter build ios --simulator --debug --no-pub
+  )
+  ios_smoke_app="$ios_smoke_workspace/client/build/ios/iphonesimulator/Runner.app"
+  [[ -d "$ios_smoke_app" ]] || fail 'iOS smoke app bundle was not built.'
+  xcrun simctl install "$resolved_ios" "$ios_smoke_app"
+  grant_ios_call_permissions "$resolved_ios" dev.connectanum.wampApp || \
+    fail 'iOS call permissions could not be granted.'
+else
+  (
+    cd "$(repo_root)/examples/wamp_app/client"
+    flutter pub get
+  )
+fi
 
 printf 'Starting isolated router at %s...\n' "$endpoint"
 (
@@ -466,26 +598,10 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS direct/group/sticker/view-once smoke concurrently...\n'
+  printf 'Running Android and iOS encrypted chat/voice-call smoke concurrently...\n'
   (
-    cd "$(repo_root)/examples/wamp_app/client"
-    exec flutter test -d "$resolved_android" --no-pub --timeout 8m \
-      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
-      --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
-      --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
-      --dart-define="WAMP_APP_SMOKE_OUTBOUND=$android_smoke_message" \
-      --dart-define="WAMP_APP_SMOKE_INBOUND=$ios_smoke_message" \
-      --dart-define=WAMP_APP_SMOKE_ROLE=initiator \
-      --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
-      --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
-      --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
-      --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
-      integration_test/two_device_smoke_test.dart
-  ) >"$android_smoke_log" 2>&1 &
-  android_smoke_pid=$!
-  (
-    cd "$(repo_root)/examples/wamp_app/client"
-    exec flutter test -d "$resolved_ios" --no-pub --timeout 8m \
+    cd "$ios_smoke_workspace/client"
+    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 11m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -496,9 +612,36 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$ios_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$android_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$ios_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$android_smoke_call_ready" \
       integration_test/two_device_smoke_test.dart
   ) >"$ios_smoke_log" 2>&1 &
   ios_smoke_pid=$!
+
+  if ! wait_for_flutter_test_body "$ios_smoke_log" "$ios_smoke_pid"; then
+    printf 'iOS smoke did not reach the test body. Last log lines:\n' >&2
+    tail -n 80 "$ios_smoke_log" >&2 || true
+    fail 'iOS smoke failed during Flutter startup.'
+  fi
+
+  (
+    cd "$android_smoke_workspace/client"
+    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 11m \
+      --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
+      --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
+      --dart-define="WAMP_APP_SMOKE_OUTBOUND=$android_smoke_message" \
+      --dart-define="WAMP_APP_SMOKE_INBOUND=$ios_smoke_message" \
+      --dart-define=WAMP_APP_SMOKE_ROLE=initiator \
+      --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$android_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$ios_smoke_call_ready" \
+      integration_test/two_device_smoke_test.dart
+  ) >"$android_smoke_log" 2>&1 &
+  android_smoke_pid=$!
 
   set +e
   wait "$android_smoke_pid"
@@ -519,6 +662,8 @@ if [[ "$smoke" == true ]]; then
 
   message_store="$state_dir/data/messages.json"
   [[ -f "$message_store" ]] || fail 'the smoke router did not persist its message store.'
+  call_store="$state_dir/data/calls.json"
+  [[ -f "$call_store" ]] || fail 'the smoke router did not persist its call store.'
   if ! assert_router_data_encrypted \
     "$state_dir/data" \
     "$android_smoke_message" \
@@ -526,14 +671,16 @@ if [[ "$smoke" == true ]]; then
     "$smoke_group_title" \
     "$android_smoke_group_message" \
     "$ios_smoke_group_message" \
-    "$smoke_view_once_message"
+    "$smoke_view_once_message" \
+    "$android_smoke_call_ready" \
+    "$ios_smoke_call_ready"
   then
-    fail 'the smoke router persisted plaintext chat, sticker, or view-once content.'
+    fail 'the smoke router persisted plaintext chat, media, or call signaling.'
   fi
 
   cat <<EOF
 
-WampApp two-device direct/group/sticker/view-once UI smoke passed.
+WampApp two-device encrypted chat and WebRTC voice-call UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -275,6 +275,56 @@ launch_ios_app() {
     wait_for_ios_app "$device_id" "$bundle_id" 5
 }
 
+start_android_mirror() {
+  local device_id="$1"
+  local log_path="$2"
+
+  if ! command -v scrcpy >/dev/null 2>&1; then
+    printf 'scrcpy is unavailable; use the Android emulator window.\n'
+    return 0
+  fi
+
+  printf 'Mirroring Android emulator %s with scrcpy...\n' "$device_id"
+  scrcpy \
+    --serial "$device_id" \
+    --window-title 'WampApp Android' \
+    --stay-awake \
+    --no-audio \
+    --window-x 20 \
+    --window-y 40 \
+    --window-width 540 \
+    --window-height 900 >>"$log_path" 2>&1 &
+  android_mirror_pid=$!
+
+  sleep 1
+  if ! kill -0 "$android_mirror_pid" 2>/dev/null; then
+    wait "$android_mirror_pid" 2>/dev/null || true
+    android_mirror_pid=""
+    printf 'scrcpy could not mirror %s. See %s; the lab remains usable through the emulator window.\n' \
+      "$device_id" "$log_path" >&2
+  fi
+}
+
+show_ios_simulator() {
+  local device_id="$1"
+  local log_path="$2"
+
+  printf 'Showing iOS simulator %s...\n' "$device_id"
+  if ! open -a Simulator --args -CurrentDeviceUDID "$device_id" \
+    >>"$log_path" 2>&1
+  then
+    printf 'Simulator could not be shown for %s. See %s.\n' \
+      "$device_id" "$log_path" >&2
+    return 0
+  fi
+  if command -v osascript >/dev/null 2>&1 && \
+    ! osascript -e 'tell application "Simulator" to activate' \
+      >>"$log_path" 2>&1
+  then
+    printf 'Simulator is running but could not be brought forward automatically.\n' >&2
+  fi
+}
+
 supervise_interactive_lab() {
   local router_pid="$1"
   local android_device_id="$2"
@@ -646,10 +696,6 @@ if [[ "$dry_run" == true ]]; then
   else
     printf '  iOS simulator: boot the default simulator\n'
   fi
-  if [[ "$smoke" == false && -n "$resolved_ios" ]]; then
-    printf 'iOS Simulator window command:\n'
-    shell_join open -a Simulator --args -CurrentDeviceUDID "$resolved_ios"
-  fi
   printf 'Router command:\n'
   shell_join dart run wamp_app_server --config "$config_path"
   if [[ "$smoke" == true && -n "$resolved_android" ]]; then
@@ -732,6 +778,13 @@ if [[ "$dry_run" == true ]]; then
     shell_join flutter run -d "$resolved_ios" --no-resident \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
   fi
+  if [[ "$smoke" == false && -n "$resolved_android" && -n "$resolved_ios" ]]; then
+    printf 'Interactive display commands (after both clients launch):\n'
+    printf '  scrcpy mirrors %s when the command is installed.\n' \
+      "$resolved_android"
+    shell_join open -a Simulator --args -CurrentDeviceUDID "$resolved_ios"
+    shell_join osascript -e 'tell application "Simulator" to activate'
+  fi
   exit 0
 fi
 
@@ -773,6 +826,7 @@ fi
 android_reverse_installed=false
 android_smoke_pid=""
 ios_smoke_pid=""
+android_mirror_pid=""
 server_pid=""
 cleanup() {
   local status=$?
@@ -782,6 +836,9 @@ cleanup() {
   fi
   if [[ -n "$ios_smoke_pid" ]]; then
     stop_process "$ios_smoke_pid"
+  fi
+  if [[ -n "$android_mirror_pid" ]]; then
+    stop_process "$android_mirror_pid"
   fi
   if [[ "$android_reverse_installed" == true ]]; then
     adb -s "$resolved_android" reverse --remove "tcp:$port" >/dev/null 2>&1 || true
@@ -999,9 +1056,6 @@ EOF
   exit 0
 fi
 
-printf 'Showing iOS simulator %s...\n' "$resolved_ios"
-open -a Simulator --args -CurrentDeviceUDID "$resolved_ios"
-
 printf 'Installing Android client on %s...\n' "$resolved_android"
 (
   cd "$(repo_root)/examples/wamp_app/client"
@@ -1016,6 +1070,9 @@ printf 'Installing iOS client on %s...\n' "$resolved_ios"
     --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint"
 )
 
+start_android_mirror "$resolved_android" "$android_client_log"
+show_ios_simulator "$resolved_ios" "$ios_client_log"
+
 cat <<EOF
 
 WampApp lab is ready.
@@ -1024,6 +1081,7 @@ WampApp lab is ready.
   iOS:     $resolved_ios
   State:   $state_dir
   Log:     $server_log
+  Android mirror log: $android_client_log
 
 Register one account in each app, then use the usernames to start a direct or
 group chat. The lab relaunches either client if it exits. Press Ctrl+C here to

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Verify encrypted direct, group, and sticker chat.
+  --smoke                  Verify encrypted direct, group, sticker, and view-once chat.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -322,6 +322,7 @@ ios_smoke_message="from-ios-$smoke_run_id"
 smoke_group_title="native-group-$smoke_run_id"
 android_smoke_group_message="group-from-android-$smoke_run_id"
 ios_smoke_group_message="group-from-ios-$smoke_run_id"
+smoke_view_once_message="view-once-from-android-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -345,7 +346,7 @@ if [[ "$dry_run" == true ]]; then
   shell_join dart run wamp_app_server --config "$config_path"
   if [[ "$smoke" == true && -n "$resolved_android" ]]; then
     printf 'Android smoke command:\n'
-    shell_join flutter test -d "$resolved_android" --no-pub --timeout 6m \
+    shell_join flutter test -d "$resolved_android" --no-pub --timeout 8m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -355,6 +356,7 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
@@ -363,7 +365,7 @@ if [[ "$dry_run" == true ]]; then
   fi
   if [[ "$smoke" == true && -n "$resolved_ios" ]]; then
     printf 'iOS smoke command:\n'
-    shell_join flutter test -d "$resolved_ios" --no-pub --timeout 6m \
+    shell_join flutter test -d "$resolved_ios" --no-pub --timeout 8m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -373,6 +375,7 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$ios_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$android_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
@@ -463,10 +466,10 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS direct/group/sticker smoke concurrently...\n'
+  printf 'Running Android and iOS direct/group/sticker/view-once smoke concurrently...\n'
   (
     cd "$(repo_root)/examples/wamp_app/client"
-    exec flutter test -d "$resolved_android" --no-pub --timeout 6m \
+    exec flutter test -d "$resolved_android" --no-pub --timeout 8m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -476,12 +479,13 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       integration_test/two_device_smoke_test.dart
   ) >"$android_smoke_log" 2>&1 &
   android_smoke_pid=$!
   (
     cd "$(repo_root)/examples/wamp_app/client"
-    exec flutter test -d "$resolved_ios" --no-pub --timeout 6m \
+    exec flutter test -d "$resolved_ios" --no-pub --timeout 8m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -491,6 +495,7 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
       --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$ios_smoke_group_message" \
       --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$android_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       integration_test/two_device_smoke_test.dart
   ) >"$ios_smoke_log" 2>&1 &
   ios_smoke_pid=$!
@@ -520,14 +525,15 @@ if [[ "$smoke" == true ]]; then
     "$ios_smoke_message" \
     "$smoke_group_title" \
     "$android_smoke_group_message" \
-    "$ios_smoke_group_message"
+    "$ios_smoke_group_message" \
+    "$smoke_view_once_message"
   then
-    fail 'the smoke router persisted plaintext chat or sticker content.'
+    fail 'the smoke router persisted plaintext chat, sticker, or view-once content.'
   fi
 
   cat <<EOF
 
-WampApp two-device direct/group/sticker UI smoke passed.
+WampApp two-device direct/group/sticker/view-once UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Verify encrypted chat, account controls, backup, and native WebRTC calls.
+  --smoke                  Verify encrypted chat/rich media, account controls, backup, and native WebRTC calls.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -190,7 +190,7 @@ wait_for_flutter_test_body() {
   local deadline=$((SECONDS + 180))
 
   while ((SECONDS < deadline)); do
-    if grep -Fq 'exchanges encrypted chat, account controls, backup, and WebRTC calls' \
+    if grep -Fq 'exchanges encrypted chat, rich media, controls, backup, and WebRTC calls' \
       "$log_file" 2>/dev/null; then
       return 0
     fi
@@ -264,7 +264,11 @@ import sys
 
 root = Path(sys.argv[1])
 tokens = [value.encode("utf-8") for value in sys.argv[2:] if value]
-png_signature = b"\x89PNG\r\n\x1a\n"
+media_signatures = (
+    ("PNG", b"\x89PNG\r\n\x1a\n"),
+    ("GIF87a", b"GIF87a"),
+    ("GIF89a", b"GIF89a"),
+)
 call_signaling_markers = (
     b"\r\nm=audio ",
     b"\na=ice-ufrag:",
@@ -278,9 +282,16 @@ for path in root.rglob("*"):
         if token in payload:
             print(f"plaintext smoke token found in {path}", file=sys.stderr)
             raise SystemExit(1)
-    if png_signature in payload:
-        print(f"raw PNG bytes found in {path}", file=sys.stderr)
-        raise SystemExit(1)
+    for label, signature in media_signatures:
+        if signature in payload:
+            print(f"raw {label} bytes found in {path}", file=sys.stderr)
+            raise SystemExit(1)
+    riff = payload.find(b"RIFF")
+    while riff >= 0:
+        if payload[riff + 8:riff + 12] == b"WAVE":
+            print(f"raw WAVE bytes found in {path}", file=sys.stderr)
+            raise SystemExit(1)
+        riff = payload.find(b"RIFF", riff + 1)
     for marker in call_signaling_markers:
         if marker in payload:
             print(f"plaintext WebRTC signaling found in {path}", file=sys.stderr)
@@ -426,6 +437,7 @@ fi
 endpoint="ws://localhost:$port/ws"
 config_path="$state_dir/wamp_app_server.yaml"
 server_log="$state_dir/server.log"
+runtime_tmp_dir="$state_dir/runtime-tmp"
 android_emulator_log="$state_dir/android-emulator.log"
 ios_emulator_log="$state_dir/ios-emulator.log"
 android_smoke_log="$state_dir/android-smoke.log"
@@ -455,6 +467,8 @@ android_smoke_controls_ready="controls-ready-android-$smoke_run_id"
 ios_smoke_controls_ready="controls-ready-ios-$smoke_run_id"
 android_smoke_backup_passphrase="backup-passphrase-android-$smoke_run_id"
 ios_smoke_backup_passphrase="backup-passphrase-ios-$smoke_run_id"
+smoke_rich_media="rich-media-from-android-$smoke_run_id"
+smoke_rich_media_ack="rich-media-opened-ios-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -506,6 +520,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$android_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
@@ -542,6 +558,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$ios_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
@@ -560,7 +578,7 @@ fi
 [[ "$(uname -s)" == Darwin ]] || fail 'the Android + iOS lab requires macOS.'
 port_is_available "$port" || fail "127.0.0.1:$port is already in use."
 
-mkdir -p "$state_dir"
+mkdir -p "$state_dir" "$runtime_tmp_dir"
 write_lab_config \
   "$config_path" \
   "$port" \
@@ -657,6 +675,7 @@ fi
 printf 'Starting isolated router at %s...\n' "$endpoint"
 (
   cd "$(repo_root)/examples/wamp_app/server"
+  export TMPDIR="$runtime_tmp_dir"
   exec dart run wamp_app_server --config "$config_path"
 ) >"$server_log" 2>&1 &
 server_pid=$!
@@ -671,7 +690,7 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS encrypted chat/account-controls/backup/voice/video smoke concurrently...\n'
+  printf 'Running Android and iOS encrypted chat/rich-media/account-controls/backup/voice/video smoke concurrently...\n'
   (
     cd "$ios_smoke_workspace/client"
     exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 22m \
@@ -697,6 +716,8 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$ios_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
   ) >"$ios_smoke_log" 2>&1 &
   ios_smoke_pid=$!
@@ -732,6 +753,8 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$android_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
+      --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
   ) >"$android_smoke_log" 2>&1 &
   android_smoke_pid=$!
@@ -774,7 +797,9 @@ if [[ "$smoke" == true ]]; then
     "$android_smoke_controls_ready" \
     "$ios_smoke_controls_ready" \
     "$android_smoke_backup_passphrase" \
-    "$ios_smoke_backup_passphrase"
+    "$ios_smoke_backup_passphrase" \
+    "$smoke_rich_media" \
+    "$smoke_rich_media_ack"
   then
     fail 'the smoke router persisted plaintext chat, media, or call signaling.'
   fi
@@ -789,7 +814,7 @@ if [[ "$smoke" == true ]]; then
 
   cat <<EOF
 
-WampApp two-device encrypted chat, account controls, backup, and WebRTC UI smoke passed.
+WampApp two-device encrypted chat, rich media, account controls, backup, and WebRTC UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Verify encrypted chat/rich media, account controls, backup, and native WebRTC calls.
+  --smoke                  Verify peer trust, encrypted chat/media, account controls, backup, and WebRTC calls.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -190,7 +190,7 @@ wait_for_flutter_test_body() {
   local deadline=$((SECONDS + 180))
 
   while ((SECONDS < deadline)); do
-    if grep -Fq 'exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls' \
+    if grep -Fq 'verifies peer identities and exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls' \
       "$log_file" 2>/dev/null; then
       return 0
     fi
@@ -646,6 +646,10 @@ if [[ "$dry_run" == true ]]; then
   else
     printf '  iOS simulator: boot the default simulator\n'
   fi
+  if [[ "$smoke" == false && -n "$resolved_ios" ]]; then
+    printf 'iOS Simulator window command:\n'
+    shell_join open -a Simulator --args -CurrentDeviceUDID "$resolved_ios"
+  fi
   printf 'Router command:\n'
   shell_join dart run wamp_app_server --config "$config_path"
   if [[ "$smoke" == true && -n "$resolved_android" ]]; then
@@ -736,6 +740,8 @@ require_command adb
 require_command xcrun
 if [[ "$smoke" == true ]]; then
   require_command rsync
+else
+  require_command open
 fi
 [[ "$(uname -s)" == Darwin ]] || fail 'the Android + iOS lab requires macOS.'
 port_is_available "$port" || fail "127.0.0.1:$port is already in use."
@@ -852,7 +858,7 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS encrypted chat/rich-media/account-controls/backup-recovery/voice/video smoke concurrently...\n'
+  printf 'Running Android and iOS peer-verification/encrypted-chat/rich-media/account-controls/backup-recovery/voice/video smoke concurrently...\n'
   (
     cd "$ios_smoke_workspace/client"
     exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 25m \
@@ -982,7 +988,7 @@ if [[ "$smoke" == true ]]; then
 
   cat <<EOF
 
-WampApp two-device encrypted chat, rich media, account controls, destructive backup recovery, and WebRTC UI smoke passed.
+WampApp two-device peer verification, encrypted chat, rich media, account controls, destructive backup recovery, and WebRTC UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)
@@ -992,6 +998,9 @@ WampApp two-device encrypted chat, rich media, account controls, destructive bac
 EOF
   exit 0
 fi
+
+printf 'Showing iOS simulator %s...\n' "$resolved_ios"
+open -a Simulator --args -CurrentDeviceUDID "$resolved_ios"
 
 printf 'Installing Android client on %s...\n' "$resolved_android"
 (

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -190,7 +190,7 @@ wait_for_flutter_test_body() {
   local deadline=$((SECONDS + 180))
 
   while ((SECONDS < deadline)); do
-    if grep -Fq 'exchanges encrypted chat, rich media, controls, backup, and WebRTC calls' \
+    if grep -Fq 'exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls' \
       "$log_file" 2>/dev/null; then
       return 0
     fi
@@ -467,6 +467,8 @@ android_smoke_controls_ready="controls-ready-android-$smoke_run_id"
 ios_smoke_controls_ready="controls-ready-ios-$smoke_run_id"
 android_smoke_backup_passphrase="backup-passphrase-android-$smoke_run_id"
 ios_smoke_backup_passphrase="backup-passphrase-ios-$smoke_run_id"
+android_smoke_backup_restored="backup-restored-android-$smoke_run_id"
+ios_smoke_backup_restored="backup-restored-ios-$smoke_run_id"
 smoke_rich_media="rich-media-from-android-$smoke_run_id"
 smoke_rich_media_ack="rich-media-opened-ios-$smoke_run_id"
 
@@ -497,7 +499,7 @@ if [[ "$dry_run" == true ]]; then
       dev.connectanum.wamp_app android.permission.RECORD_AUDIO
     shell_join adb -s "$resolved_android" shell pm grant \
       dev.connectanum.wamp_app android.permission.CAMERA
-    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 22m \
+    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 25m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -520,6 +522,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$android_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND=$android_smoke_backup_restored" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND=$ios_smoke_backup_restored" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
@@ -535,7 +539,7 @@ if [[ "$dry_run" == true ]]; then
       dev.connectanum.wampApp
     shell_join xcrun simctl privacy "$resolved_ios" grant camera \
       dev.connectanum.wampApp
-    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 22m \
+    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 25m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -558,6 +562,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$ios_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND=$ios_smoke_backup_restored" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND=$android_smoke_backup_restored" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
@@ -690,10 +696,10 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS encrypted chat/rich-media/account-controls/backup/voice/video smoke concurrently...\n'
+  printf 'Running Android and iOS encrypted chat/rich-media/account-controls/backup-recovery/voice/video smoke concurrently...\n'
   (
     cd "$ios_smoke_workspace/client"
-    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 22m \
+    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 25m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -716,6 +722,8 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$ios_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND=$ios_smoke_backup_restored" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND=$android_smoke_backup_restored" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
@@ -730,7 +738,7 @@ if [[ "$smoke" == true ]]; then
 
   (
     cd "$android_smoke_workspace/client"
-    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 22m \
+    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 25m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -753,6 +761,8 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$android_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$ios_smoke_controls_ready" \
       --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$android_smoke_backup_passphrase" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND=$android_smoke_backup_restored" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND=$ios_smoke_backup_restored" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA=$smoke_rich_media" \
       --dart-define="WAMP_APP_SMOKE_RICH_MEDIA_ACK=$smoke_rich_media_ack" \
       integration_test/two_device_smoke_test.dart
@@ -798,6 +808,8 @@ if [[ "$smoke" == true ]]; then
     "$ios_smoke_controls_ready" \
     "$android_smoke_backup_passphrase" \
     "$ios_smoke_backup_passphrase" \
+    "$android_smoke_backup_restored" \
+    "$ios_smoke_backup_restored" \
     "$smoke_rich_media" \
     "$smoke_rich_media_ack"
   then
@@ -814,7 +826,7 @@ if [[ "$smoke" == true ]]; then
 
   cat <<EOF
 
-WampApp two-device encrypted chat, rich media, account controls, backup, and WebRTC UI smoke passed.
+WampApp two-device encrypted chat, rich media, account controls, destructive backup recovery, and WebRTC UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Register both clients and verify encrypted chat.
+  --smoke                  Verify encrypted direct, group, and sticker chat.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -188,6 +188,31 @@ Path(sys.argv[2]).write_text(updated, encoding="utf-8")
 PY
 }
 
+assert_router_data_encrypted() {
+  local data_dir="$1"
+  shift
+
+  python3 - "$data_dir" "$@" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+tokens = [value.encode("utf-8") for value in sys.argv[2:] if value]
+png_signature = b"\x89PNG\r\n\x1a\n"
+for path in root.rglob("*"):
+    if not path.is_file():
+        continue
+    payload = path.read_bytes()
+    for token in tokens:
+        if token in payload:
+            print(f"plaintext smoke token found in {path}", file=sys.stderr)
+            raise SystemExit(1)
+    if png_signature in payload:
+        print(f"raw PNG bytes found in {path}", file=sys.stderr)
+        raise SystemExit(1)
+PY
+}
+
 android_device=""
 android_emulator=""
 dry_run=false
@@ -294,6 +319,9 @@ android_smoke_username="android-$smoke_run_id"
 ios_smoke_username="ios-$smoke_run_id"
 android_smoke_message="from-android-$smoke_run_id"
 ios_smoke_message="from-ios-$smoke_run_id"
+smoke_group_title="native-group-$smoke_run_id"
+android_smoke_group_message="group-from-android-$smoke_run_id"
+ios_smoke_group_message="group-from-ios-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -323,6 +351,10 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_OUTBOUND=$android_smoke_message" \
       --dart-define="WAMP_APP_SMOKE_INBOUND=$ios_smoke_message" \
+      --dart-define=WAMP_APP_SMOKE_ROLE=initiator \
+      --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
@@ -337,6 +369,10 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_OUTBOUND=$ios_smoke_message" \
       --dart-define="WAMP_APP_SMOKE_INBOUND=$android_smoke_message" \
+      --dart-define=WAMP_APP_SMOKE_ROLE=responder \
+      --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$ios_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$android_smoke_group_message" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
@@ -427,7 +463,7 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS registration/message smoke concurrently...\n'
+  printf 'Running Android and iOS direct/group/sticker smoke concurrently...\n'
   (
     cd "$(repo_root)/examples/wamp_app/client"
     exec flutter test -d "$resolved_android" --no-pub --timeout 6m \
@@ -436,6 +472,10 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_OUTBOUND=$android_smoke_message" \
       --dart-define="WAMP_APP_SMOKE_INBOUND=$ios_smoke_message" \
+      --dart-define=WAMP_APP_SMOKE_ROLE=initiator \
+      --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$android_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$ios_smoke_group_message" \
       integration_test/two_device_smoke_test.dart
   ) >"$android_smoke_log" 2>&1 &
   android_smoke_pid=$!
@@ -447,6 +487,10 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_OUTBOUND=$ios_smoke_message" \
       --dart-define="WAMP_APP_SMOKE_INBOUND=$android_smoke_message" \
+      --dart-define=WAMP_APP_SMOKE_ROLE=responder \
+      --dart-define="WAMP_APP_SMOKE_GROUP_TITLE=$smoke_group_title" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_OUTBOUND=$ios_smoke_group_message" \
+      --dart-define="WAMP_APP_SMOKE_GROUP_INBOUND=$android_smoke_group_message" \
       integration_test/two_device_smoke_test.dart
   ) >"$ios_smoke_log" 2>&1 &
   ios_smoke_pid=$!
@@ -470,14 +514,20 @@ if [[ "$smoke" == true ]]; then
 
   message_store="$state_dir/data/messages.json"
   [[ -f "$message_store" ]] || fail 'the smoke router did not persist its message store.'
-  if grep -Fq -- "$android_smoke_message" "$message_store" || \
-     grep -Fq -- "$ios_smoke_message" "$message_store"; then
-    fail 'the smoke router persisted plaintext message content.'
+  if ! assert_router_data_encrypted \
+    "$state_dir/data" \
+    "$android_smoke_message" \
+    "$ios_smoke_message" \
+    "$smoke_group_title" \
+    "$android_smoke_group_message" \
+    "$ios_smoke_group_message"
+  then
+    fail 'the smoke router persisted plaintext chat or sticker content.'
   fi
 
   cat <<EOF
 
-WampApp two-device UI smoke passed.
+WampApp two-device direct/group/sticker UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -17,7 +17,7 @@ Options:
   --ios-device <id>        Use an already-running iOS simulator.
   --port <port>            Router port (default: 18080).
   --state-dir <path>       Override the run state and evidence directory.
-  --smoke                  Verify encrypted chat plus a native WebRTC voice call.
+  --smoke                  Verify encrypted chat, account controls, backup, and native WebRTC calls.
   --dry-run                Print the resolved plan without changing the machine.
   -h, --help               Show this help.
 EOF
@@ -190,7 +190,7 @@ wait_for_flutter_test_body() {
   local deadline=$((SECONDS + 180))
 
   while ((SECONDS < deadline)); do
-    if grep -Fq 'exchanges encrypted chat and completes WebRTC voice and video calls' \
+    if grep -Fq 'exchanges encrypted chat, account controls, backup, and WebRTC calls' \
       "$log_file" 2>/dev/null; then
       return 0
     fi
@@ -285,6 +285,47 @@ for path in root.rglob("*"):
         if marker in payload:
             print(f"plaintext WebRTC signaling found in {path}", file=sys.stderr)
             raise SystemExit(1)
+PY
+}
+
+assert_account_controls_persisted() {
+  local data_dir="$1"
+  local backup_username="$2"
+  local first_username="$3"
+  local second_username="$4"
+
+  python3 - "$data_dir" "$backup_username" "$first_username" "$second_username" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+backup_username = sys.argv[2]
+usernames = sys.argv[3:]
+
+consent_document = json.loads((root / "mcp-consent.json").read_text(encoding="utf-8"))
+consents = consent_document.get("consents")
+if not isinstance(consents, dict):
+    raise SystemExit("MCP consent evidence is malformed")
+for username in usernames:
+    consent = consents.get(username)
+    if not isinstance(consent, dict) or consent.get("profile_read_allowed") is not True:
+        raise SystemExit(f"MCP profile consent is not enabled for {username}")
+    if not isinstance(consent.get("revision"), int) or consent["revision"] <= 0:
+        raise SystemExit(f"MCP profile consent revision is invalid for {username}")
+
+manifests = list((root / "backups").rglob("manifest.json"))
+if len(manifests) != 1:
+    raise SystemExit(f"expected one committed encrypted backup, found {len(manifests)}")
+manifest = json.loads(manifests[0].read_text(encoding="utf-8"))
+if manifest.get("username") != backup_username:
+    raise SystemExit("the encrypted backup belongs to an unexpected account")
+archive_name = manifest.get("archive_name")
+if not isinstance(archive_name, str):
+    raise SystemExit("the encrypted backup manifest has no archive name")
+archive = manifests[0].parent / archive_name
+if not archive.is_file() or archive.stat().st_size <= 0:
+    raise SystemExit("the encrypted backup archive is missing or empty")
 PY
 }
 
@@ -404,6 +445,16 @@ android_smoke_call_ready="voice-ready-android-$smoke_run_id"
 ios_smoke_call_ready="voice-ready-ios-$smoke_run_id"
 android_smoke_video_ready="video-ready-android-$smoke_run_id"
 ios_smoke_video_ready="video-ready-ios-$smoke_run_id"
+android_smoke_profile_display_name="Android profile $smoke_run_id"
+ios_smoke_profile_display_name="iOS profile $smoke_run_id"
+android_smoke_profile_status="profile-status-android-$smoke_run_id"
+ios_smoke_profile_status="profile-status-ios-$smoke_run_id"
+android_smoke_contact_display_name="Local iOS contact $smoke_run_id"
+ios_smoke_contact_display_name="Local Android contact $smoke_run_id"
+android_smoke_controls_ready="controls-ready-android-$smoke_run_id"
+ios_smoke_controls_ready="controls-ready-ios-$smoke_run_id"
+android_smoke_backup_passphrase="backup-passphrase-android-$smoke_run_id"
+ios_smoke_backup_passphrase="backup-passphrase-ios-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -432,7 +483,7 @@ if [[ "$dry_run" == true ]]; then
       dev.connectanum.wamp_app android.permission.RECORD_AUDIO
     shell_join adb -s "$resolved_android" shell pm grant \
       dev.connectanum.wamp_app android.permission.CAMERA
-    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 16m \
+    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 22m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -447,6 +498,14 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$ios_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$android_smoke_video_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$ios_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_DISPLAY_NAME=$android_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_STATUS=$android_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_DISPLAY_NAME=$ios_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_STATUS=$ios_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_CONTACT_DISPLAY_NAME=$android_smoke_contact_display_name" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$android_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$ios_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$android_smoke_backup_passphrase" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
@@ -460,7 +519,7 @@ if [[ "$dry_run" == true ]]; then
       dev.connectanum.wampApp
     shell_join xcrun simctl privacy "$resolved_ios" grant camera \
       dev.connectanum.wampApp
-    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 16m \
+    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 22m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -475,6 +534,14 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$android_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$ios_smoke_video_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$android_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_DISPLAY_NAME=$ios_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_STATUS=$ios_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_DISPLAY_NAME=$android_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_STATUS=$android_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_CONTACT_DISPLAY_NAME=$ios_smoke_contact_display_name" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$ios_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$android_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$ios_smoke_backup_passphrase" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
@@ -604,10 +671,10 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS encrypted chat/voice/video-call smoke concurrently...\n'
+  printf 'Running Android and iOS encrypted chat/account-controls/backup/voice/video smoke concurrently...\n'
   (
     cd "$ios_smoke_workspace/client"
-    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 16m \
+    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 22m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -622,6 +689,14 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$android_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$ios_smoke_video_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$android_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_DISPLAY_NAME=$ios_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_STATUS=$ios_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_DISPLAY_NAME=$android_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_STATUS=$android_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_CONTACT_DISPLAY_NAME=$ios_smoke_contact_display_name" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$ios_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$android_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$ios_smoke_backup_passphrase" \
       integration_test/two_device_smoke_test.dart
   ) >"$ios_smoke_log" 2>&1 &
   ios_smoke_pid=$!
@@ -634,7 +709,7 @@ if [[ "$smoke" == true ]]; then
 
   (
     cd "$android_smoke_workspace/client"
-    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 16m \
+    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 22m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -649,6 +724,14 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$ios_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$android_smoke_video_ready" \
       --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$ios_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_DISPLAY_NAME=$android_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PROFILE_STATUS=$android_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_DISPLAY_NAME=$ios_smoke_profile_display_name" \
+      --dart-define="WAMP_APP_SMOKE_PEER_PROFILE_STATUS=$ios_smoke_profile_status" \
+      --dart-define="WAMP_APP_SMOKE_CONTACT_DISPLAY_NAME=$android_smoke_contact_display_name" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=$android_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=$ios_smoke_controls_ready" \
+      --dart-define="WAMP_APP_SMOKE_BACKUP_PASSPHRASE=$android_smoke_backup_passphrase" \
       integration_test/two_device_smoke_test.dart
   ) >"$android_smoke_log" 2>&1 &
   android_smoke_pid=$!
@@ -685,14 +768,28 @@ if [[ "$smoke" == true ]]; then
     "$android_smoke_call_ready" \
     "$ios_smoke_call_ready" \
     "$android_smoke_video_ready" \
-    "$ios_smoke_video_ready"
+    "$ios_smoke_video_ready" \
+    "$android_smoke_contact_display_name" \
+    "$ios_smoke_contact_display_name" \
+    "$android_smoke_controls_ready" \
+    "$ios_smoke_controls_ready" \
+    "$android_smoke_backup_passphrase" \
+    "$ios_smoke_backup_passphrase"
   then
     fail 'the smoke router persisted plaintext chat, media, or call signaling.'
+  fi
+  if ! assert_account_controls_persisted \
+    "$state_dir/data" \
+    "$android_smoke_username" \
+    "$android_smoke_username" \
+    "$ios_smoke_username"
+  then
+    fail 'the smoke router did not persist encrypted backup and MCP consent evidence.'
   fi
 
   cat <<EOF
 
-WampApp two-device encrypted chat and WebRTC voice/video-call UI smoke passed.
+WampApp two-device encrypted chat, account controls, backup, and WebRTC UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -190,7 +190,7 @@ wait_for_flutter_test_body() {
   local deadline=$((SECONDS + 180))
 
   while ((SECONDS < deadline)); do
-    if grep -Fq 'exchanges encrypted chat and completes a WebRTC voice call' \
+    if grep -Fq 'exchanges encrypted chat and completes WebRTC voice and video calls' \
       "$log_file" 2>/dev/null; then
       return 0
     fi
@@ -402,6 +402,8 @@ ios_smoke_group_message="group-from-ios-$smoke_run_id"
 smoke_view_once_message="view-once-from-android-$smoke_run_id"
 android_smoke_call_ready="voice-ready-android-$smoke_run_id"
 ios_smoke_call_ready="voice-ready-ios-$smoke_run_id"
+android_smoke_video_ready="video-ready-android-$smoke_run_id"
+ios_smoke_video_ready="video-ready-ios-$smoke_run_id"
 
 if [[ "$dry_run" == true ]]; then
   if [[ "$smoke" == true ]]; then
@@ -430,7 +432,7 @@ if [[ "$dry_run" == true ]]; then
       dev.connectanum.wamp_app android.permission.RECORD_AUDIO
     shell_join adb -s "$resolved_android" shell pm grant \
       dev.connectanum.wamp_app android.permission.CAMERA
-    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 11m \
+    shell_join flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 16m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -443,6 +445,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$android_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$ios_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$android_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$ios_smoke_video_ready" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_android" ]]; then
     printf 'Android client command:\n'
@@ -456,7 +460,7 @@ if [[ "$dry_run" == true ]]; then
       dev.connectanum.wampApp
     shell_join xcrun simctl privacy "$resolved_ios" grant camera \
       dev.connectanum.wampApp
-    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 11m \
+    shell_join flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 16m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -469,6 +473,8 @@ if [[ "$dry_run" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$ios_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$android_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$ios_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$android_smoke_video_ready" \
       integration_test/two_device_smoke_test.dart
   elif [[ -n "$resolved_ios" ]]; then
     printf 'iOS client command:\n'
@@ -598,10 +604,10 @@ adb -s "$resolved_android" reverse "tcp:$port" "tcp:$port"
 android_reverse_installed=true
 
 if [[ "$smoke" == true ]]; then
-  printf 'Running Android and iOS encrypted chat/voice-call smoke concurrently...\n'
+  printf 'Running Android and iOS encrypted chat/voice/video-call smoke concurrently...\n'
   (
     cd "$ios_smoke_workspace/client"
-    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 11m \
+    exec flutter test -d "$resolved_ios" --no-pub --no-uninstall --timeout 16m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$ios_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$android_smoke_username" \
@@ -614,6 +620,8 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$ios_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$android_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$ios_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$android_smoke_video_ready" \
       integration_test/two_device_smoke_test.dart
   ) >"$ios_smoke_log" 2>&1 &
   ios_smoke_pid=$!
@@ -626,7 +634,7 @@ if [[ "$smoke" == true ]]; then
 
   (
     cd "$android_smoke_workspace/client"
-    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 11m \
+    exec flutter test -d "$resolved_android" --no-pub --no-uninstall --timeout 16m \
       --dart-define="WAMP_APP_SERVER_ADDRESS=$endpoint" \
       --dart-define="WAMP_APP_SMOKE_USERNAME=$android_smoke_username" \
       --dart-define="WAMP_APP_SMOKE_PEER=$ios_smoke_username" \
@@ -639,6 +647,8 @@ if [[ "$smoke" == true ]]; then
       --dart-define="WAMP_APP_SMOKE_VIEW_ONCE=$smoke_view_once_message" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_OUTBOUND=$android_smoke_call_ready" \
       --dart-define="WAMP_APP_SMOKE_CALL_READY_INBOUND=$ios_smoke_call_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=$android_smoke_video_ready" \
+      --dart-define="WAMP_APP_SMOKE_VIDEO_READY_INBOUND=$ios_smoke_video_ready" \
       integration_test/two_device_smoke_test.dart
   ) >"$android_smoke_log" 2>&1 &
   android_smoke_pid=$!
@@ -673,14 +683,16 @@ if [[ "$smoke" == true ]]; then
     "$ios_smoke_group_message" \
     "$smoke_view_once_message" \
     "$android_smoke_call_ready" \
-    "$ios_smoke_call_ready"
+    "$ios_smoke_call_ready" \
+    "$android_smoke_video_ready" \
+    "$ios_smoke_video_ready"
   then
     fail 'the smoke router persisted plaintext chat, media, or call signaling.'
   fi
 
   cat <<EOF
 
-WampApp two-device encrypted chat and WebRTC voice-call UI smoke passed.
+WampApp two-device encrypted chat and WebRTC voice/video-call UI smoke passed.
   Router:  $endpoint
   Android: $resolved_android ($android_smoke_username)
   iOS:     $resolved_ios ($ios_smoke_username)

--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -203,6 +203,160 @@ wait_for_flutter_test_body() {
   return 1
 }
 
+android_app_is_running() {
+  local device_id="$1"
+  local package_id="$2"
+  local process_ids
+
+  process_ids="$(adb -s "$device_id" shell pidof "$package_id" 2>/dev/null | tr -d '\r')" || \
+    return 1
+  [[ "$process_ids" =~ ^[0-9]+([[:space:]][0-9]+)*$ ]]
+}
+
+ios_app_is_running() {
+  local device_id="$1"
+  local bundle_id="$2"
+  local services
+
+  services="$(xcrun simctl spawn "$device_id" launchctl list 2>/dev/null)" || \
+    return 1
+  grep -Fq "UIKitApplication:${bundle_id}[" <<<"$services"
+}
+
+wait_for_android_app() {
+  local device_id="$1"
+  local package_id="$2"
+  local timeout_seconds="$3"
+  local deadline=$((SECONDS + timeout_seconds))
+
+  while ((SECONDS < deadline)); do
+    if android_app_is_running "$device_id" "$package_id"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+wait_for_ios_app() {
+  local device_id="$1"
+  local bundle_id="$2"
+  local timeout_seconds="$3"
+  local deadline=$((SECONDS + timeout_seconds))
+
+  while ((SECONDS < deadline)); do
+    if ios_app_is_running "$device_id" "$bundle_id"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+launch_android_app() {
+  local device_id="$1"
+  local package_id="$2"
+  local log_path="$3"
+
+  adb -s "$device_id" get-state >/dev/null 2>&1 &&
+    adb -s "$device_id" shell am start \
+      -n "$package_id/.MainActivity" >>"$log_path" 2>&1 &&
+    wait_for_android_app "$device_id" "$package_id" 5
+}
+
+launch_ios_app() {
+  local device_id="$1"
+  local bundle_id="$2"
+  local log_path="$3"
+
+  xcrun simctl launch "$device_id" "$bundle_id" >>"$log_path" 2>&1 &&
+    wait_for_ios_app "$device_id" "$bundle_id" 5
+}
+
+supervise_interactive_lab() {
+  local router_pid="$1"
+  local android_device_id="$2"
+  local ios_device_id="$3"
+  local android_log_path="$4"
+  local ios_log_path="$5"
+  local android_package_id=dev.connectanum.wamp_app
+  local ios_bundle_id=dev.connectanum.wampApp
+  local android_restart_attempts=0
+  local ios_restart_attempts=0
+  local android_last_restart=-10
+  local ios_last_restart=-10
+  local router_status
+
+  while kill -0 "$router_pid" 2>/dev/null; do
+    if android_app_is_running "$android_device_id" "$android_package_id"; then
+      if ((SECONDS - android_last_restart >= 10)); then
+        android_restart_attempts=0
+      fi
+    else
+      if ((SECONDS - android_last_restart >= 10)); then
+        android_restart_attempts=0
+      fi
+      ((android_restart_attempts += 1))
+      android_last_restart=$SECONDS
+      if ((android_restart_attempts > 3)); then
+        printf 'Android WampApp exited repeatedly on %s. See %s.\n' \
+          "$android_device_id" "$android_log_path" >&2
+        return 1
+      fi
+      printf 'Android WampApp exited; relaunching on %s (attempt %d/3)...\n' \
+        "$android_device_id" "$android_restart_attempts"
+      if ! launch_android_app \
+        "$android_device_id" "$android_package_id" "$android_log_path" && \
+        ((android_restart_attempts >= 3))
+      then
+        printf 'Android WampApp could not be kept running on %s. See %s.\n' \
+          "$android_device_id" "$android_log_path" >&2
+        return 1
+      fi
+    fi
+
+    if ios_app_is_running "$ios_device_id" "$ios_bundle_id"; then
+      if ((SECONDS - ios_last_restart >= 10)); then
+        ios_restart_attempts=0
+      fi
+    else
+      if ((SECONDS - ios_last_restart >= 10)); then
+        ios_restart_attempts=0
+      fi
+      ((ios_restart_attempts += 1))
+      ios_last_restart=$SECONDS
+      if ((ios_restart_attempts > 3)); then
+        printf 'iOS WampApp exited repeatedly on %s. See %s.\n' \
+          "$ios_device_id" "$ios_log_path" >&2
+        return 1
+      fi
+      printf 'iOS WampApp exited; relaunching on %s (attempt %d/3)...\n' \
+        "$ios_device_id" "$ios_restart_attempts"
+      if ! launch_ios_app \
+        "$ios_device_id" "$ios_bundle_id" "$ios_log_path" && \
+        ((ios_restart_attempts >= 3))
+      then
+        printf 'iOS WampApp could not be kept running on %s. See %s.\n' \
+          "$ios_device_id" "$ios_log_path" >&2
+        return 1
+      fi
+    fi
+
+    sleep 2
+  done
+
+  set +e
+  wait "$router_pid"
+  router_status=$?
+  set -e
+  server_pid=""
+  printf 'WampApp router exited unexpectedly with status %d.\n' \
+    "$router_status" >&2
+  return 1
+}
+
 prepare_smoke_workspace() {
   local destination="$1"
 
@@ -440,6 +594,8 @@ server_log="$state_dir/server.log"
 runtime_tmp_dir="$state_dir/runtime-tmp"
 android_emulator_log="$state_dir/android-emulator.log"
 ios_emulator_log="$state_dir/ios-emulator.log"
+android_client_log="$state_dir/android-client.log"
+ios_client_log="$state_dir/ios-client.log"
 android_smoke_log="$state_dir/android-smoke.log"
 ios_smoke_log="$state_dir/ios-smoke.log"
 android_smoke_workspace="$state_dir/android-workspace"
@@ -861,7 +1017,16 @@ WampApp lab is ready.
   Log:     $server_log
 
 Register one account in each app, then use the usernames to start a direct or
-group chat. Press Ctrl+C here to stop the router; installed apps remain open.
+group chat. The lab relaunches either client if it exits. Press Ctrl+C here to
+stop the router; installed apps remain open.
 EOF
 
-wait "$server_pid"
+if ! supervise_interactive_lab \
+  "$server_pid" \
+  "$resolved_android" \
+  "$resolved_ios" \
+  "$android_client_log" \
+  "$ios_client_log"
+then
+  fail 'interactive router or client supervision failed.'
+fi

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -867,3 +867,17 @@ integration without private project assumptions.
   tests, Flutter analysis, the complete Android API 36.1 plus iOS 26.4 paired
   smoke, and repository-wide `bin/verify` pass. Exact-head hosted evidence is
   next.
+- 2026-08-29: Paired native acceptance now proves destructive encrypted local
+  file recovery on the responder while the initiator completes destructive
+  cloud recovery. The responder exports through the real Flutter backup dialog
+  into an ownership-safe file boundary, requires a bounded non-empty
+  `.wampbackup`, and scans the archive for raw UTF-8 and base64 forms of every
+  protected chat, group, contact, synchronization, password, and recovery
+  token. It then signs out, deletes and verifies every tracked local vault
+  ciphertext, restores through the signed-out local-backup UI, and must recover
+  the same device identity, avatar bytes, encrypted preferences, contact alias,
+  direct history, and group history. The file gateway gives the controller a
+  defensive copy, proving import can wipe temporary bytes without deleting the
+  user-owned archive. The exact Android API 36.1 plus iOS 26.4 paired smoke,
+  focused Flutter analysis, local-model review, and repository-wide
+  `bin/verify` pass. Exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -852,3 +852,18 @@ integration without private project assumptions.
   syntax and all nine launcher tests, focused Flutter analysis and
   vault/controller tests, the exact Android API 35 plus iOS 26.4 smoke, and
   repository-wide `bin/verify` pass; exact-head hosted evidence is next.
+- 2026-08-29: Paired native acceptance now drives public-profile avatar
+  selection and opt-in contact import through the real Flutter dialogs using
+  injectable platform boundaries. The production avatar picker keeps the
+  `file_selector` implementation, preserves cancellation, bounds files before
+  persistence, owns selected bytes, and redacts selector/read failures. Both
+  native clients select and render a bounded PNG, persist it through the router,
+  observe the peer avatar, import a display name before binding the
+  authenticated peer username, and require the initiator's avatar to survive
+  destructive encrypted cloud recovery byte-for-byte. The first native run
+  proved the size guard by rejecting a 262,488-byte generated sticker against
+  the 262,144-byte profile limit; the harness now uses a compact valid PNG and
+  asserts that precondition immediately. Six picker tests, 22 focused widget
+  tests, Flutter analysis, the complete Android API 36.1 plus iOS 26.4 paired
+  smoke, and repository-wide `bin/verify` pass. Exact-head hosted evidence is
+  next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -766,3 +766,21 @@ integration without private project assumptions.
   Flutter analysis, the one-time widget and six-device conflict suites, the
   pre-change `bin/test-fast`, and the real Android API 35 plus iOS 26.4 smoke
   pass. Canonical `bin/verify` also passes; exact-head hosted evidence is next.
+- 2026-08-28: Native acceptance now continues from encrypted chat into a real
+  Android/iOS WebRTC voice call. Android starts the call, iOS accepts it, both
+  clients prove active native media bound to the expected peer, exchange
+  authenticated E2EE-readiness markers, exercise mute/unmute, and converge
+  through hangup, media disposal, result UI, and dismissal. Recursive router
+  inspection additionally rejects plaintext SDP and ICE candidate material.
+  The first live run exposed an outgoing-call race: the native connected event
+  could arrive synchronously while applying the answer, before the controller
+  entered its connecting phase, and the following durable update could then
+  overwrite an active phase. The controller now enters connecting before
+  applying an answer and preserves a newer active phase. A fail-first unit
+  regression covers that callback ordering. The launcher preinstalls both apps,
+  grants camera and microphone permissions before either test starts, staggers
+  startup past the iOS test-body marker, and uses isolated Android/iOS
+  workspaces to avoid Flutter startup-lock and artifact contention. Nine
+  launcher tests, 30 focused call/widget tests, Flutter analysis, two exact-tree
+  Android API 35 plus iOS 26.4 smokes, and repository-wide `bin/verify` pass;
+  exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -733,3 +733,23 @@ integration without private project assumptions.
   tests, Flutter analysis, nine launcher tests, the real Android+iOS smoke, and
   canonical repository `bin/verify` pass locally. Exact-head hosted evidence
   remains pending.
+- 2026-08-28: Native acceptance now covers encrypted group and rich-content
+  behavior as well as direct chat. After reciprocal direct messages, Android
+  creates a two-member group and sends group text plus the bundled PNG sticker;
+  iOS discovers the group, downloads and decrypts the sticker, renders its
+  preview, and replies in the same group; Android decrypts and renders that
+  reply. The launcher recursively rejects all direct/group smoke tokens, the
+  group title, and raw PNG bytes anywhere in persistent router data. Live
+  acceptance exposed and fixed three product defects: group dialog controllers
+  could be disposed while the route animation still used them, the compact
+  sticker composer overflowed on a phone viewport, and completion of one send
+  could erase a newer draft or staged attachment. Lifecycle, compact-layout,
+  draft-preservation, discovered-member reply, and launcher-contract
+  regressions pass. `bin/test-fast`, `bin/test-wamp-app`, Flutter analysis, and
+  the real Android API 35 plus iOS 26.4 smoke pass locally; canonical
+  `bin/verify` initially reached the WebSocket I/O suite before an intermittent
+  localhost upgrade failure. The focused file reproduced the race by run 4;
+  using ephemeral IPv4 loopback listeners throughout instead of one fixed port
+  plus hostname resolution, and explicitly closing all four first-case client
+  transports, then passed 50 fresh-process repetitions. The clean canonical
+  `bin/verify` rerun passes; exact-head hosted evidence remains next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -908,6 +908,20 @@ integration without private project assumptions.
   acceptance now requires it after destructive restore. Ten preference tests,
   49 controller tests, 22 vault tests, 22 widget tests, the full 198-test
   Flutter suite, `bin/test-wamp-app` with Chrome and a release web build,
-  local-model review, and repository-wide `bin/verify` pass. Exact device
-  recovery execution and hosted evidence are next; the interactive Android/iOS
-  tester lab remains running and undisturbed.
+  local-model review, and repository-wide `bin/verify` pass. Exact-head package
+  dry run `33240068792`, PR CI `33240068807`, push CI `33240067540`, and
+  WampApp artifact run `33240067539` pass, including all seven bundles and the
+  production benchmark gate. The comprehensive feature-head audit and
+  protected-`master` strict audit also pass.
+- 2026-08-29: Exact native appearance recovery now passes on a disposable
+  Android API 36.1 emulator and iOS 26.4 simulator while the interactive
+  Android/iOS tester lab and its router remain running and undisturbed. The
+  paired smoke proves the per-conversation preset survives both destructive
+  cloud and local-file restore together with identity, avatar, encrypted
+  preferences, contact alias, direct history, and group history. The required
+  pre-change `bin/test-fast` exposed legacy fixed WebSocket and RawSocket ports
+  in the client transport I/O-event tests. The suite now uses ephemeral IPv4
+  loopback listeners, connects through each listener's actual address and port,
+  and explicitly tears down clients, upgraded sockets, and servers. All 11
+  tests pass with every former port occupied and in three concurrent test
+  processes, and the post-change `bin/test-fast` passes end to end.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -996,3 +996,18 @@ integration without private project assumptions.
   and automated smoke records no desktop command. Fourteen launcher tests,
   shell/Python syntax checks, dry-run command ordering, local-model review, and
   repository-wide `bin/verify` pass.
+- 2026-08-29: Paired native acceptance now proves that a separate application
+  or agent can consume the profile access granted through both real client UIs.
+  After the Android/iOS interaction sequence passes, a bounded external process
+  discovers the Bearer challenge, authenticates each account with WAMP-SCRAM,
+  requires the exact tools/resources/prompts catalog, reads only the consented
+  public-profile fields through stateful Streamable HTTP and direct JSON, checks
+  both resources and the profile-review prompt, and proves access-token
+  rejection plus refresh-token cleanup. Synthetic credentials cross only
+  bounded stdin pipes, never arguments, child environments, or diagnostics;
+  malformed, oversized, and non-loopback cleartext input fails with redacted
+  stage-only output. A disposable Android API 36.1 plus iOS 26.4 run passes the
+  full peer-trust, encrypted-chat, rich-media, account-control, destructive-
+  recovery, WebRTC, and external-MCP sequence while the interactive lab remains
+  running. The two-account real-router MCP regressions, all 14 launcher tests,
+  `bin/test-wamp-app`, and repository-wide `bin/verify` pass.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -784,3 +784,18 @@ integration without private project assumptions.
   launcher tests, 30 focused call/widget tests, Flutter analysis, two exact-tree
   Android API 35 plus iOS 26.4 smokes, and repository-wide `bin/verify` pass;
   exact-head hosted evidence is next.
+- 2026-08-28: The paired native acceptance now completes both WebRTC voice and
+  video calls on disposable Android and iOS devices while the interactive lab
+  remains available. Each call proves the expected native media kind and peer,
+  exchanges fresh encrypted in-call readiness messages, and converges through
+  hangup, media-session disposal, result UI, and dismissal. Voice toggles mute;
+  video proves local rendering, toggles the camera off and on, and requires the
+  renderer to disappear at teardown. The expanded run exposed stale native
+  keyboard insets that could place the expression sheet below Android's root,
+  and long compact identity/group labels that reduced iOS message history to a
+  two-pixel strip. Explicit keyboard dismissal, bounded compact labels, tighter
+  compact spacing, and focused widget regressions close both defects. Nine
+  launcher tests, 30 focused call/media/widget tests, Flutter analysis, the
+  isolated pre-change `bin/test-fast`, and the real Android/iOS voice/video
+  smoke pass. Repository-wide `bin/verify` also passes; exact-head hosted
+  evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -830,4 +830,25 @@ integration without private project assumptions.
   interactive lab router without sharing the default native-runtime lock. Nine
   launcher tests, focused fixture/attachment/playback tests, Flutter analysis,
   the complete Android API 35 plus iOS 26.4 smoke, and repository-wide
-  `bin/verify` pass locally; exact-head hosted evidence is next.
+  `bin/verify` pass locally. Exact-head push CI run `33226004196`, PR CI run
+  `33226006235`, package dry run `33226006245`, and WampApp artifact run
+  `33226004193` pass; the artifact run includes the production benchmark gate
+  and all seven beta bundles. The comprehensive feature-head audit and
+  protected-`master` strict audit also pass.
+- 2026-08-29: The paired native acceptance now proves destructive encrypted
+  cloud-backup recovery instead of upload alone. The initiator records its
+  device identity, uploads the recovery-phrase-encrypted archive, signs out
+  through the real UI, deletes and verifies deletion of every tracked local
+  vault ciphertext, then restores through the signed-out onboarding UI. The
+  recovered archive must recreate the identical device identity, encrypted
+  contact alias, dark theme, direct-chat mute, one-hour disappearing-message
+  policy, direct history, and group history. A reciprocal encrypted marker
+  exchange proves the recovered session still sends and receives. The launcher
+  rejects both markers in plaintext router persistence and allows the second
+  64 MiB Argon2 derivation within a 25-minute command budget. Sign-out is now a
+  joinable operation, so the smoke waits for the exact UI-started connection
+  and trust-session cleanup before deleting local vault state; a gated
+  transport regression proves concurrent callers share that cleanup. Launcher
+  syntax and all nine launcher tests, focused Flutter analysis and
+  vault/controller tests, the exact Android API 35 plus iOS 26.4 smoke, and
+  repository-wide `bin/verify` pass; exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -971,5 +971,19 @@ integration without private project assumptions.
   distinguishes trust-on-first-use, fully verified, and blocked-change states.
   Focused vault/controller/widget tests, the real router two-device enrollment
   test, the complete 212-test Flutter client suite, and Flutter analysis pass;
-  `bin/test-wamp-app` and repository-wide `bin/verify` also pass. Exact-head
-  hosted evidence is next.
+  `bin/test-wamp-app` and repository-wide `bin/verify` also pass. Commit
+  `f95d7e24` is on both maintained remotes. Exact-head push CI `33254106778`,
+  PR CI `33254108332`, package dry run `33254108326`, WampApp artifact run
+  `33254106781`, Codecov project/patch checks, feature-head CI/log audit, and
+  the protected-`master` strict policy/workflow/package audit all pass. PR #84
+  awaits the required code-owner review.
+- 2026-08-29: The paired native smoke now verifies the router-backed
+  per-device safety number through the real peer-identity dialog before either
+  client sends encrypted traffic. A disposable Android API 36.1 plus iOS 26.4
+  run passes peer verification and the complete chat, rich-media,
+  account-control, destructive-recovery, and WebRTC sequence. That run exposed
+  and fixed a stale MCP-consent driver which skipped the current access dialog.
+  Interactive lab startup now brings the selected iOS Simulator to the
+  foreground while automated smoke remains headless. Thirteen launcher tests,
+  focused Flutter analysis/tests, `bin/test-wamp-app`, and repository-wide
+  `bin/verify` pass.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -880,4 +880,19 @@ integration without private project assumptions.
   defensive copy, proving import can wipe temporary bytes without deleting the
   user-owned archive. The exact Android API 36.1 plus iOS 26.4 paired smoke,
   focused Flutter analysis, local-model review, and repository-wide
-  `bin/verify` pass. Exact-head hosted evidence is next.
+  `bin/verify` pass. Exact-head package dry run `33234293755`, PR CI run
+  `33234293811`, push CI run `33234291717`, and WampApp artifact run
+  `33234291729` pass; the artifact run includes the production benchmark gate
+  and all seven beta bundles. The comprehensive feature-head audit and
+  protected-`master` strict audit also pass.
+- 2026-08-29: The interactive tester lab now supervises both installed
+  no-resident clients instead of waiting on the router alone. It polls Android
+  and iOS process state, relaunches either client after an exit, bounds failed
+  launches and rapid crash loops to three attempts, fails on unexpected router
+  exit, and preserves router plus Android reverse-tunnel cleanup. Thirteen
+  process-level launcher tests cover both platform relaunch paths, failed
+  launches, rapid Android crashes, router death, port release, and reverse
+  cleanup. A real Android API 35 plus iOS 26.4 run replaced both client
+  processes while preserving the router PID and a successful WebSocket `101`
+  upgrade. `bin/test-fast` and repository-wide `bin/verify` pass; exact-head
+  hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -987,3 +987,12 @@ integration without private project assumptions.
   foreground while automated smoke remains headless. Thirteen launcher tests,
   focused Flutter analysis/tests, `bin/test-wamp-app`, and repository-wide
   `bin/verify` pass.
+- 2026-08-29: Interactive tester visibility is hardened after the first manual
+  two-device session exposed that a healthy headless router and running iOS
+  client could still appear absent. The launcher now waits until both apps
+  launch, starts an owned scrcpy Android mirror when available, and then brings
+  the selected Simulator forward. Missing or failed scrcpy remains non-fatal
+  with a bounded warning, cleanup joins only the mirror started by that lab,
+  and automated smoke records no desktop command. Fourteen launcher tests,
+  shell/Python syntax checks, dry-run command ordering, local-model review, and
+  repository-wide `bin/verify` pass.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -894,5 +894,20 @@ integration without private project assumptions.
   launches, rapid Android crashes, router death, port release, and reverse
   cleanup. A real Android API 35 plus iOS 26.4 run replaced both client
   processes while preserving the router PID and a successful WebSocket `101`
-  upgrade. `bin/test-fast` and repository-wide `bin/verify` pass; exact-head
-  hosted evidence is next.
+  upgrade. `bin/test-fast` and repository-wide `bin/verify` pass. Exact-head
+  package dry run `33236799210`, PR CI run `33236799221`, and push CI run
+  `33236797692` pass; the comprehensive feature-head audit and
+  protected-`master` strict audit also pass.
+- 2026-08-29: Per-conversation chat design is implemented locally with
+  Standard, Ocean, and Sunset message-bubble presets. Direct and group choices
+  stay independent from account-wide system/light/dark mode, global-search
+  results use their own conversation's preset, and only non-default overrides
+  are retained in a canonical, bounded 500-entry map inside the encrypted
+  device vault. Invalid identifiers and values fail closed. Existing encrypted
+  local/cloud backup snapshots carry the setting, and paired native recovery
+  acceptance now requires it after destructive restore. Ten preference tests,
+  49 controller tests, 22 vault tests, 22 widget tests, the full 198-test
+  Flutter suite, `bin/test-wamp-app` with Chrome and a release web build,
+  local-model review, and repository-wide `bin/verify` pass. Exact device
+  recovery execution and hosted evidence are next; the interactive Android/iOS
+  tester lab remains running and undisturbed.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -815,3 +815,19 @@ integration without private project assumptions.
   recovery phrase from router storage. Nine launcher tests, 39 focused Flutter
   tests, Flutter analysis, the complete Android API 36.1 plus iOS 26.4 smoke,
   and repository-wide `bin/verify` pass. Exact-head hosted evidence is next.
+- 2026-08-29: The paired native acceptance now proves encrypted rich media on
+  the same WAMP session. Android sends a generated PNG, a deterministic
+  two-frame animated GIF, a valid two-second 16 kHz mono PCM16 voice note, and
+  emoji; iOS authenticates and decodes the image and GIF, starts and pauses the
+  real voice-note player, and returns an authenticated acknowledgement that
+  Android observes. Router persistence is recursively rejected if it contains
+  raw PNG, GIF, RIFF/WAVE signatures or any rich-media/acknowledgement token.
+  Exact native execution exposed two harness boundaries: attachment traversal
+  had to keep tap targets inside the visible message-history viewport, and the
+  reversed history had to return to its newest edge before view-once checks.
+  The launcher now also gives every router a state-local temporary runtime
+  namespace, allowing disposable smoke routers to run concurrently with an
+  interactive lab router without sharing the default native-runtime lock. Nine
+  launcher tests, focused fixture/attachment/playback tests, Flutter analysis,
+  the complete Android API 35 plus iOS 26.4 smoke, and repository-wide
+  `bin/verify` pass locally; exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -753,3 +753,16 @@ integration without private project assumptions.
   plus hostname resolution, and explicitly closing all four first-case client
   transports, then passed 50 fresh-process repetitions. The clean canonical
   `bin/verify` rerun passes; exact-head hosted evidence remains next.
+- 2026-08-28: Native acceptance now covers the privacy-sensitive view-once
+  lifecycle after the direct/group/sticker exchange. Android returns to the
+  existing direct conversation and sends a unique encrypted view-once token;
+  iOS proves the plaintext is not rendered before opening, reveals it through the
+  real dialog, verifies local removal after consumption, and Android observes
+  the authenticated open receipt. The router-data guard rejects this new token
+  alongside all direct/group tokens, the group title, and raw PNG bytes. The
+  first live run exposed a test-only keyboard/rebuild race before Android sent;
+  restoring the compact composer controls after unfocus and waiting through
+  transient finder absence made the harness deterministic. Launcher contracts,
+  Flutter analysis, the one-time widget and six-device conflict suites, the
+  pre-change `bin/test-fast`, and the real Android API 35 plus iOS 26.4 smoke
+  pass. Canonical `bin/verify` also passes; exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -1011,3 +1011,22 @@ integration without private project assumptions.
   recovery, WebRTC, and external-MCP sequence while the interactive lab remains
   running. The two-account real-router MCP regressions, all 14 launcher tests,
   `bin/test-wamp-app`, and repository-wide `bin/verify` pass.
+- 2026-08-29: Signed-out onboarding now performs a bounded anonymous WAMP
+  handshake against the entered router and reports debounced checking, ready,
+  unreachable, and retry states without making the advisory probe authoritative
+  over registration. Generation fencing ignores stale endpoint results and
+  disposal prevents late UI updates; the paired native driver waits for router
+  readiness before registration and backup recovery. A real embedded-router
+  regression covers the default path. While testing failed probes, a source-
+  level client defect was reproduced: canceling a pending Dart WebSocket HTTP
+  upgrade could leave I/O alive. The transport now owns and force-closes its
+  pending HTTP client, rejects late successful sockets, remains safe when closed
+  before open on web, and preserves established reconnect semantics. A real TCP
+  stalled-upgrade regression proves bounded disconnect. Package analysis, the
+  full 11-test transport/reconnect suite, `bin/test-wamp-app` with Chrome workers
+  and a release web build, and repository-wide `bin/verify` pass. The existing
+  interactive Android/iPad lab and router remain running. Because the standalone
+  app intentionally verifies exact published package consumption, the client
+  lifecycle correction needs the next synchronized beta publication followed by
+  an exact dependency update before published app artifacts consume it; the new
+  readiness UI remains compatible with the current beta.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -799,3 +799,19 @@ integration without private project assumptions.
   isolated pre-change `bin/test-fast`, and the real Android/iOS voice/video
   smoke pass. Repository-wide `bin/verify` also passes; exact-head hosted
   evidence is next.
+- 2026-08-29: The paired native acceptance now continues through account and
+  privacy controls after encrypted chat/media/view-once and WebRTC calls. Both
+  clients update public profiles and read the peer's propagated display name
+  and status, persist dark theme, per-chat mute, one-hour disappearing-message
+  policy, and a verified local contact alias inside their encrypted vaults,
+  then explicitly enable server-side MCP profile consent. The initiator uploads
+  one recovery-phrase-encrypted remote backup. Fresh encrypted synchronization
+  messages prove both clients reached this state before global local-history
+  search, authenticated read state, and read/unread filters are exercised.
+  Message bubbles now expose stable message-ID keys so native assertions target
+  result rows rather than matching editable search text. The launcher validates
+  both persisted consent records and the committed ciphertext archive while its
+  recursive guard rejects every new local alias, synchronization token, and
+  recovery phrase from router storage. Nine launcher tests, 39 focused Flutter
+  tests, Flutter analysis, the complete Android API 36.1 plus iOS 26.4 smoke,
+  and repository-wide `bin/verify` pass. Exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -187,8 +187,10 @@ integration without private project assumptions.
   session. Upload-before-message ordering, exact retry/resume, recipient-scoped
   download, native-file/IndexedDB ciphertext persistence, local descriptor-key
   encryption, integrity verification, cancellation, stale-session fencing, and
-  file/image/GIF picker/preview/save UX are covered. View-once attachments fail
-  closed. `bin/test-wamp-app` passes with 28 shared, 36 server, and 50 Flutter
+  file/image/GIF picker/preview/save UX are covered. The original increment
+  failed closed for view-once attachments; current head closes that limitation
+  with authenticated prefetch, atomic consumption/deletion, and ephemeral
+  cache-only reveal. `bin/test-wamp-app` passes with 28 shared, 36 server, and 50 Flutter
   tests plus a release web build; a real Chrome IndexedDB test and repository
   `bin/verify` also pass. A repeatable five-iteration 64 MiB benchmark reports
   0.159/0.139 Gbit/s for
@@ -925,3 +927,23 @@ integration without private project assumptions.
   and explicitly tears down clients, upgraded sockets, and servers. All 11
   tests pass with every former port occupied and in three concurrent test
   processes, and the post-change `bin/test-fast` passes end to end.
+  Repository-wide `bin/verify` also passes. Implementation commit `066a6d42`
+  is pushed to both maintained remotes. Exact-head push CI `33243602817`, PR CI
+  `33243604898`, push package dry run `33243602835`, PR package dry run
+  `33243604871`, and WAMP Profile Benchmarks `33244524715` pass; the benchmark
+  run uploaded the canonical profile artifact. The comprehensive feature-head
+  audit and protected-`master` strict audit also pass.
+- 2026-08-29: Encrypted view-once direct messages now support attachments. The
+  client authenticates and caches all ciphertext before requesting durable
+  consumption; the server atomically records the first-device winner, deletes
+  every attachment before success, and immediately retries cleanup during
+  retention after transient filesystem failures. Reveal is cache-only and
+  ephemeral, and close, sign-out, disposal, or a lost consume race invalidates
+  the cache. Protocol, retention, service, cache, controller, multi-device, and
+  widget regressions pass. A disposable Android API 36 plus iOS 26.4 paired
+  smoke proves an encrypted sticker stays hidden before reveal, renders after
+  server deletion, and cannot be fetched afterward while the interactive lab
+  remains running. `bin/test-wamp-app` passes with 53 shared, 144 server, and
+  201 Flutter tests, real Chrome IndexedDB and 64 MiB worker checks, and a
+  release web build. Repository-wide `bin/verify` also passes; exact-head
+  hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -947,3 +947,17 @@ integration without private project assumptions.
   201 Flutter tests, real Chrome IndexedDB and 64 MiB worker checks, and a
   release web build. Repository-wide `bin/verify` also passes; exact-head
   hosted evidence is next.
+- 2026-08-29: Authenticated MCP access discovery is implemented locally. An
+  account-scoped WAMP RPC returns only relative MCP/authentication routes,
+  transport capabilities, and the exact public-profile field boundary; strict
+  clients reject unknown schema, fields, routes, or capabilities and derive
+  HTTP(S) endpoints from the connected WAMP origin. The Flutter account panel
+  now displays and copies those endpoints, identifies the real application
+  realm, keeps profile sharing default-denied, supports immediate revocation,
+  and explicitly excludes conversations, media, backups, devices, calls,
+  keys, avatars, passwords, and tokens. Shared protocol tests, real-router MCP
+  and gateway integration tests, controller fencing tests, compact widget
+  coverage, and package analysis pass. `bin/test-wamp-app` passes with 56
+  shared and 144 server tests, the complete native and isolated Chrome client
+  suites, Dart2Wasm, and a release web build. Repository-wide `bin/verify` also
+  passes; exact-head hosted evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -961,3 +961,15 @@ integration without private project assumptions.
   shared and 144 server tests, the complete native and isolated Chrome client
   suites, Dart2Wasm, and a release web build. Repository-wide `bin/verify` also
   passes; exact-head hosted evidence is next.
+- 2026-08-29: Explicit peer-device safety-number verification and
+  post-verification continuity are implemented locally. Verification records
+  commit transactionally inside the encrypted vault, stale directory results
+  cannot approve a replacement key, and direct or atomic group sends stop
+  before attachment encryption or content-key wrapping whenever a previously
+  verified contact has a new or changed active device. The Flutter dialog lists
+  every active device, requires an out-of-band number-match confirmation, and
+  distinguishes trust-on-first-use, fully verified, and blocked-change states.
+  Focused vault/controller/widget tests, the real router two-device enrollment
+  test, the complete 212-test Flutter client suite, and Flutter analysis pass;
+  `bin/test-wamp-app` and repository-wide `bin/verify` also pass. Exact-head
+  hosted evidence is next.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -3,7 +3,7 @@
 Last updated: 2026-08-28
 Current branch: `codex/wamp-app-native-rich-smoke`
 Current milestone: prove standalone WampApp encrypted direct and group chat,
-including rich content, privacy-sensitive consumption, and WebRTC voice calls,
+including rich content, privacy-sensitive consumption, and WebRTC voice/video calls,
 through concurrent native platform UIs. PR #83 is
 merged to `master` as `d9c53bf9` on both maintained remotes. Exact-head GitHub
 CI run `33180625653` and WampApp artifact run `33180625646` pass; the artifact
@@ -20,7 +20,10 @@ rendered before opening, reveals it through the real UI, removes it after consum
 and Android observes the open receipt. Android then starts a real WebRTC voice
 call, iOS accepts it, both clients prove active native media bound to the right
 peer, synchronize authenticated E2EE-readiness markers, exercise mute/unmute,
-and converge through hangup, native-media disposal, result UI, and dismissal. A
+and converge through hangup, native-media disposal, result UI, and dismissal.
+The pair then repeats that lifecycle for video, proves local rendering, toggles
+the camera off and on, and requires both the media session and renderer to be
+released at teardown. A
 recursive router-data guard rejects every direct/group/view-once smoke token,
 the group title, raw PNG bytes, and plaintext SDP/ICE signaling. This richer
 acceptance exposed and fixed a dialog-controller dismissal race, compact
@@ -30,9 +33,11 @@ lose a synchronous native WebRTC connected callback while applying the answer.
 The launcher now preinstalls both apps, grants camera and microphone permissions
 before tests start, and uses isolated Android/iOS workspaces so concurrent
 Flutter tooling cannot contend over startup or build artifacts. Nine launcher
-tests, 30 focused call/widget tests, Flutter analysis, `bin/test-fast`, the real
-Android API 35 plus iOS 26.4 smoke, and repository-wide `bin/verify` pass
-locally. Exact-head hosted evidence remains next.
+tests, 30 focused call/widget tests, Flutter analysis, `bin/test-fast`, and the
+real Android plus iOS voice/video smoke pass locally. Native acceptance also
+fixed stale-keyboard expression-sheet placement and compact identity/title
+wrapping that could collapse message history to two pixels. Repository-wide
+`bin/verify` also passes; exact-head hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -3,7 +3,8 @@
 Last updated: 2026-08-28
 Current branch: `codex/wamp-app-native-rich-smoke`
 Current milestone: prove standalone WampApp encrypted direct and group chat,
-including rich content, through concurrent native platform UIs. PR #83 is
+including rich content and privacy-sensitive consumption, through concurrent
+native platform UIs. PR #83 is
 merged to `master` as `d9c53bf9` on both maintained remotes. Exact-head GitHub
 CI run `33180625653` and WampApp artifact run `33180625646` pass; the artifact
 run includes the production benchmark gate and all seven beta bundles, and the
@@ -13,8 +14,11 @@ clients through registration, 3-pass/64 MiB Argon2id SCRAM, reciprocal device
 discovery and direct chat, then creates and discovers a two-member encrypted
 group. Android sends group text plus the bundled PNG sticker, iOS downloads,
 decrypts, and renders its preview before replying in the same group, and Android
-decrypts and renders that reply. A recursive router-data guard rejects every
-direct/group smoke token, the group title, and raw PNG bytes. This richer
+decrypts and renders that reply. Android then sends an encrypted view-once
+message in the original direct conversation; iOS proves its plaintext is not
+rendered before opening, reveals it through the real UI, removes it after consumption,
+and Android observes the open receipt. A recursive router-data guard rejects
+every direct/group/view-once smoke token, the group title, and raw PNG bytes. This richer
 acceptance exposed and fixed a dialog-controller dismissal race, compact sticker
 composer overflow, and an asynchronous send race that could discard a newly
 typed draft or newly staged attachment. Nine launcher tests, all 21 WampApp
@@ -24,8 +28,8 @@ smoke pass locally. The first repository-wide `bin/verify` attempt exposed an
 intermittent WebSocket I/O test upgrade failure; replacing its fixed port and
 hostname-resolved listeners with ephemeral IPv4 loopback listeners and closing
 all four first-case client transports explicitly survives 50 fresh-process
-repetitions. The clean repository-wide `bin/verify` rerun passes; exact-head
-hosted evidence remains next.
+repetitions. Repository-wide `bin/verify` and the real view-once Android/iOS
+smoke pass for the follow-up; exact-head hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -81,6 +81,22 @@ callers share that cleanup. Launcher syntax and all nine launcher tests,
 focused Flutter analysis and vault/controller tests, the exact Android API 35
 plus iOS 26.4 destructive-recovery smoke, and repository-wide `bin/verify`
 pass; exact-head hosted evidence is next.
+Native acceptance now also drives bounded public-profile avatar selection and
+opt-in contact import through the real Flutter dialogs. Production profile
+selection uses an injectable `file_selector` boundary that preserves
+cancellation, rejects empty or over-256-KiB inputs before persistence, owns the
+selected bytes, and maps selector/read failures to redacted UI errors. The
+paired smoke injects deterministic platform-boundary results while exercising
+the production dialog/controller/router path: both clients render their chosen
+PNG, persist it in the account profile, observe the peer avatar, import a
+display name before binding the authenticated peer username, and preserve the
+initiator avatar byte-for-byte through destructive encrypted cloud recovery.
+The first native run correctly rejected a generated 262,488-byte sticker as an
+avatar because the protocol limit is 262,144 bytes; the harness now uses a
+compact valid PNG and asserts the limit before opening the dialog. Six picker
+boundary tests plus 22 focused widget tests, Flutter analysis, the complete
+Android API 36.1 plus iOS 26.4 paired smoke, and repository-wide `bin/verify`
+pass. Exact-head hosted evidence is next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -3,8 +3,8 @@
 Last updated: 2026-08-28
 Current branch: `codex/wamp-app-native-rich-smoke`
 Current milestone: prove standalone WampApp encrypted direct and group chat,
-including rich content and privacy-sensitive consumption, through concurrent
-native platform UIs. PR #83 is
+including rich content, privacy-sensitive consumption, and WebRTC voice calls,
+through concurrent native platform UIs. PR #83 is
 merged to `master` as `d9c53bf9` on both maintained remotes. Exact-head GitHub
 CI run `33180625653` and WampApp artifact run `33180625646` pass; the artifact
 run includes the production benchmark gate and all seven beta bundles, and the
@@ -17,19 +17,22 @@ decrypts, and renders its preview before replying in the same group, and Android
 decrypts and renders that reply. Android then sends an encrypted view-once
 message in the original direct conversation; iOS proves its plaintext is not
 rendered before opening, reveals it through the real UI, removes it after consumption,
-and Android observes the open receipt. A recursive router-data guard rejects
-every direct/group/view-once smoke token, the group title, and raw PNG bytes. This richer
-acceptance exposed and fixed a dialog-controller dismissal race, compact sticker
-composer overflow, and an asynchronous send race that could discard a newly
-typed draft or newly staged attachment. Nine launcher tests, all 21 WampApp
-widget tests, the discovered-member group integration regression, Flutter
-analysis, `bin/test-fast`, `bin/test-wamp-app`, and the real two-device native
-smoke pass locally. The first repository-wide `bin/verify` attempt exposed an
-intermittent WebSocket I/O test upgrade failure; replacing its fixed port and
-hostname-resolved listeners with ephemeral IPv4 loopback listeners and closing
-all four first-case client transports explicitly survives 50 fresh-process
-repetitions. Repository-wide `bin/verify` and the real view-once Android/iOS
-smoke pass for the follow-up; exact-head hosted evidence remains next.
+and Android observes the open receipt. Android then starts a real WebRTC voice
+call, iOS accepts it, both clients prove active native media bound to the right
+peer, synchronize authenticated E2EE-readiness markers, exercise mute/unmute,
+and converge through hangup, native-media disposal, result UI, and dismissal. A
+recursive router-data guard rejects every direct/group/view-once smoke token,
+the group title, raw PNG bytes, and plaintext SDP/ICE signaling. This richer
+acceptance exposed and fixed a dialog-controller dismissal race, compact
+sticker-composer overflow, an asynchronous send race that could discard a newly
+typed draft or staged attachment, and an outgoing-call state race that could
+lose a synchronous native WebRTC connected callback while applying the answer.
+The launcher now preinstalls both apps, grants camera and microphone permissions
+before tests start, and uses isolated Android/iOS workspaces so concurrent
+Flutter tooling cannot contend over startup or build artifacts. Nine launcher
+tests, 30 focused call/widget tests, Flutter analysis, `bin/test-fast`, the real
+Android API 35 plus iOS 26.4 smoke, and repository-wide `bin/verify` pass
+locally. Exact-head hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -32,6 +32,21 @@ that skipped the current access dialog. Interactive lab startup now brings the
 selected iOS Simulator to the foreground while `--smoke` remains headless.
 Thirteen launcher tests, focused Flutter analysis/tests, and `bin/test-wamp-app`
 pass for this follow-up; repository-wide `bin/verify` also passes.
+The paired native acceptance now consumes the profile consent granted by both
+real client UIs from a separate MCP process. The bounded probe discovers the
+Bearer challenge, authenticates each account with WAMP-SCRAM, requires the
+exact tools/resources/prompts catalog, reads the exact consented public-profile
+fields through stateful Streamable HTTP and direct JSON, checks both resources
+and the prompt, and proves access-token rejection plus refresh-token cleanup.
+Synthetic credentials travel only through bounded stdin pipes and never through
+command arguments, child-process environments, or emitted diagnostics;
+malformed, oversized, and non-loopback cleartext requests fail with stage-only
+output. A
+disposable Android API 36.1 plus iOS 26.4 run passes the complete peer-trust,
+encrypted-chat, rich-media, account-control, destructive-recovery, WebRTC, and
+external-MCP sequence while the interactive tester lab remains undisturbed.
+The two-account real-router MCP regressions, all 14 launcher lifecycle tests,
+`bin/test-wamp-app`, and repository-wide `bin/verify` pass.
 The first manual tester session exposed that a healthy headless router and two
 running clients could still appear incomplete when the Android AVD had no
 window or Simulator remained behind another application. Interactive startup

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -9,6 +9,16 @@ merged to `master` as `d9c53bf9` on both maintained remotes. Exact-head GitHub
 CI run `33180625653` and WampApp artifact run `33180625646` pass; the artifact
 run includes the production benchmark gate and all seven beta bundles, and the
 strict deployment audit passes.
+The current working revision adds explicit per-device safety-number review and
+post-verification key continuity. Verification state is transactionally
+persisted in the encrypted vault, stale device snapshots cannot be approved,
+and direct or group sends stop before encryption whenever a previously verified
+contact presents a new or changed active device. The compact Flutter dialog
+requires out-of-band number comparison and states the remaining trust-on-first-
+use/key-transparency limitation. Focused regressions, a real router-backed
+second-device test, all 212 Flutter client tests, and Flutter analysis pass;
+`bin/test-wamp-app` and repository-wide `bin/verify` also pass; exact-head
+hosted verification is pending for this revision.
 `bin/run-wamp-app-lab --smoke` now drives fresh Android API 35 and iOS 26.4
 clients through registration, 3-pass/64 MiB Argon2id SCRAM, reciprocal device
 discovery and direct chat, then creates and discovers a two-member encrypted

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -139,9 +139,25 @@ currently selected chat. Ten preference tests, 49 controller tests, 22 vault
 tests, 22 widget tests, the full 198-test Flutter client suite,
 `bin/test-wamp-app` including Chrome and the release web build, local-model
 review, and repository-wide `bin/verify` pass. The paired native recovery smoke
-now requires the preset after destructive local/cloud restore; exact device
-execution and hosted evidence are next, without interrupting the active tester
-lab.
+now requires the preset after destructive local/cloud restore. Exact-head
+package dry run `33240068792`, PR CI `33240068807`, push CI `33240067540`, and
+WampApp artifact run `33240067539` pass, including all seven bundles and the
+production benchmark gate; the comprehensive feature-head audit and
+protected-`master` strict audit also pass. Exact native device recovery now
+passes on a disposable Android API 36.1 emulator and iOS 26.4 simulator while
+the interactive Android/iOS tester lab and its router remain running and
+undisturbed. The paired smoke proves Standard/Ocean/Sunset selection survives
+both destructive cloud and local-file recovery alongside the existing encrypted
+identity, profile, preference, contact, direct-history, and group-history
+assertions.
+The pre-change `bin/test-fast` for that acceptance run exposed legacy fixed
+ports in the client transport I/O-event tests. Every local WebSocket and
+RawSocket listener in that suite now binds IPv4 loopback on an ephemeral port,
+clients use the listener's resolved address and port, and teardown explicitly
+disconnects clients and closes upgraded sockets and servers. The complete
+11-test file passes while all former ports are occupied and in three concurrent
+processes under the same collision pressure; the post-change `bin/test-fast`
+also passes end to end.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,26 +1,31 @@
 # Project State
 
 Last updated: 2026-08-28
-Current branch: `codex/wamp-app-native-ui-smoke`
-Current milestone: prove standalone WampApp registration and encrypted chat
-through concurrent native platform UIs. PR #82 is merged to `master` as
-`48783adf` on both maintained remotes. Exact-head GitHub CI run `33171843544`
-and WampApp artifact run `33171843583` pass; the artifact run includes the
-production benchmark gate and all seven beta bundles, and the strict deployment
-audit passes.
-`bin/run-wamp-app-lab` retains its interactive Android+iOS mode and now adds a
-deterministic `--smoke` mode. Fresh Android API 35 and iOS 26.4 clients register
-unique accounts through the real keyed UI and 3-pass/64 MiB Argon2id SCRAM,
-discover the peer device, send reciprocal direct messages through the UI,
-receive them through mailbox pub/sub, decrypt them locally, and render both
-bubbles. The launcher rejects plaintext tokens in the router message store and
-uses bounded process termination so failed runs cannot leave the router or
-Android reverse tunnel behind. This acceptance exposed and fixed a real mobile
-keyboard overflow: the compact authenticated shell now collapses secondary
-account and conversation controls while preserving recipient, history, errors,
-attachments, and composer. Nine launcher tests, all 18 WampApp widget tests,
-Flutter analysis, the two-device native smoke, and repository-wide `bin/verify`
-pass locally; exact-head hosted evidence remains next.
+Current branch: `codex/wamp-app-native-rich-smoke`
+Current milestone: prove standalone WampApp encrypted direct and group chat,
+including rich content, through concurrent native platform UIs. PR #83 is
+merged to `master` as `d9c53bf9` on both maintained remotes. Exact-head GitHub
+CI run `33180625653` and WampApp artifact run `33180625646` pass; the artifact
+run includes the production benchmark gate and all seven beta bundles, and the
+strict deployment audit passes.
+`bin/run-wamp-app-lab --smoke` now drives fresh Android API 35 and iOS 26.4
+clients through registration, 3-pass/64 MiB Argon2id SCRAM, reciprocal device
+discovery and direct chat, then creates and discovers a two-member encrypted
+group. Android sends group text plus the bundled PNG sticker, iOS downloads,
+decrypts, and renders its preview before replying in the same group, and Android
+decrypts and renders that reply. A recursive router-data guard rejects every
+direct/group smoke token, the group title, and raw PNG bytes. This richer
+acceptance exposed and fixed a dialog-controller dismissal race, compact sticker
+composer overflow, and an asynchronous send race that could discard a newly
+typed draft or newly staged attachment. Nine launcher tests, all 21 WampApp
+widget tests, the discovered-member group integration regression, Flutter
+analysis, `bin/test-fast`, `bin/test-wamp-app`, and the real two-device native
+smoke pass locally. The first repository-wide `bin/verify` attempt exposed an
+intermittent WebSocket I/O test upgrade failure; replacing its fixed port and
+hostname-resolved listeners with ephemeral IPv4 loopback listeners and closing
+all four first-case client transports explicitly survives 50 fresh-process
+repetitions. The clean repository-wide `bin/verify` rerun passes; exact-head
+hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -177,6 +177,17 @@ server copy is gone, and cannot be fetched after close, while the interactive
 tester lab remains undisturbed. `bin/test-wamp-app` passes with 53 shared, 144
 server, and 201 Flutter tests, real Chrome IndexedDB and 64 MiB worker checks,
 and a release web build; repository-wide `bin/verify` also passes.
+Authenticated MCP access discovery is now implemented locally. An
+account-authenticated WAMP procedure exposes only server-configured relative
+MCP and authentication paths plus fixed capability metadata. The client
+strictly validates that boundary, derives HTTP(S) URLs from its connected
+WAMP origin, and presents a usable account panel with copyable endpoints,
+default-denied public-profile consent, immediate revocation, and explicit
+credential/content exclusions. Focused shared, server, real-router gateway,
+controller, compact-widget, and analysis checks pass. `bin/test-wamp-app`
+passes with 56 shared and 144 server tests, the complete native and isolated
+Chrome client suites, Dart2Wasm, and a release web build. Repository-wide
+`bin/verify` also passes; exact-head hosted evidence is next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -124,7 +124,24 @@ Android and iOS relaunch, failed launch, rapid crash, router death, port
 release, and reverse cleanup. A real Android API 35 plus iOS 26.4 lab proved
 both client processes were replaced while the router PID remained stable and
 the WebSocket endpoint still returned `101 Switching Protocols`; `bin/test-fast`
-and repository-wide `bin/verify` pass.
+and repository-wide `bin/verify` pass. Exact-head package dry run
+`33236799210`, PR CI run `33236799221`, and push CI run `33236797692` pass;
+the comprehensive feature-head audit and protected-`master` strict audit also
+pass.
+Per-conversation chat design is now implemented locally. Direct and group
+conversations independently select Standard, Ocean, or Sunset message-bubble
+presets without changing account-wide system/light/dark mode. Only non-default
+overrides are retained in a canonical, bounded 500-entry map inside the
+encrypted device vault; malformed identifiers or values fail closed, and the
+same encrypted local/cloud backup payload restores the selection. Global-search
+results resolve the design from each result's conversation rather than the
+currently selected chat. Ten preference tests, 49 controller tests, 22 vault
+tests, 22 widget tests, the full 198-test Flutter client suite,
+`bin/test-wamp-app` including Chrome and the release web build, local-model
+review, and repository-wide `bin/verify` pass. The paired native recovery smoke
+now requires the preset after destructive local/cloud restore; exact device
+execution and hosted evidence are next, without interrupting the active tester
+lab.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -59,7 +59,28 @@ runtime namespace, so disposable smoke routers no longer contend with an
 interactive lab router's native-runtime lock. Nine launcher tests, focused
 fixture/attachment/playback tests, Flutter analysis, the complete Android API
 35 plus iOS 26.4 native smoke, and repository-wide `bin/verify` pass for this
-expansion; exact-head hosted evidence remains next.
+expansion. Exact-head push CI run `33226004196`, PR CI run `33226006235`,
+package dry run `33226006245`, and WampApp artifact run `33226004193` pass;
+the artifact run includes the production benchmark gate and all seven beta
+bundles. The comprehensive feature-head audit and protected-`master` strict
+audit also pass.
+Native acceptance now proves destructive encrypted cloud-backup recovery rather
+than upload alone. After the initiator uploads its recovery-phrase-encrypted
+archive, the smoke records its device identity, signs out through the real UI,
+deletes and verifies deletion of every tracked local vault ciphertext, and
+restores from the router through the signed-out onboarding UI. Recovery must
+recreate the identical device identity plus the encrypted contact alias, dark
+theme, direct-chat mute, one-hour disappearing-message policy, direct history,
+and group history. A reciprocal encrypted marker exchange then proves the
+restored session can still send and receive. The launcher treats both markers
+as forbidden plaintext and extends the native smoke budget for the second
+64 MiB Argon2 derivation. Sign-out operations are now joinable, so a caller can
+wait for the exact UI-started connection and trust-session cleanup before
+deleting local vault state; a gated transport regression proves concurrent
+callers share that cleanup. Launcher syntax and all nine launcher tests,
+focused Flutter analysis and vault/controller tests, the exact Android API 35
+plus iOS 26.4 destructive-recovery smoke, and repository-wide `bin/verify`
+pass; exact-head hosted evidence is next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -48,7 +48,18 @@ single committed ciphertext backup, and absence of every chat, media, call,
 contact, synchronization, and recovery-phrase smoke token from router storage.
 Nine launcher tests, 39 focused Flutter tests, Flutter analysis, the complete
 Android API 36.1 plus iOS 26.4 smoke, and repository-wide `bin/verify` pass;
-exact-head hosted evidence remains next.
+exact-head hosted evidence remains next. Native acceptance now also transfers
+an encrypted generated PNG, a two-frame animated GIF, a valid two-second PCM16
+voice note, and emoji through the existing WAMP session. iOS authenticates and
+decodes both images, starts and pauses real voice-note playback, and returns an
+authenticated acknowledgement that Android observes. The recursive router-data
+guard rejects PNG, GIF, RIFF/WAVE signatures and all rich-media or
+acknowledgement tokens. The launcher gives each router a state-local temporary
+runtime namespace, so disposable smoke routers no longer contend with an
+interactive lab router's native-runtime lock. Nine launcher tests, focused
+fixture/attachment/playback tests, Flutter analysis, the complete Android API
+35 plus iOS 26.4 native smoke, and repository-wide `bin/verify` pass for this
+expansion; exact-head hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -157,7 +157,26 @@ clients use the listener's resolved address and port, and teardown explicitly
 disconnects clients and closes upgraded sockets and servers. The complete
 11-test file passes while all former ports are occupied and in three concurrent
 processes under the same collision pressure; the post-change `bin/test-fast`
-also passes end to end.
+and repository-wide `bin/verify` also pass end to end. Implementation commit
+`066a6d42` is on both maintained remotes. Exact-head push CI `33243602817`, PR
+CI `33243604898`, push package dry run `33243602835`, PR package dry run
+`33243604871`, and WAMP Profile Benchmarks `33244524715` pass; the benchmark
+run uploaded the canonical profile artifact. The comprehensive feature-head
+audit and protected-`master` strict audit also pass.
+Encrypted view-once direct messages now support attachments without exposing
+plaintext before durable consumption. The client prefetches and authenticates
+all ciphertext, the server atomically commits the first-device-wins consume
+before deleting every message attachment and acknowledging success, and the
+winner decrypts only from its ephemeral cache. Closing, signing out, disposing,
+or losing the consume race invalidates that cache; startup and periodic
+retention immediately retry deletion after a transient filesystem failure.
+Protocol, retention, service, cache, controller, multi-device, and widget
+regressions pass. A disposable Android API 36 plus iOS 26.4 paired smoke proves
+an encrypted sticker stays hidden before reveal, renders from cache after the
+server copy is gone, and cannot be fetched after close, while the interactive
+tester lab remains undisturbed. `bin/test-wamp-app` passes with 53 shared, 144
+server, and 201 Flutter tests, real Chrome IndexedDB and 64 MiB worker checks,
+and a release web build; repository-wide `bin/verify` also passes.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact
@@ -431,8 +450,11 @@ records, rejects incomplete/conflicting envelopes, and authorizes download only
 after an attachment is referenced by a caller-visible mailbox record. Direct
 and group attachment-only messages, ciphertext/plaintext integrity, cache
 restart, cancellation, stale-session fencing, and browser IndexedDB persistence
-have focused regressions. View-once attachments fail closed pending atomic
-consumption/deletion. `bin/test-wamp-app` passes with 28 shared, 36 server, and
+have focused regressions. The original attachment increment failed closed for
+view-once messages; current head closes that limitation with authenticated
+ciphertext prefetch, atomic first-device consumption, server-side deletion
+before success, cache-only ephemeral reveal, and immediate retention recovery
+after transient deletion failures. `bin/test-wamp-app` passes with 28 shared, 36 server, and
 50 Flutter tests plus a release web build; Chrome separately passes the real
 IndexedDB test, and repository `bin/verify` passes on 2026-08-25. Five measured
 64 MiB iterations establish a macOS baseline of

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -17,8 +17,21 @@ contact presents a new or changed active device. The compact Flutter dialog
 requires out-of-band number comparison and states the remaining trust-on-first-
 use/key-transparency limitation. Focused regressions, a real router-backed
 second-device test, all 212 Flutter client tests, and Flutter analysis pass;
-`bin/test-wamp-app` and repository-wide `bin/verify` also pass; exact-head
-hosted verification is pending for this revision.
+`bin/test-wamp-app` and repository-wide `bin/verify` also pass. Commit
+`f95d7e24` is on both maintained remotes. Exact-head push CI `33254106778`, PR
+CI `33254108332`, package dry run `33254108326`, WampApp artifact run
+`33254106781`, Codecov project/patch checks, feature-head CI/log audit, and the
+protected-`master` strict policy/workflow/package audit all pass. PR #84 awaits
+the required code-owner review.
+The paired native smoke now opens each peer's identity dialog, compares the
+router-backed per-device safety number, and records explicit verification before
+the first encrypted send. A disposable Android API 36.1 plus iOS 26.4 run passes
+that flow and the full chat, rich-media, account-control, destructive-recovery,
+and WebRTC sequence. The run also exposed and fixed a stale MCP-consent driver
+that skipped the current access dialog. Interactive lab startup now brings the
+selected iOS Simulator to the foreground while `--smoke` remains headless.
+Thirteen launcher tests, focused Flutter analysis/tests, and `bin/test-wamp-app`
+pass for this follow-up; repository-wide `bin/verify` also passes.
 `bin/run-wamp-app-lab --smoke` now drives fresh Android API 35 and iOS 26.4
 clients through registration, 3-pass/64 MiB Argon2id SCRAM, reciprocal device
 discovery and direct chat, then creates and discovers a two-member encrypted

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -97,6 +97,20 @@ compact valid PNG and asserts the limit before opening the dialog. Six picker
 boundary tests plus 22 focused widget tests, Flutter analysis, the complete
 Android API 36.1 plus iOS 26.4 paired smoke, and repository-wide `bin/verify`
 pass. Exact-head hosted evidence is next.
+Native acceptance now also proves destructive encrypted local-file backup
+recovery while the peer completes destructive cloud recovery in the same
+paired run. The responder exports through the real Flutter backup dialog into
+an ownership-safe test file boundary, requires a bounded non-empty
+`.wampbackup`, and rejects raw UTF-8 plus base64 forms of every protected chat,
+group, contact, synchronization, password, and recovery-phrase token. It then
+signs out, deletes and verifies every tracked local vault ciphertext, restores
+through the signed-out local-backup UI, and must recover the same device
+identity, profile avatar, encrypted preferences, contact alias, direct history,
+and group history. The file gateway returns a defensive archive copy for
+import, so the smoke also proves the controller can wipe its working bytes
+without deleting the user-owned archive. The complete Android API 36.1 plus iOS
+26.4 paired smoke, focused Flutter analysis, local-model review, and
+repository-wide `bin/verify` pass; exact-head hosted evidence is next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,6 +1,6 @@
 # Project State
 
-Last updated: 2026-08-28
+Last updated: 2026-08-29
 Current branch: `codex/wamp-app-native-rich-smoke`
 Current milestone: prove standalone WampApp encrypted direct and group chat,
 including rich content, privacy-sensitive consumption, and WebRTC voice/video calls,
@@ -37,7 +37,18 @@ tests, 30 focused call/widget tests, Flutter analysis, `bin/test-fast`, and the
 real Android plus iOS voice/video smoke pass locally. Native acceptance also
 fixed stale-keyboard expression-sheet placement and compact identity/title
 wrapping that could collapse message history to two pixels. Repository-wide
-`bin/verify` also passes; exact-head hosted evidence remains next.
+`bin/verify` also passes. The same smoke now continues through public-profile
+updates and cross-device reads, encrypted local theme/mute/disappearing-message
+preferences, encrypted contact aliases, explicit MCP profile consent on both
+accounts, one initiator-owned encrypted remote backup, global local-history
+search, authenticated read receipts, and read/unread filters. Stable
+message-ID bubble keys keep native search/filter evidence independent of
+editable-field text. The launcher verifies both persisted consent records, the
+single committed ciphertext backup, and absence of every chat, media, call,
+contact, synchronization, and recovery-phrase smoke token from router storage.
+Nine launcher tests, 39 focused Flutter tests, Flutter analysis, the complete
+Android API 36.1 plus iOS 26.4 smoke, and repository-wide `bin/verify` pass;
+exact-head hosted evidence remains next.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -110,7 +110,21 @@ and group history. The file gateway returns a defensive archive copy for
 import, so the smoke also proves the controller can wipe its working bytes
 without deleting the user-owned archive. The complete Android API 36.1 plus iOS
 26.4 paired smoke, focused Flutter analysis, local-model review, and
-repository-wide `bin/verify` pass; exact-head hosted evidence is next.
+repository-wide `bin/verify` pass. Exact-head package dry run `33234293755`, PR
+CI run `33234293811`, push CI run `33234291717`, and WampApp artifact run
+`33234291729` pass; the artifact run includes the production benchmark gate and
+all seven beta bundles. The comprehensive feature-head audit and
+protected-`master` strict audit also pass.
+Interactive tester-lab readiness now includes bounded client supervision.
+`bin/run-wamp-app-lab` polls both no-resident native clients, relaunches either
+one after an exit, rejects unavailable devices and rapid crash loops after
+three attempts, detects unexpected router exit, and retains router and Android
+reverse-tunnel cleanup on failure. Thirteen process-level launcher tests cover
+Android and iOS relaunch, failed launch, rapid crash, router death, port
+release, and reverse cleanup. A real Android API 35 plus iOS 26.4 lab proved
+both client processes were replaced while the router PID remained stable and
+the WebSocket endpoint still returned `101 Switching Protocols`; `bin/test-fast`
+and repository-wide `bin/verify` pass.
 Milestone 9 production hardening has exact-head hosted CI, benchmark, and
 seven-platform artifact evidence at `0c9ca252`. Opt-in, privacy-preserving
 contact import is complete with exact-head CI and seven-platform artifact

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -32,6 +32,15 @@ that skipped the current access dialog. Interactive lab startup now brings the
 selected iOS Simulator to the foreground while `--smoke` remains headless.
 Thirteen launcher tests, focused Flutter analysis/tests, and `bin/test-wamp-app`
 pass for this follow-up; repository-wide `bin/verify` also passes.
+The first manual tester session exposed that a healthy headless router and two
+running clients could still appear incomplete when the Android AVD had no
+window or Simulator remained behind another application. Interactive startup
+now waits until both clients launch, opens a managed scrcpy mirror when the
+optional command is installed, and brings the selected Simulator forward.
+Mirror failure is non-fatal and logged, cleanup stops only the mirror owned by
+the current lab, and smoke mode remains strictly headless. Fourteen
+process-level launcher tests, shell/Python syntax checks, dry-run ordering, and
+repository-wide `bin/verify` pass.
 `bin/run-wamp-app-lab --smoke` now drives fresh Android API 35 and iOS 26.4
 clients through registration, 3-pass/64 MiB Argon2id SCRAM, reciprocal device
 discovery and direct chat, then creates and discovers a two-member encrypted

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -23,6 +23,22 @@ CI `33254108332`, package dry run `33254108326`, WampApp artifact run
 `33254106781`, Codecov project/patch checks, feature-head CI/log audit, and the
 protected-`master` strict policy/workflow/package audit all pass. PR #84 awaits
 the required code-owner review.
+Onboarding now probes the configured router with a bounded anonymous WAMP
+handshake and presents debounced checking, ready, unreachable, and retry states
+without weakening registration validation. Stale and post-disposal probe
+results are fenced, the paired native driver waits for proven readiness, and a
+real embedded-router regression covers the default path. The probe exposed a
+client lifecycle defect where canceling a pending Dart WebSocket upgrade could
+leave I/O alive. Source now interrupts pending opens, rejects late sockets, and
+preserves established reconnect behavior on VM and web; a real stalled-upgrade
+regression proves bounded disconnect. Repository-wide `bin/verify`, the full
+11-test transport/reconnect suite, package analysis, and `bin/test-wamp-app`
+including Chrome workers and the release web build pass. The interactive
+Android/iPad tester lab and its router remain running. The standalone app still
+intentionally consumes exact published packages, so the lifecycle correction
+requires the next synchronized beta publication and dependency update before
+published app artifacts consume it; router-readiness UI itself remains
+compatible with the current beta.
 The paired native smoke now opens each peer's identity dialog, compares the
 router-backed per-device safety number, and records explicit verification before
 the first encrypted send. A disposable Android API 36.1 plus iOS 26.4 run passes

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -75,8 +75,12 @@ contact IDs, and address-book files are never uploaded or retained by WampApp.
 Credential-backed FCM deployment evidence requires operator-owned secrets and
 remains before a final release. The reviewed security boundaries and residual
 risks are explicit in [THREAT_MODEL.md](THREAT_MODEL.md).
-View-once attachments are rejected until attachment consumption and deletion
-can be made atomic.
+View-once direct messages support encrypted attachments. An official client
+authenticates and caches the ciphertext before a first-device-wins consume;
+the server deletes every attachment chunk before acknowledging success, and
+the client permits only cache-backed ephemeral reveal before invalidating that
+cache on close. This limits ordinary replay across supported clients but is not
+DRM against a modified or compromised recipient device.
 
 ## Run Locally
 

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -15,6 +15,9 @@ The implemented slices provide:
 - a file-backed account store containing only SCRAM verifier material;
 - encrypted, account-and-endpoint-bound local device identity storage;
 - signed Ed25519/X25519 device enrollment, revocation, and safety numbers;
+- explicit per-device safety-number review persisted in the encrypted vault;
+  after the first verification, direct and group sends fail closed whenever
+  the active directory contains a new or changed unverified device;
 - direct-message keys wrapped independently for every active participant
   device;
 - XSalsa20-Poly1305 message payloads carried as WAMP CBOR binary fields;

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -173,6 +173,27 @@ characters, and use a password with at least twelve characters. Cleartext
 deployments must expose the endpoint through `wss://`; the included server
 configuration is not yet a production TLS deployment recipe.
 
+## Connect an MCP Client
+
+Sign in to WampApp, open the account menu, and select **Connect an AI
+service**. The app discovers the MCP and authentication routes from the
+authenticated WAMP session, derives their HTTP or HTTPS origin from the server
+address, and shows copyable endpoints. With the default local configuration
+they are `http://localhost:8080/mcp` and
+`http://localhost:8080/mcp/auth`.
+
+Configure an MCP client for Streamable HTTP or direct JSON at the displayed
+MCP endpoint. Obtain its access grant from the displayed authentication
+endpoint using the same WampApp username and password with WAMP-SCRAM. WampApp
+does not display, return, or copy the password, access token, or refresh token.
+
+Profile access is disabled by default. The user must enable it in the same
+panel before MCP tools can read the exact public-profile allowlist. Revocation
+takes effect immediately. Chats, messages, attachments, backups, devices,
+calls, encryption keys, and avatars are never included in the MCP profile
+surface. Use `wss://` so the derived endpoints use HTTPS outside loopback
+development.
+
 ## Build Beta Artifacts
 
 The platform packager creates a clean archive, SHA-256 checksum, and

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -112,6 +112,12 @@ installs the client on both, and keeps the router attached to the terminal:
 bin/run-wamp-app-lab
 ```
 
+After both clients launch, the lab brings the selected Simulator forward. When
+`scrcpy` is installed, it also opens a managed Android mirror so a headless AVD
+and the iOS client remain directly testable; otherwise use the Android emulator
+window. The mirror closes with the lab, while both emulators and installed apps
+remain available.
+
 Use `bin/run-wamp-app-lab --dry-run` to inspect device selection and commands
 without changing the machine. Lab account, mailbox, attachment, backup, call,
 push, and MCP-consent state persists under `.dart_tool/wamp_app_lab`; it never

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -35,6 +35,9 @@ The implemented slices provide:
   encrypted message and device vault;
 - a responsive Flutter onboarding, composer, history, sync, attachment picker,
   preview, and platform save flow;
+- account-wide system/light/dark themes plus local-only Standard, Ocean, and
+  Sunset bubble designs selected independently per chat, stored in the
+  encrypted vault, and recovered by encrypted local or remote backups;
 - five-minute encrypted voice notes recorded as mono 16 kHz PCM16 WAV, with
   private duration metadata, bounded memory, explicit cancellation, and
   authenticated playback on the existing WAMP attachment path;

--- a/examples/wamp_app/THREAT_MODEL.md
+++ b/examples/wamp_app/THREAT_MODEL.md
@@ -14,9 +14,10 @@ The design treats the router and application server as trusted for account
 authentication, authorization, availability, and device-directory delivery,
 but not for message, attachment, backup, or call-signaling plaintext. It
 protects content from passive network observers, storage disclosure, and an
-honest-but-curious service. It does not yet provide key transparency, a double
-ratchet, or a defense against an active server that substitutes an unverified
-participant device key.
+honest-but-curious service. It does not yet provide key transparency or a
+double ratchet. An active server can still substitute or equivocate about a
+device on first use unless users compare the displayed safety numbers through
+another trusted channel.
 
 ## Assets And Trust Boundaries
 
@@ -66,7 +67,12 @@ and push delivery timing. WampApp does not claim traffic-analysis resistance.
 - Device enrollment and revocation are caller-bound. Ed25519 signing and
   X25519 exchange keys are generated per device and private keys remain in the
   encrypted vault.
-- Safety numbers support out-of-band identity verification. There is no public
+- Safety numbers support explicit per-device out-of-band identity verification
+  and are retained only in the encrypted vault. Once any device for a contact
+  has been verified, direct and group encryption fails closed if the current
+  active directory contains any new or changed unverified device. Verification
+  re-fetches the device and requires the same fingerprint before committing.
+  First-contact sends remain trust-on-first-use because there is no public
   account discovery or key-transparency service. Contact import is opt-in and
   local: Android/iOS use the permissionless system picker without requesting
   properties, while other platforms use an explicit vCard. The parser decodes
@@ -124,6 +130,8 @@ and push delivery timing. WampApp does not claim traffic-analysis resistance.
    missing benchmark evidence fails closed.
 7. Contact import must not upload or retain phone numbers, email addresses,
    postal addresses, native contact IDs, or the selected address-book file.
+8. After explicit contact-device verification, no new direct or group content
+   key may be wrapped for an unverified active device of that contact.
 
 These invariants are covered by focused unit tests, real native-router consumer
 smokes, six-device conflict stress, real Chrome worker tests, cross-platform
@@ -136,10 +144,11 @@ artifact builds, and the production benchmark gate.
 - Static per-device exchange keys and independent per-message keys do not offer
   double-ratchet forward secrecy or post-compromise security. A stolen device
   private key can open retained wraps addressed to that device.
-- Without key transparency, an active server can attempt device-key
-  substitution. Out-of-band safety-number verification is the current
-  detection mechanism and must be made mandatory for stronger active-server
-  resistance.
+- Without key transparency, an active server can substitute a key on first use,
+  present different directories to different clients, or keep clients
+  partitioned. Out-of-band safety-number comparison is the current detection
+  mechanism. Post-verification continuity blocks later new or changed devices,
+  but first-contact sends remain allowed and there is no global auditable log.
 - A saved contact alias is convenience metadata, not proof of identity. The
   operating-system picker or file chooser observes the selection, and wiping
   WampApp's selected vCard bytes does not erase the source file outside the

--- a/examples/wamp_app/client/integration_test/support/rich_media_fixtures.dart
+++ b/examples/wamp_app/client/integration_test/support/rich_media_fixtures.dart
@@ -1,0 +1,129 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+const nativeVoiceNoteDurationMilliseconds = 2000;
+
+Uint8List nativeAnimatedGifBytes() => Uint8List.fromList([
+  0x47,
+  0x49,
+  0x46,
+  0x38,
+  0x39,
+  0x61,
+  0x01,
+  0x00,
+  0x01,
+  0x00,
+  0x80,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0xff,
+  0xff,
+  0xff,
+  0x21,
+  0xff,
+  0x0b,
+  0x4e,
+  0x45,
+  0x54,
+  0x53,
+  0x43,
+  0x41,
+  0x50,
+  0x45,
+  0x32,
+  0x2e,
+  0x30,
+  0x03,
+  0x01,
+  0x00,
+  0x00,
+  0x00,
+  0x21,
+  0xf9,
+  0x04,
+  0x00,
+  0x0a,
+  0x00,
+  0x00,
+  0x00,
+  0x2c,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x02,
+  0x02,
+  0x44,
+  0x01,
+  0x00,
+  0x21,
+  0xf9,
+  0x04,
+  0x00,
+  0x0a,
+  0x00,
+  0x00,
+  0x00,
+  0x2c,
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  0x01,
+  0x00,
+  0x01,
+  0x00,
+  0x00,
+  0x02,
+  0x02,
+  0x4c,
+  0x01,
+  0x00,
+  0x3b,
+]);
+
+Uint8List nativeVoiceNoteBytes() {
+  const sampleRate = 16000;
+  const channelCount = 1;
+  const bitsPerSample = 16;
+  const bytesPerSample = bitsPerSample ~/ 8;
+  const sampleCount = sampleRate * nativeVoiceNoteDurationMilliseconds ~/ 1000;
+  const payloadBytes = sampleCount * bytesPerSample;
+  final bytes = Uint8List(44 + payloadBytes);
+  final data = ByteData.view(bytes.buffer);
+
+  void writeAscii(int offset, String value) {
+    for (var index = 0; index < value.length; index += 1) {
+      bytes[offset + index] = value.codeUnitAt(index);
+    }
+  }
+
+  writeAscii(0, 'RIFF');
+  data.setUint32(4, 36 + payloadBytes, Endian.little);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  data.setUint32(16, 16, Endian.little);
+  data.setUint16(20, 1, Endian.little);
+  data.setUint16(22, channelCount, Endian.little);
+  data.setUint32(24, sampleRate, Endian.little);
+  data.setUint32(28, sampleRate * channelCount * bytesPerSample, Endian.little);
+  data.setUint16(32, channelCount * bytesPerSample, Endian.little);
+  data.setUint16(34, bitsPerSample, Endian.little);
+  writeAscii(36, 'data');
+  data.setUint32(40, payloadBytes, Endian.little);
+  for (var sample = 0; sample < sampleCount; sample += 1) {
+    final value = (math.sin(2 * math.pi * 440 * sample / sampleRate) * 10000)
+        .round();
+    data.setInt16(44 + (sample * bytesPerSample), value, Endian.little);
+  }
+  return bytes;
+}

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -33,13 +33,35 @@ const _videoCallReadyOutbound = String.fromEnvironment(
 const _videoCallReadyInbound = String.fromEnvironment(
   'WAMP_APP_SMOKE_VIDEO_READY_INBOUND',
 );
+const _profileDisplayName = String.fromEnvironment(
+  'WAMP_APP_SMOKE_PROFILE_DISPLAY_NAME',
+);
+const _profileStatus = String.fromEnvironment('WAMP_APP_SMOKE_PROFILE_STATUS');
+const _peerProfileDisplayName = String.fromEnvironment(
+  'WAMP_APP_SMOKE_PEER_PROFILE_DISPLAY_NAME',
+);
+const _peerProfileStatus = String.fromEnvironment(
+  'WAMP_APP_SMOKE_PEER_PROFILE_STATUS',
+);
+const _contactDisplayName = String.fromEnvironment(
+  'WAMP_APP_SMOKE_CONTACT_DISPLAY_NAME',
+);
+const _controlsReadyOutbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND',
+);
+const _controlsReadyInbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_CONTROLS_READY_INBOUND',
+);
+const _backupPassphrase = String.fromEnvironment(
+  'WAMP_APP_SMOKE_BACKUP_PASSPHRASE',
+);
 const _password = 'wamp-app-native-smoke-password';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'exchanges encrypted chat and completes WebRTC voice and video calls',
+    'exchanges encrypted chat, account controls, backup, and WebRTC calls',
     (tester) async {
       _validateConfiguration();
       final controller = WampAppController(deviceName: '$_username device');
@@ -166,9 +188,371 @@ void main() {
         readyOutbound: _videoCallReadyOutbound,
         readyInbound: _videoCallReadyInbound,
       );
+      await _exerciseAccountPrivacyControls(tester, controller);
     },
-    timeout: const Timeout(Duration(minutes: 15)),
+    timeout: const Timeout(Duration(minutes: 21)),
   );
+}
+
+Future<void> _exerciseAccountPrivacyControls(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  await _selectDirectConversation(tester);
+  await _updatePublicProfile(tester, controller);
+  await _setLocalConversationPreferences(tester, controller);
+  await _saveLocalContactAlias(tester, controller);
+  await _enableMcpProfileConsent(tester, controller);
+  if (_role == 'initiator') {
+    await _uploadRemoteBackup(tester, controller);
+  }
+
+  final sent = await controller.sendMessage(
+    recipientUsername: _peerUsername,
+    text: _controlsReadyOutbound,
+  );
+  if (!sent) {
+    fail(
+      'Could not send the account-controls marker '
+      '(${controller.messageError ?? 'message channel unavailable'}).',
+    );
+  }
+  final outbound = controller.messages.singleWhere(
+    (message) => message.outgoing && message.text == _controlsReadyOutbound,
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(outbound.messageId) == null &&
+        controller.messages.any(
+          (message) =>
+              !message.outgoing && message.text == _controlsReadyInbound,
+        ),
+    label: 'peer account-controls marker',
+    timeout: const Duration(minutes: 2),
+  );
+
+  await _viewPeerProfile(tester);
+  await _exerciseSearchAndReadFilters(tester, controller);
+}
+
+Future<void> _updatePublicProfile(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final edit = find.byKey(const Key('account-profile-edit'));
+  await _tapWhenReady(tester, edit, label: 'public-profile editor');
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('profile-save')).evaluate().isNotEmpty,
+    label: 'public-profile dialog',
+  );
+  await tester.enterText(
+    find.byKey(const Key('profile-display-name')),
+    _profileDisplayName,
+  );
+  await tester.enterText(
+    find.byKey(const Key('profile-status')),
+    _profileStatus,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('profile-save')),
+    label: 'public-profile save',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        find.byKey(const Key('profile-save')).evaluate().isEmpty &&
+        !controller.profileBusy &&
+        controller.connection?.profile.displayName == _profileDisplayName &&
+        controller.connection?.profile.status == _profileStatus,
+    label: 'persisted public profile',
+  );
+  expect(controller.profileError, isNull);
+}
+
+Future<void> _setLocalConversationPreferences(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final theme = find.byKey(const Key('account-theme-menu'));
+  await _tapWhenReady(tester, theme, label: 'appearance menu');
+  final dark = find.byKey(const ValueKey('appearance-dark'));
+  await _tapWhenReady(tester, dark, label: 'dark appearance');
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.preferenceBusy &&
+        controller.themePreference.wireName == 'dark' &&
+        tester.widget<MaterialApp>(find.byType(MaterialApp)).themeMode ==
+            ThemeMode.dark,
+    label: 'local dark appearance',
+  );
+
+  final conversationId = controller.directConversationIdFor(_peerUsername);
+  if (conversationId == null) {
+    fail('The direct conversation was unavailable for local preferences.');
+  }
+  final mute = find.byKey(const Key('conversation-mute'));
+  await _tapWhenReady(tester, mute, label: 'conversation mute');
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.preferenceBusy &&
+        controller.isConversationMuted(conversationId),
+    label: 'persisted local mute preference',
+  );
+
+  final expiry = find.byKey(const Key('message-expiry'));
+  await _tapWhenReady(tester, expiry, label: 'disappearing-message menu');
+  await _tapWhenReady(
+    tester,
+    find.text('Delete after 1 hour'),
+    label: 'one-hour disappearing-message policy',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.preferenceBusy &&
+        controller.disappearingMessagesFor(conversationId) ==
+            const Duration(hours: 1),
+    label: 'persisted disappearing-message policy',
+  );
+  expect(controller.preferenceError, isNull);
+}
+
+Future<void> _saveLocalContactAlias(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final compact = find.byKey(const Key('account-contacts-compact'));
+  final contacts = compact.evaluate().isNotEmpty
+      ? compact
+      : find.byKey(const Key('account-contacts'));
+  await _tapWhenReady(tester, contacts, label: 'local contact manager');
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('contact-save')).evaluate().isNotEmpty,
+    label: 'local contact dialog',
+  );
+  await tester.tap(find.byKey(const Key('contact-add-manual')));
+  await tester.enterText(
+    find.byKey(const Key('contact-display-name')),
+    _contactDisplayName,
+  );
+  await tester.enterText(
+    find.byKey(const Key('contact-username')),
+    _peerUsername,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('contact-save')),
+    label: 'verified local contact save',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.contactBusy &&
+        controller.contacts.any(
+          (contact) =>
+              contact.username == _peerUsername &&
+              contact.displayName == _contactDisplayName,
+        ),
+    label: 'encrypted local contact alias',
+  );
+  expect(controller.contactError, isNull);
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('contact-close')),
+    label: 'contact dialog close',
+  );
+}
+
+Future<void> _enableMcpProfileConsent(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('account-mcp-profile-consent')),
+    label: 'MCP profile consent',
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('mcp-profile-consent-confirm')),
+    label: 'MCP profile consent confirmation',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.mcpConsentBusy && controller.mcpConsent.profileReadAllowed,
+    label: 'persisted MCP profile consent',
+  );
+  expect(controller.mcpConsentError, isNull);
+}
+
+Future<void> _uploadRemoteBackup(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final compact = find.byKey(const Key('account-backup-compact'));
+  if (compact.evaluate().isNotEmpty) {
+    await _tapWhenReady(tester, compact, label: 'backup options');
+    await _tapWhenReady(
+      tester,
+      find.byKey(const Key('backup-action-remote')),
+      label: 'remote encrypted backup action',
+    );
+  } else {
+    await _tapWhenReady(
+      tester,
+      find.byKey(const Key('account-backup-remote')),
+      label: 'remote encrypted backup action',
+    );
+  }
+  await _pumpUntil(
+    tester,
+    () => find
+        .byKey(const Key('backup-recovery-confirmation'))
+        .evaluate()
+        .isNotEmpty,
+    label: 'backup recovery phrase dialog',
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-passphrase')),
+    _backupPassphrase,
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-confirmation')),
+    _backupPassphrase,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('backup-passphrase-submit')),
+    label: 'encrypted backup creation',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.backupBusy &&
+        find
+            .text('Encrypted backup stored on this server.')
+            .evaluate()
+            .isNotEmpty,
+    label: 'remote encrypted backup upload',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(controller.backupError, isNull);
+}
+
+Future<void> _viewPeerProfile(WidgetTester tester) async {
+  await _selectDirectConversation(tester);
+  final recipient = find.byKey(const Key('message-recipient'));
+  await tester.enterText(recipient, _peerUsername);
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('recipient-profile-view')),
+    label: 'peer public profile',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        find.text(_peerProfileDisplayName).evaluate().isNotEmpty &&
+        find.text(_peerProfileStatus).evaluate().isNotEmpty &&
+        find.byKey(const Key('peer-profile-status')).evaluate().isNotEmpty,
+    label: 'peer public-profile propagation',
+  );
+  await _tapWhenReady(tester, find.text('Close'), label: 'peer profile close');
+}
+
+Future<void> _exerciseSearchAndReadFilters(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final inbound = controller.messages.singleWhere(
+    (message) => !message.outgoing && message.text == _controlsReadyInbound,
+  );
+  final inboundBubble = find.byKey(
+    ValueKey('message-bubble-${inbound.messageId}'),
+  );
+  expect(inbound.readAt, isNull);
+  final search = find.byKey(const Key('message-global-search'));
+  await _tapWhenReady(tester, search, label: 'global message search');
+  await tester.enterText(search, _controlsReadyInbound);
+  await _pumpUntil(
+    tester,
+    () =>
+        find.text(_controlsReadyInbound).evaluate().isNotEmpty &&
+        inboundBubble.evaluate().length == 1,
+    label: 'global search result',
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await controller.markMessageRead(inbound.messageId);
+  await _pumpUntil(
+    tester,
+    () => controller.messages.any(
+      (message) =>
+          message.messageId == inbound.messageId && message.readAt != null,
+    ),
+    label: 'authenticated read receipt from search result',
+  );
+  await tester.enterText(search, '');
+  await tester.pump(const Duration(milliseconds: 400));
+
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('message-filter-read')),
+    label: 'read-message filter',
+  );
+  await _pumpUntil(
+    tester,
+    () => inboundBubble.evaluate().length == 1,
+    label: 'read-filter result',
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('message-filter-unread')),
+    label: 'unread-message filter',
+  );
+  await _pumpUntil(
+    tester,
+    () => inboundBubble.evaluate().isEmpty,
+    label: 'read message excluded from unread filter',
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('message-filter-all')),
+    label: 'all-message filter reset',
+  );
+  expect(controller.messageError, isNull);
+}
+
+Future<void> _tapWhenReady(
+  WidgetTester tester,
+  Finder finder, {
+  required String label,
+}) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 1));
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (finder.evaluate().length != 1) continue;
+    await tester.ensureVisible(finder);
+    await tester.pump();
+    if (finder.hitTestable().evaluate().length != 1) continue;
+    await tester.tap(finder);
+    return;
+  }
+  fail('Timed out waiting for $label.');
 }
 
 Future<void> _exerciseWebRtcCall(
@@ -806,6 +1190,14 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_CALL_READY_INBOUND': _voiceCallReadyInbound,
     'WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND': _videoCallReadyOutbound,
     'WAMP_APP_SMOKE_VIDEO_READY_INBOUND': _videoCallReadyInbound,
+    'WAMP_APP_SMOKE_PROFILE_DISPLAY_NAME': _profileDisplayName,
+    'WAMP_APP_SMOKE_PROFILE_STATUS': _profileStatus,
+    'WAMP_APP_SMOKE_PEER_PROFILE_DISPLAY_NAME': _peerProfileDisplayName,
+    'WAMP_APP_SMOKE_PEER_PROFILE_STATUS': _peerProfileStatus,
+    'WAMP_APP_SMOKE_CONTACT_DISPLAY_NAME': _contactDisplayName,
+    'WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND': _controlsReadyOutbound,
+    'WAMP_APP_SMOKE_CONTROLS_READY_INBOUND': _controlsReadyInbound,
+    'WAMP_APP_SMOKE_BACKUP_PASSPHRASE': _backupPassphrase,
   };
   for (final entry in values.entries) {
     if (entry.value.trim().isEmpty) {
@@ -825,10 +1217,15 @@ void _validateConfiguration() {
     _voiceCallReadyInbound,
     _videoCallReadyOutbound,
     _videoCallReadyInbound,
+    _controlsReadyOutbound,
+    _controlsReadyInbound,
   ];
   if (_username == _peerUsername ||
       messageTokens.toSet().length != messageTokens.length) {
     fail('The two smoke clients must use distinct identities and messages.');
+  }
+  if (_backupPassphrase.length < 16) {
+    fail('WAMP_APP_SMOKE_BACKUP_PASSPHRASE must be at least 16 characters.');
   }
 }
 

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -19,13 +19,14 @@ const _groupOutboundText = String.fromEnvironment(
 const _groupInboundText = String.fromEnvironment(
   'WAMP_APP_SMOKE_GROUP_INBOUND',
 );
+const _oneTimeText = String.fromEnvironment('WAMP_APP_SMOKE_VIEW_ONCE');
 const _password = 'wamp-app-native-smoke-password';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'exchanges encrypted direct, group, and sticker messages with the peer',
+    'exchanges encrypted direct, group, sticker, and view-once messages',
     (tester) async {
       _validateConfiguration();
       final controller = WampAppController(deviceName: '$_username device');
@@ -137,8 +138,9 @@ void main() {
       );
 
       await _exerciseEncryptedGroupSticker(tester, controller);
+      await _exerciseViewOnceMessage(tester, controller);
     },
-    timeout: const Timeout(Duration(minutes: 5)),
+    timeout: const Timeout(Duration(minutes: 7)),
   );
 }
 
@@ -394,6 +396,159 @@ Future<void> _receiveStickerAndReply(
   expect(controller.messageError, isNull);
 }
 
+Future<void> _exerciseViewOnceMessage(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  await _selectDirectConversation(tester);
+  if (_role == 'initiator') {
+    await _sendViewOnceMessage(tester, controller);
+    return;
+  }
+  await _receiveViewOnceMessage(tester, controller);
+}
+
+Future<void> _selectDirectConversation(WidgetTester tester) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump();
+  final direct = find.byKey(const Key('conversation-direct'));
+  await tester.ensureVisible(direct);
+  await tester.tap(direct);
+  await _pumpUntil(
+    tester,
+    () =>
+        direct.evaluate().length == 1 &&
+        tester.widget<ChoiceChip>(direct).selected &&
+        find.byKey(const Key('message-recipient')).evaluate().isNotEmpty,
+    label: 'selected direct conversation',
+  );
+  final recipient = find.byKey(const Key('message-recipient'));
+  await tester.ensureVisible(recipient);
+  await tester.enterText(recipient, _peerUsername);
+  FocusManager.instance.primaryFocus?.unfocus();
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('message-one-time')).evaluate().isNotEmpty,
+    label: 'restored direct-message controls',
+  );
+}
+
+Future<void> _sendViewOnceMessage(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final oneTime = find.byKey(const Key('message-one-time'));
+  await tester.ensureVisible(oneTime);
+  await tester.tap(oneTime);
+  await _pumpUntil(
+    tester,
+    () =>
+        oneTime.evaluate().length == 1 &&
+        tester.widget<FilterChip>(oneTime).selected,
+    label: 'enabled view-once mode',
+  );
+
+  final composer = find.byKey(const Key('message-composer'));
+  await _enterMessageWhenReady(
+    tester,
+    composer,
+    _oneTimeText,
+    label: 'view-once composer',
+  );
+  final send = find.byKey(const Key('message-send'));
+  await _tapSendAndWait(
+    tester,
+    controller,
+    send,
+    () => controller.messages.any(_matchesOutboundViewOnce),
+    label: 'encrypted view-once send',
+  );
+  final outbound = controller.messages.singleWhere(_matchesOutboundViewOnce);
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(outbound.messageId) == null &&
+        controller.messageError == null,
+    label: 'router acceptance of view-once message',
+    timeout: const Duration(minutes: 2),
+  );
+  await _pumpUntil(
+    tester,
+    () => controller.messages.any(
+      (message) =>
+          message.messageId == outbound.messageId && message.readAt != null,
+    ),
+    label: 'view-once open receipt',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(controller.messageError, isNull);
+}
+
+Future<void> _receiveViewOnceMessage(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  LocalChatMessage? received;
+  await _pumpUntil(
+    tester,
+    () {
+      for (final message in controller.messages) {
+        if (!message.outgoing &&
+            !message.isGroup &&
+            message.peerUsername == _peerUsername &&
+            message.oneTime &&
+            message.text == _oneTimeText) {
+          received = message;
+          return true;
+        }
+      }
+      return false;
+    },
+    label: 'decrypted inbound view-once message',
+    timeout: const Duration(minutes: 2),
+  );
+  final viewOnce = received!;
+  expect(find.text(_oneTimeText), findsNothing);
+
+  final reveal = find.byKey(
+    ValueKey('message-view-once-${viewOnce.messageId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => reveal.evaluate().isNotEmpty,
+    label: 'hidden view-once message',
+  );
+  await tester.ensureVisible(reveal);
+  await tester.tap(reveal);
+  final content = find.byKey(const Key('one-time-message-content'));
+  await _pumpUntil(
+    tester,
+    () => content.evaluate().isNotEmpty,
+    label: 'revealed view-once dialog',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(find.text(_oneTimeText), findsOneWidget);
+  await tester.tap(find.widgetWithText(TextButton, 'Close'));
+  await _pumpUntil(
+    tester,
+    () =>
+        content.evaluate().isEmpty &&
+        !controller.messages.any(
+          (message) => message.messageId == viewOnce.messageId,
+        ),
+    label: 'consumed view-once removal',
+  );
+  expect(find.text(_oneTimeText), findsNothing);
+  expect(controller.messageError, isNull);
+}
+
+bool _matchesOutboundViewOnce(LocalChatMessage message) =>
+    message.outgoing &&
+    !message.isGroup &&
+    message.peerUsername == _peerUsername &&
+    message.oneTime &&
+    message.text == _oneTimeText;
+
 bool _matchesGroupMessage(
   LocalChatMessage message, {
   required bool outgoing,
@@ -442,6 +597,7 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_GROUP_TITLE': _groupTitle,
     'WAMP_APP_SMOKE_GROUP_OUTBOUND': _groupOutboundText,
     'WAMP_APP_SMOKE_GROUP_INBOUND': _groupInboundText,
+    'WAMP_APP_SMOKE_VIEW_ONCE': _oneTimeText,
   };
   for (final entry in values.entries) {
     if (entry.value.trim().isEmpty) {
@@ -456,6 +612,7 @@ void _validateConfiguration() {
     _inboundText,
     _groupOutboundText,
     _groupInboundText,
+    _oneTimeText,
   ];
   if (_username == _peerUsername ||
       messageTokens.toSet().length != messageTokens.length) {

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -3,19 +3,29 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:wamp_app/src/app.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
+import 'package:wamp_app/src/domain/local_chat_message.dart';
+import 'package:wamp_app_protocol/wamp_app_protocol.dart';
 
 const _serverAddress = String.fromEnvironment('WAMP_APP_SERVER_ADDRESS');
 const _username = String.fromEnvironment('WAMP_APP_SMOKE_USERNAME');
 const _peerUsername = String.fromEnvironment('WAMP_APP_SMOKE_PEER');
 const _outboundText = String.fromEnvironment('WAMP_APP_SMOKE_OUTBOUND');
 const _inboundText = String.fromEnvironment('WAMP_APP_SMOKE_INBOUND');
+const _role = String.fromEnvironment('WAMP_APP_SMOKE_ROLE');
+const _groupTitle = String.fromEnvironment('WAMP_APP_SMOKE_GROUP_TITLE');
+const _groupOutboundText = String.fromEnvironment(
+  'WAMP_APP_SMOKE_GROUP_OUTBOUND',
+);
+const _groupInboundText = String.fromEnvironment(
+  'WAMP_APP_SMOKE_GROUP_INBOUND',
+);
 const _password = 'wamp-app-native-smoke-password';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'registers and exchanges an encrypted message with the peer device',
+    'exchanges encrypted direct, group, and sticker messages with the peer',
     (tester) async {
       _validateConfiguration();
       final controller = WampAppController(deviceName: '$_username device');
@@ -58,11 +68,15 @@ void main() {
       await tester.ensureVisible(recipient);
       await tester.enterText(recipient, _peerUsername);
       await tester.pump();
-      await tester.ensureVisible(composer);
-      await tester.enterText(composer, _outboundText);
+      await _enterMessageWhenReady(
+        tester,
+        composer,
+        _outboundText,
+        label: 'direct-message composer',
+      );
       final send = find.byKey(const Key('message-send'));
       await tester.ensureVisible(send);
-      await _tapSendUntilOutbound(tester, controller, send);
+      await _tapSendAndWaitOutbound(tester, controller, send);
       final outbound = controller.messages.singleWhere(
         (message) =>
             message.outgoing &&
@@ -121,8 +135,299 @@ void main() {
         inboundRendered || find.text(_inboundText).evaluate().isNotEmpty,
         isTrue,
       );
+
+      await _exerciseEncryptedGroupSticker(tester, controller);
     },
     timeout: const Timeout(Duration(minutes: 5)),
+  );
+}
+
+Future<void> _exerciseEncryptedGroupSticker(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump();
+  if (_role == 'initiator') {
+    await _createGroupAndSendSticker(tester, controller);
+    return;
+  }
+  await _receiveStickerAndReply(tester, controller);
+}
+
+Future<void> _createGroupAndSendSticker(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final createGroup = find.byKey(const Key('conversation-create-group'));
+  await tester.ensureVisible(createGroup);
+  await tester.tap(createGroup);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('group-create')).evaluate().isNotEmpty,
+    label: 'group creation dialog',
+  );
+  await tester.enterText(find.byKey(const Key('group-title')), _groupTitle);
+  await tester.enterText(find.byKey(const Key('group-members')), _peerUsername);
+  await tester.tap(find.byKey(const Key('group-create')));
+
+  await _pumpUntil(
+    tester,
+    () => controller.groups.any(
+      (group) =>
+          group.title == _groupTitle &&
+          group.memberUsernames.contains(_username) &&
+          group.memberUsernames.contains(_peerUsername),
+    ),
+    label: 'local encrypted group creation',
+  );
+  final group = controller.groups.singleWhere(
+    (group) => group.title == _groupTitle,
+  );
+  final groupChip = find.byKey(
+    ValueKey('conversation-group-${group.conversationId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        groupChip.evaluate().isNotEmpty &&
+        find.byKey(const Key('group-members-summary')).evaluate().isNotEmpty,
+    label: 'selected group conversation',
+  );
+
+  final expression = find.byKey(const Key('message-expression'));
+  await tester.ensureVisible(expression);
+  await tester.tap(expression);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('expression-sticker-tab')).evaluate().isNotEmpty,
+    label: 'expression picker',
+  );
+  await tester.tap(find.byKey(const Key('expression-sticker-tab')));
+  await tester.pump(const Duration(milliseconds: 400));
+  final sticker = find.byKey(const ValueKey('sticker-nice'));
+  await tester.ensureVisible(sticker);
+  await tester.tap(sticker);
+  await _pumpUntil(
+    tester,
+    () =>
+        find.byKey(const Key('expression-close')).evaluate().isEmpty &&
+        find.byKey(const Key('selected-attachment-0')).evaluate().isNotEmpty,
+    label: 'staged bundled sticker',
+  );
+
+  final composer = find.byKey(const Key('message-composer'));
+  await _enterMessageWhenReady(
+    tester,
+    composer,
+    _groupOutboundText,
+    label: 'group sticker composer',
+  );
+  final send = find.byKey(const Key('message-send'));
+  await tester.ensureVisible(send);
+  await _tapSendAndWait(
+    tester,
+    controller,
+    send,
+    () => controller.messages.any(
+      (message) =>
+          _matchesGroupMessage(
+            message,
+            outgoing: true,
+            text: _groupOutboundText,
+          ) &&
+          message.attachments.length == 1 &&
+          message.attachments.single.kind == ChatAttachmentKind.sticker,
+    ),
+    label: 'encrypted group sticker send',
+  );
+  final outbound = controller.messages.singleWhere(
+    (message) =>
+        _matchesGroupMessage(
+          message,
+          outgoing: true,
+          text: _groupOutboundText,
+        ) &&
+        message.attachments.length == 1,
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(outbound.messageId) == null &&
+        controller.messageError == null,
+    label: 'router acceptance of encrypted group sticker',
+    timeout: const Duration(minutes: 2),
+  );
+  await _pumpUntil(
+    tester,
+    () => controller.messages.any(
+      (message) => _matchesGroupMessage(
+        message,
+        outgoing: false,
+        text: _groupInboundText,
+      ),
+    ),
+    label: 'decrypted same-group reply',
+    timeout: const Duration(minutes: 2),
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await _pumpUntil(
+    tester,
+    () => find.text(_groupInboundText).evaluate().isNotEmpty,
+    label: 'rendered same-group reply',
+  );
+  expect(controller.messageError, isNull);
+}
+
+Future<void> _receiveStickerAndReply(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  LocalChatMessage? received;
+  await _pumpUntil(
+    tester,
+    () {
+      for (final message in controller.messages) {
+        if (_matchesGroupMessage(
+              message,
+              outgoing: false,
+              text: _groupInboundText,
+            ) &&
+            message.attachments.length == 1 &&
+            message.attachments.single.kind == ChatAttachmentKind.sticker) {
+          received = message;
+          return true;
+        }
+      }
+      return false;
+    },
+    label: 'decrypted inbound group sticker',
+    timeout: const Duration(minutes: 2),
+  );
+  final groupMessage = received!;
+  final group = controller.groups.singleWhere(
+    (group) => group.conversationId == groupMessage.conversationId,
+  );
+  expect(group.title, _groupTitle);
+  expect(group.memberUsernames, containsAll([_username, _peerUsername]));
+
+  final groupChip = find.byKey(
+    ValueKey('conversation-group-${group.conversationId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => groupChip.evaluate().isNotEmpty,
+    label: 'discovered group conversation chip',
+  );
+  await tester.ensureVisible(groupChip);
+  await tester.tap(groupChip);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.widget<ChoiceChip>(groupChip).selected &&
+        find.byKey(const Key('group-members-summary')).evaluate().isNotEmpty,
+    label: 'selected discovered group',
+  );
+
+  final attachment = groupMessage.attachments.single;
+  final attachmentCard = find.byKey(
+    ValueKey('attachment-open-${attachment.attachmentId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => attachmentCard.evaluate().isNotEmpty,
+    label: 'rendered encrypted sticker attachment card',
+  );
+  await tester.ensureVisible(attachmentCard);
+  await tester.tap(attachmentCard);
+  final preview = find.byKey(
+    ValueKey('attachment-preview-${attachment.attachmentId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => preview.evaluate().isNotEmpty,
+    label: 'downloaded and decrypted sticker preview',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(preview, findsOneWidget);
+  await tester.tap(find.widgetWithText(FilledButton, 'Close'));
+  await _pumpUntil(
+    tester,
+    () => preview.evaluate().isEmpty,
+    label: 'closed sticker preview',
+  );
+
+  final composer = find.byKey(const Key('message-composer'));
+  await _enterMessageWhenReady(
+    tester,
+    composer,
+    _groupOutboundText,
+    label: 'group reply composer',
+  );
+  final send = find.byKey(const Key('message-send'));
+  await tester.ensureVisible(send);
+  await _tapSendAndWait(
+    tester,
+    controller,
+    send,
+    () => controller.messages.any(
+      (message) => _matchesGroupMessage(
+        message,
+        outgoing: true,
+        text: _groupOutboundText,
+      ),
+    ),
+    label: 'same-group encrypted reply send',
+  );
+  final reply = controller.messages.singleWhere(
+    (message) =>
+        _matchesGroupMessage(message, outgoing: true, text: _groupOutboundText),
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(reply.messageId) == null &&
+        controller.messageError == null,
+    label: 'router acceptance of same-group reply',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(controller.messageError, isNull);
+}
+
+bool _matchesGroupMessage(
+  LocalChatMessage message, {
+  required bool outgoing,
+  required String text,
+}) =>
+    message.outgoing == outgoing &&
+    message.isGroup &&
+    message.groupTitle == _groupTitle &&
+    message.text == text;
+
+Future<void> _enterMessageWhenReady(
+  WidgetTester tester,
+  Finder composer,
+  String text, {
+  required String label,
+}) async {
+  await _pumpUntil(
+    tester,
+    () =>
+        composer.evaluate().length == 1 &&
+        composer.hitTestable().evaluate().length == 1 &&
+        tester.widget<TextField>(composer).enabled != false,
+    label: '$label readiness',
+  );
+  await tester.ensureVisible(composer);
+  await tester.tap(composer);
+  await tester.pump(const Duration(milliseconds: 100));
+  await tester.showKeyboard(composer);
+  await tester.enterText(composer, text);
+  await tester.pump();
+  expect(
+    tester.widget<TextField>(composer).controller?.text,
+    text,
+    reason: '$label must accept the smoke message.',
   );
 }
 
@@ -133,23 +438,36 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_PEER': _peerUsername,
     'WAMP_APP_SMOKE_OUTBOUND': _outboundText,
     'WAMP_APP_SMOKE_INBOUND': _inboundText,
+    'WAMP_APP_SMOKE_ROLE': _role,
+    'WAMP_APP_SMOKE_GROUP_TITLE': _groupTitle,
+    'WAMP_APP_SMOKE_GROUP_OUTBOUND': _groupOutboundText,
+    'WAMP_APP_SMOKE_GROUP_INBOUND': _groupInboundText,
   };
   for (final entry in values.entries) {
     if (entry.value.trim().isEmpty) {
       fail('${entry.key} must be provided for the two-device smoke.');
     }
   }
-  if (_username == _peerUsername || _outboundText == _inboundText) {
+  if (_role != 'initiator' && _role != 'responder') {
+    fail('WAMP_APP_SMOKE_ROLE must be initiator or responder.');
+  }
+  final messageTokens = [
+    _outboundText,
+    _inboundText,
+    _groupOutboundText,
+    _groupInboundText,
+  ];
+  if (_username == _peerUsername ||
+      messageTokens.toSet().length != messageTokens.length) {
     fail('The two smoke clients must use distinct identities and messages.');
   }
 }
 
-Future<void> _tapSendUntilOutbound(
+Future<void> _tapSendAndWaitOutbound(
   WidgetTester tester,
   WampAppController controller,
   Finder send,
 ) async {
-  final deadline = DateTime.now().add(const Duration(minutes: 1));
   bool hasOutbound() => controller.messages.any(
     (message) =>
         message.outgoing &&
@@ -157,15 +475,66 @@ Future<void> _tapSendUntilOutbound(
         message.text == _outboundText,
   );
 
-  while (DateTime.now().isBefore(deadline)) {
+  await _tapSendAndWait(
+    tester,
+    controller,
+    send,
+    hasOutbound,
+    label: 'successful encrypted direct-message tap',
+  );
+}
+
+Future<void> _tapSendAndWait(
+  WidgetTester tester,
+  WampAppController controller,
+  Finder send,
+  bool Function() accepted, {
+  required String label,
+}) async {
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await tester.ensureVisible(send);
+  DateTime? readySince;
+  final readyDeadline = DateTime.now().add(const Duration(minutes: 1));
+  while (DateTime.now().isBefore(readyDeadline)) {
     await tester.pump(const Duration(milliseconds: 100));
-    if (hasOutbound()) return;
-    if (tester.widget<IconButton>(send).onPressed != null) {
-      await tester.tap(send, warnIfMissed: false);
+    final ready =
+        send.evaluate().length == 1 &&
+        send.hitTestable().evaluate().length == 1 &&
+        tester.widget<IconButton>(send).onPressed != null;
+    if (!ready) {
+      readySince = null;
+      continue;
+    }
+    readySince ??= DateTime.now();
+    if (DateTime.now().difference(readySince) >=
+        const Duration(milliseconds: 500)) {
+      break;
     }
   }
-  fail('Timed out waiting for a successful encrypted-message tap.');
+  if (readySince == null ||
+      DateTime.now().difference(readySince) <
+          const Duration(milliseconds: 500)) {
+    fail(
+      'Timed out waiting for $label readiness (${_messageState(controller)}).',
+    );
+  }
+  await tester.tap(send);
+  final acceptedDeadline = DateTime.now().add(const Duration(minutes: 1));
+  while (DateTime.now().isBefore(acceptedDeadline)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (accepted()) return;
+    if (!controller.messageBusy && controller.messageError != null) {
+      fail('$label failed (${_messageState(controller)}).');
+    }
+  }
+  fail('Timed out waiting for $label (${_messageState(controller)}).');
 }
+
+String _messageState(WampAppController controller) =>
+    'busy=${controller.messageBusy}, error=${controller.messageError}, '
+    'groups=${controller.groups.length}, '
+    'outgoingGroups=${controller.messages.where((message) => message.outgoing && message.isGroup).length}';
 
 Future<void> _waitForPeerDevice(
   WidgetTester tester,

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -8,10 +8,54 @@ import 'package:wamp_app/src/application/call_controller.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
+import 'package:wamp_app/src/infrastructure/device_vault.dart';
+import 'package:wamp_app/src/infrastructure/vault_storage.dart';
 import 'package:wamp_app/src/ui/expression_picker.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
 
 import 'support/rich_media_fixtures.dart';
+
+final class _TrackedVaultStorage implements VaultStorage {
+  _TrackedVaultStorage({VaultStorage? delegate})
+    : _delegate = delegate ?? SharedPreferencesVaultStorage();
+
+  final VaultStorage _delegate;
+  final Set<String> _trackedKeys = <String>{};
+
+  int get trackedKeyCount => _trackedKeys.length;
+
+  @override
+  Future<String?> read(String key) {
+    _trackedKeys.add(key);
+    return _delegate.read(key);
+  }
+
+  @override
+  Future<void> write(String key, String value) {
+    _trackedKeys.add(key);
+    return _delegate.write(key, value);
+  }
+
+  @override
+  Future<void> delete(String key) {
+    _trackedKeys.add(key);
+    return _delegate.delete(key);
+  }
+
+  Future<void> deleteTrackedAndVerify() async {
+    if (_trackedKeys.isEmpty) {
+      throw StateError('No encrypted local vault keys were tracked.');
+    }
+    for (final key in _trackedKeys) {
+      if (await _delegate.read(key) != null) {
+        await _delegate.delete(key);
+      }
+      if (await _delegate.read(key) != null) {
+        throw StateError('Encrypted local vault deletion failed.');
+      }
+    }
+  }
+}
 
 const _serverAddress = String.fromEnvironment('WAMP_APP_SERVER_ADDRESS');
 const _username = String.fromEnvironment('WAMP_APP_SMOKE_USERNAME');
@@ -61,6 +105,12 @@ const _controlsReadyInbound = String.fromEnvironment(
 const _backupPassphrase = String.fromEnvironment(
   'WAMP_APP_SMOKE_BACKUP_PASSPHRASE',
 );
+const _backupRestoredOutbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND',
+);
+const _backupRestoredInbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND',
+);
 const _richMediaToken = String.fromEnvironment('WAMP_APP_SMOKE_RICH_MEDIA');
 const _richMediaText = '$_richMediaToken 🚀';
 const _richMediaAck = String.fromEnvironment('WAMP_APP_SMOKE_RICH_MEDIA_ACK');
@@ -70,10 +120,14 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'exchanges encrypted chat, rich media, controls, backup, and WebRTC calls',
+    'exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls',
     (tester) async {
       _validateConfiguration();
-      final controller = WampAppController(deviceName: '$_username device');
+      final vaultStorage = _TrackedVaultStorage();
+      final controller = WampAppController(
+        trustStore: EncryptedDeviceVault(storage: vaultStorage),
+        deviceName: '$_username device',
+      );
       addTearDown(controller.dispose);
 
       await tester.pumpWidget(WampApp(controller: controller));
@@ -198,15 +252,16 @@ void main() {
         readyOutbound: _videoCallReadyOutbound,
         readyInbound: _videoCallReadyInbound,
       );
-      await _exerciseAccountPrivacyControls(tester, controller);
+      await _exerciseAccountPrivacyControls(tester, controller, vaultStorage);
     },
-    timeout: const Timeout(Duration(minutes: 21)),
+    timeout: const Timeout(Duration(minutes: 24)),
   );
 }
 
 Future<void> _exerciseAccountPrivacyControls(
   WidgetTester tester,
   WampAppController controller,
+  _TrackedVaultStorage vaultStorage,
 ) async {
   await _selectDirectConversation(tester);
   await _updatePublicProfile(tester, controller);
@@ -244,6 +299,14 @@ Future<void> _exerciseAccountPrivacyControls(
 
   await _viewPeerProfile(tester);
   await _exerciseSearchAndReadFilters(tester, controller);
+  if (_role == 'initiator') {
+    await _restoreRemoteBackupAfterLocalVaultDeletion(
+      tester,
+      controller,
+      vaultStorage,
+    );
+  }
+  await _exchangeBackupRecoveryMarkers(tester, controller);
 }
 
 Future<void> _updatePublicProfile(
@@ -460,6 +523,167 @@ Future<void> _uploadRemoteBackup(
     timeout: const Duration(minutes: 2),
   );
   expect(controller.backupError, isNull);
+}
+
+Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
+  WidgetTester tester,
+  WampAppController controller,
+  _TrackedVaultStorage vaultStorage,
+) async {
+  final originalDeviceId = controller.localDevice?.deviceId;
+  if (originalDeviceId == null) {
+    fail('The encrypted backup source device was unavailable.');
+  }
+  expect(vaultStorage.trackedKeyCount, greaterThan(0));
+
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('account-sign-out-compact')),
+    label: 'backup recovery sign out',
+  );
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
+    label: 'signed-out backup recovery form',
+  );
+  await controller.signOut();
+  await vaultStorage.deleteTrackedAndVerify();
+
+  await _tapWhenReady(tester, find.text('Sign in'), label: 'sign-in mode');
+  await tester.enterText(
+    find.byKey(const Key('server-address')),
+    _serverAddress,
+  );
+  await tester.enterText(find.byKey(const Key('username')), _username);
+  await tester.enterText(find.byKey(const Key('password')), _password);
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('restore-remote-backup')),
+    label: 'remote backup restore action',
+  );
+  await _pumpUntil(
+    tester,
+    () => find
+        .byKey(const Key('backup-recovery-passphrase'))
+        .evaluate()
+        .isNotEmpty,
+    label: 'remote backup recovery phrase dialog',
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-passphrase')),
+    _backupPassphrase,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('backup-passphrase-submit')),
+    label: 'remote backup recovery',
+  );
+
+  await _pumpUntil(
+    tester,
+    () {
+      final conversationId = controller.directConversationIdFor(_peerUsername);
+      return controller.status == WampAppStatus.connected &&
+          controller.connection?.username == _username &&
+          controller.localDevice?.deviceId == originalDeviceId &&
+          controller.themePreference.wireName == 'dark' &&
+          conversationId != null &&
+          controller.isConversationMuted(conversationId) &&
+          controller.disappearingMessagesFor(conversationId) ==
+              const Duration(hours: 1) &&
+          controller.contacts.any(
+            (contact) =>
+                contact.username == _peerUsername &&
+                contact.displayName == _contactDisplayName,
+          ) &&
+          controller.groups.any((group) => group.title == _groupTitle) &&
+          controller.messages.any(
+            (message) =>
+                message.peerUsername == _peerUsername &&
+                message.text == _outboundText,
+          ) &&
+          controller.messages.any(
+            (message) =>
+                message.peerUsername == _peerUsername &&
+                message.text == _inboundText,
+          ) &&
+          controller.messages.any(
+            (message) => _matchesGroupMessage(
+              message,
+              outgoing: true,
+              text: _groupOutboundText,
+            ),
+          ) &&
+          controller.messages.any(
+            (message) => _matchesGroupMessage(
+              message,
+              outgoing: false,
+              text: _groupInboundText,
+            ),
+          );
+    },
+    label: 'destructive encrypted cloud-backup recovery',
+    timeout: const Duration(minutes: 3),
+  );
+  expect(controller.backupError, isNull);
+  expect(controller.messageError, isNull);
+  expect(
+    tester.widget<MaterialApp>(find.byType(MaterialApp)).themeMode,
+    ThemeMode.dark,
+  );
+}
+
+Future<void> _exchangeBackupRecoveryMarkers(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  if (_role == 'responder') {
+    await _pumpUntil(
+      tester,
+      () => controller.messages.any(
+        (message) =>
+            !message.outgoing && message.text == _backupRestoredInbound,
+      ),
+      label: 'peer destructive backup recovery marker',
+      timeout: const Duration(minutes: 3),
+    );
+  }
+
+  final sent = await controller.sendMessage(
+    recipientUsername: _peerUsername,
+    text: _backupRestoredOutbound,
+  );
+  if (!sent) {
+    fail(
+      'Could not send the backup-recovery marker '
+      '(${controller.messageError ?? 'message channel unavailable'}).',
+    );
+  }
+  final outbound = controller.messages.singleWhere(
+    (message) => message.outgoing && message.text == _backupRestoredOutbound,
+  );
+  await _pumpUntil(
+    tester,
+    () => controller.outboundMessageFor(outbound.messageId) == null,
+    label: 'router acceptance of backup-recovery marker',
+  );
+
+  if (_role == 'initiator') {
+    await _pumpUntil(
+      tester,
+      () => controller.messages.any(
+        (message) =>
+            !message.outgoing && message.text == _backupRestoredInbound,
+      ),
+      label: 'post-recovery encrypted peer acknowledgement',
+      timeout: const Duration(minutes: 2),
+    );
+  }
+  expect(controller.messageError, isNull);
 }
 
 Future<void> _viewPeerProfile(WidgetTester tester) async {
@@ -1470,6 +1694,8 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND': _controlsReadyOutbound,
     'WAMP_APP_SMOKE_CONTROLS_READY_INBOUND': _controlsReadyInbound,
     'WAMP_APP_SMOKE_BACKUP_PASSPHRASE': _backupPassphrase,
+    'WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND': _backupRestoredOutbound,
+    'WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND': _backupRestoredInbound,
     'WAMP_APP_SMOKE_RICH_MEDIA': _richMediaToken,
     'WAMP_APP_SMOKE_RICH_MEDIA_ACK': _richMediaAck,
   };
@@ -1493,6 +1719,8 @@ void _validateConfiguration() {
     _videoCallReadyInbound,
     _controlsReadyOutbound,
     _controlsReadyInbound,
+    _backupRestoredOutbound,
+    _backupRestoredInbound,
     _richMediaText,
     _richMediaAck,
   ];

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -15,6 +15,7 @@ import 'package:wamp_app/src/infrastructure/device_backup_file.dart';
 import 'package:wamp_app/src/infrastructure/device_vault.dart';
 import 'package:wamp_app/src/infrastructure/profile_avatar_picker.dart';
 import 'package:wamp_app/src/infrastructure/vault_storage.dart';
+import 'package:wamp_app/src/infrastructure/wamp_account_gateway.dart';
 import 'package:wamp_app/src/ui/expression_picker.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
 
@@ -1898,6 +1899,28 @@ Future<void> _sendViewOnceMessage(
     label: 'enabled view-once mode',
   );
 
+  final expression = find.byKey(const Key('message-expression'));
+  await tester.ensureVisible(expression);
+  await tester.tap(expression);
+  final stickerTab = find.byKey(const Key('expression-sticker-tab'));
+  await _pumpUntil(
+    tester,
+    () => stickerTab.hitTestable().evaluate().isNotEmpty,
+    label: 'view-once expression picker',
+  );
+  await tester.tap(stickerTab);
+  await tester.pump(const Duration(milliseconds: 400));
+  final sticker = find.byKey(const ValueKey('sticker-nice'));
+  await tester.ensureVisible(sticker);
+  await tester.tap(sticker);
+  await _pumpUntil(
+    tester,
+    () =>
+        find.byKey(const Key('expression-close')).evaluate().isEmpty &&
+        find.byKey(const Key('selected-attachment-0')).evaluate().isNotEmpty,
+    label: 'staged encrypted view-once sticker',
+  );
+
   final composer = find.byKey(const Key('message-composer'));
   await _enterMessageWhenReady(
     tester,
@@ -1958,7 +1981,14 @@ Future<void> _receiveViewOnceMessage(
     timeout: const Duration(minutes: 2),
   );
   final viewOnce = received!;
+  final attachment = viewOnce.attachments.single;
+  expect(attachment.kind, ChatAttachmentKind.sticker);
   expect(find.text(_oneTimeText), findsNothing);
+  expect(find.text(attachment.name), findsNothing);
+  expect(
+    find.byKey(ValueKey('attachment-open-${attachment.attachmentId}')),
+    findsNothing,
+  );
 
   final historyScrollable = find.descendant(
     of: find.byKey(const Key('message-history')),
@@ -1986,6 +2016,27 @@ Future<void> _receiveViewOnceMessage(
     timeout: const Duration(minutes: 2),
   );
   expect(find.text(_oneTimeText), findsOneWidget);
+  expect(find.text(attachment.name), findsOneWidget);
+  final attachmentCard = find.byKey(
+    ValueKey('attachment-open-${attachment.attachmentId}'),
+  );
+  await tester.ensureVisible(attachmentCard);
+  await tester.tap(attachmentCard);
+  final preview = find.byKey(
+    ValueKey('attachment-preview-${attachment.attachmentId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => preview.evaluate().isNotEmpty,
+    label: 'decrypted view-once sticker preview',
+    timeout: const Duration(minutes: 2),
+  );
+  await tester.tap(find.widgetWithText(FilledButton, 'Close'));
+  await _pumpUntil(
+    tester,
+    () => preview.evaluate().isEmpty,
+    label: 'closed view-once sticker preview',
+  );
   await tester.tap(find.widgetWithText(TextButton, 'Close'));
   await _pumpUntil(
     tester,
@@ -1997,6 +2048,14 @@ Future<void> _receiveViewOnceMessage(
     label: 'consumed view-once removal',
   );
   expect(find.text(_oneTimeText), findsNothing);
+  await expectLater(
+    controller.connection!.getAttachmentChunk(
+      messageId: viewOnce.messageId,
+      attachmentId: attachment.attachmentId,
+      chunkIndex: 0,
+    ),
+    throwsA(isA<AttachmentTransferException>()),
+  );
   expect(controller.messageError, isNull);
 }
 
@@ -2005,7 +2064,9 @@ bool _matchesOutboundViewOnce(LocalChatMessage message) =>
     !message.isGroup &&
     message.peerUsername == _peerUsername &&
     message.oneTime &&
-    message.text == _oneTimeText;
+    message.text == _oneTimeText &&
+    message.attachments.length == 1 &&
+    message.attachments.single.kind == ChatAttachmentKind.sticker;
 
 bool _matchesGroupMessage(
   LocalChatMessage message, {

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -8,7 +9,9 @@ import 'package:wamp_app/src/application/call_controller.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
+import 'package:wamp_app/src/infrastructure/contact_importer.dart';
 import 'package:wamp_app/src/infrastructure/device_vault.dart';
+import 'package:wamp_app/src/infrastructure/profile_avatar_picker.dart';
 import 'package:wamp_app/src/infrastructure/vault_storage.dart';
 import 'package:wamp_app/src/ui/expression_picker.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
@@ -57,6 +60,35 @@ final class _TrackedVaultStorage implements VaultStorage {
   }
 }
 
+final class _SmokeContactImporter implements ContactImporter {
+  _SmokeContactImporter(this.displayName);
+
+  final String displayName;
+  int calls = 0;
+
+  @override
+  String get actionLabel => 'Choose smoke contact';
+
+  @override
+  Future<List<ImportedContactCandidate>> pickContacts() async {
+    calls += 1;
+    return [ImportedContactCandidate(displayName: displayName)];
+  }
+}
+
+final class _SmokeProfileAvatarPicker implements ProfileAvatarPicker {
+  _SmokeProfileAvatarPicker(this.bytes);
+
+  final Uint8List bytes;
+  int calls = 0;
+
+  @override
+  Future<ProfileAvatarSelection?> pickAvatar() async {
+    calls += 1;
+    return ProfileAvatarSelection(name: 'native-avatar.png', bytes: bytes);
+  }
+}
+
 const _serverAddress = String.fromEnvironment('WAMP_APP_SERVER_ADDRESS');
 const _username = String.fromEnvironment('WAMP_APP_SMOKE_USERNAME');
 const _peerUsername = String.fromEnvironment('WAMP_APP_SMOKE_PEER');
@@ -76,6 +108,11 @@ const _voiceCallReadyOutbound = String.fromEnvironment(
 );
 const _voiceCallReadyInbound = String.fromEnvironment(
   'WAMP_APP_SMOKE_CALL_READY_INBOUND',
+);
+
+Uint8List _nativeProfileAvatarBytes() => base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
+  'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
 );
 const _videoCallReadyOutbound = String.fromEnvironment(
   'WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND',
@@ -124,13 +161,27 @@ void main() {
     (tester) async {
       _validateConfiguration();
       final vaultStorage = _TrackedVaultStorage();
+      final avatarBytes = _nativeProfileAvatarBytes();
+      addTearDown(() => avatarBytes.fillRange(0, avatarBytes.length, 0));
+      expect(
+        avatarBytes.length,
+        lessThanOrEqualTo(AccountProfileLimits.maxAvatarBytes),
+      );
+      final avatarPicker = _SmokeProfileAvatarPicker(avatarBytes);
+      final contactImporter = _SmokeContactImporter(_contactDisplayName);
       final controller = WampAppController(
         trustStore: EncryptedDeviceVault(storage: vaultStorage),
         deviceName: '$_username device',
       );
       addTearDown(controller.dispose);
 
-      await tester.pumpWidget(WampApp(controller: controller));
+      await tester.pumpWidget(
+        WampApp(
+          controller: controller,
+          contactImporter: contactImporter,
+          profileAvatarPicker: avatarPicker,
+        ),
+      );
       await _pumpUntil(
         tester,
         () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
@@ -252,7 +303,14 @@ void main() {
         readyOutbound: _videoCallReadyOutbound,
         readyInbound: _videoCallReadyInbound,
       );
-      await _exerciseAccountPrivacyControls(tester, controller, vaultStorage);
+      await _exerciseAccountPrivacyControls(
+        tester,
+        controller,
+        vaultStorage,
+        avatarBytes,
+        avatarPicker,
+        contactImporter,
+      );
     },
     timeout: const Timeout(Duration(minutes: 24)),
   );
@@ -262,11 +320,14 @@ Future<void> _exerciseAccountPrivacyControls(
   WidgetTester tester,
   WampAppController controller,
   _TrackedVaultStorage vaultStorage,
+  Uint8List avatarBytes,
+  _SmokeProfileAvatarPicker avatarPicker,
+  _SmokeContactImporter contactImporter,
 ) async {
   await _selectDirectConversation(tester);
-  await _updatePublicProfile(tester, controller);
+  await _updatePublicProfile(tester, controller, avatarBytes, avatarPicker);
   await _setLocalConversationPreferences(tester, controller);
-  await _saveLocalContactAlias(tester, controller);
+  await _saveLocalContactAlias(tester, controller, contactImporter);
   await _enableMcpProfileConsent(tester, controller);
   if (_role == 'initiator') {
     await _uploadRemoteBackup(tester, controller);
@@ -304,6 +365,7 @@ Future<void> _exerciseAccountPrivacyControls(
       tester,
       controller,
       vaultStorage,
+      avatarBytes,
     );
   }
   await _exchangeBackupRecoveryMarkers(tester, controller);
@@ -312,6 +374,8 @@ Future<void> _exerciseAccountPrivacyControls(
 Future<void> _updatePublicProfile(
   WidgetTester tester,
   WampAppController controller,
+  Uint8List avatarBytes,
+  _SmokeProfileAvatarPicker avatarPicker,
 ) async {
   final edit = find.byKey(const Key('account-profile-edit'));
   await _tapWhenReady(tester, edit, label: 'public-profile editor');
@@ -320,6 +384,23 @@ Future<void> _updatePublicProfile(
     () => find.byKey(const Key('profile-save')).evaluate().isNotEmpty,
     label: 'public-profile dialog',
   );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('profile-avatar-pick')),
+    label: 'public-profile avatar picker',
+  );
+  await _pumpUntil(
+    tester,
+    () => find
+        .descendant(
+          of: find.byKey(const Key('profile-avatar-preview')),
+          matching: find.byType(Image),
+        )
+        .evaluate()
+        .isNotEmpty,
+    label: 'public-profile avatar preview',
+  );
+  expect(avatarPicker.calls, 1);
   await tester.enterText(
     find.byKey(const Key('profile-display-name')),
     _profileDisplayName,
@@ -341,10 +422,23 @@ Future<void> _updatePublicProfile(
         find.byKey(const Key('profile-save')).evaluate().isEmpty &&
         !controller.profileBusy &&
         controller.connection?.profile.displayName == _profileDisplayName &&
-        controller.connection?.profile.status == _profileStatus,
+        controller.connection?.profile.status == _profileStatus &&
+        controller.connection?.profile.avatarContentType == 'image/png' &&
+        controller.connection?.profile.avatarBytes != null,
     label: 'persisted public profile',
   );
   expect(controller.profileError, isNull);
+  expect(
+    controller.connection?.profile.avatarBytes,
+    orderedEquals(avatarBytes),
+  );
+  expect(
+    find.descendant(
+      of: find.byKey(const Key('account-profile-avatar')),
+      matching: find.byType(Image),
+    ),
+    findsOneWidget,
+  );
 }
 
 Future<void> _setLocalConversationPreferences(
@@ -400,6 +494,7 @@ Future<void> _setLocalConversationPreferences(
 Future<void> _saveLocalContactAlias(
   WidgetTester tester,
   WampAppController controller,
+  _SmokeContactImporter contactImporter,
 ) async {
   final compact = find.byKey(const Key('account-contacts-compact'));
   final contacts = compact.evaluate().isNotEmpty
@@ -411,11 +506,19 @@ Future<void> _saveLocalContactAlias(
     () => find.byKey(const Key('contact-save')).evaluate().isNotEmpty,
     label: 'local contact dialog',
   );
-  await tester.tap(find.byKey(const Key('contact-add-manual')));
-  await tester.enterText(
-    find.byKey(const Key('contact-display-name')),
-    _contactDisplayName,
+  expect(find.byKey(const Key('contact-privacy-boundary')), findsOneWidget);
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('contact-import')),
+    label: 'opt-in contact import',
   );
+  await _pumpUntil(tester, () {
+    final field = find.byKey(const Key('contact-display-name'));
+    if (field.evaluate().isEmpty) return false;
+    return tester.widget<TextField>(field).controller?.text ==
+        _contactDisplayName;
+  }, label: 'imported contact display name');
+  expect(contactImporter.calls, 1);
   await tester.enterText(
     find.byKey(const Key('contact-username')),
     _peerUsername,
@@ -529,6 +632,7 @@ Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
   WidgetTester tester,
   WampAppController controller,
   _TrackedVaultStorage vaultStorage,
+  Uint8List avatarBytes,
 ) async {
   final originalDeviceId = controller.localDevice?.deviceId;
   if (originalDeviceId == null) {
@@ -589,6 +693,8 @@ Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
       final conversationId = controller.directConversationIdFor(_peerUsername);
       return controller.status == WampAppStatus.connected &&
           controller.connection?.username == _username &&
+          controller.connection?.profile.avatarContentType == 'image/png' &&
+          controller.connection?.profile.avatarBytes != null &&
           controller.localDevice?.deviceId == originalDeviceId &&
           controller.themePreference.wireName == 'dark' &&
           conversationId != null &&
@@ -631,6 +737,17 @@ Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
   );
   expect(controller.backupError, isNull);
   expect(controller.messageError, isNull);
+  expect(
+    controller.connection?.profile.avatarBytes,
+    orderedEquals(avatarBytes),
+  );
+  expect(
+    find.descendant(
+      of: find.byKey(const Key('account-profile-avatar')),
+      matching: find.byType(Image),
+    ),
+    findsOneWidget,
+  );
   expect(
     tester.widget<MaterialApp>(find.byType(MaterialApp)).themeMode,
     ThemeMode.dark,
@@ -702,7 +819,14 @@ Future<void> _viewPeerProfile(WidgetTester tester) async {
     () =>
         find.text(_peerProfileDisplayName).evaluate().isNotEmpty &&
         find.text(_peerProfileStatus).evaluate().isNotEmpty &&
-        find.byKey(const Key('peer-profile-status')).evaluate().isNotEmpty,
+        find.byKey(const Key('peer-profile-status')).evaluate().isNotEmpty &&
+        find
+            .descendant(
+              of: find.byKey(const Key('peer-profile-avatar')),
+              matching: find.byType(Image),
+            )
+            .evaluate()
+            .isNotEmpty,
     label: 'peer public-profile propagation',
   );
   await _tapWhenReady(tester, find.text('Close'), label: 'peer profile close');

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -213,7 +213,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls',
+    'verifies peer identities and exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls',
     (tester) async {
       _validateConfiguration();
       final vaultStorage = _TrackedVaultStorage();
@@ -277,6 +277,7 @@ void main() {
       await tester.ensureVisible(recipient);
       await tester.enterText(recipient, _peerUsername);
       await tester.pump();
+      await _verifyPeerSafetyNumber(tester, controller);
       await _enterMessageWhenReady(
         tester,
         composer,
@@ -373,6 +374,74 @@ void main() {
       );
     },
     timeout: const Timeout(Duration(minutes: 24)),
+  );
+}
+
+Future<void> _verifyPeerSafetyNumber(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final initial = await controller.inspectPeerTrust(_peerUsername);
+  if (initial == null) {
+    fail('The account session changed before peer verification.');
+  }
+  expect(initial.status, PeerTrustStatus.unverified);
+  expect(initial.devices, hasLength(1));
+  final peerDevice = initial.devices.single;
+  expect(peerDevice.verified, isFalse);
+  expect(peerDevice.safetyNumber.trim(), isNotEmpty);
+
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 200));
+  final identityButton = find.byKey(const Key('recipient-identity-view'));
+  await tester.ensureVisible(identityButton);
+  await tester.tap(identityButton);
+
+  final safetyNumber = find.byKey(
+    ValueKey('peer-trust-number-${peerDevice.device.deviceId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => safetyNumber.evaluate().isNotEmpty,
+    label: 'peer safety number',
+  );
+  expect(find.text(peerDevice.safetyNumber), findsOneWidget);
+  expect(find.byKey(const Key('peer-trust-error')), findsNothing);
+
+  final verifyButton = find.byKey(
+    ValueKey('peer-trust-verify-${peerDevice.device.deviceId}'),
+  );
+  await tester.ensureVisible(verifyButton);
+  await tester.tap(verifyButton);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('peer-trust-confirm')).evaluate().isNotEmpty,
+    label: 'peer safety-number confirmation',
+  );
+  await tester.tap(find.byKey(const Key('peer-trust-confirm')));
+
+  await _pumpUntil(
+    tester,
+    () => find.text('Every active device is verified.').evaluate().isNotEmpty,
+    label: 'verified peer identity',
+  );
+  expect(find.byKey(const Key('peer-trust-error')), findsNothing);
+  final verified = await controller.inspectPeerTrust(_peerUsername);
+  if (verified == null) {
+    fail('The account session changed after peer verification.');
+  }
+  expect(verified.status, PeerTrustStatus.verified);
+  expect(verified.devices, hasLength(1));
+  expect(verified.devices.single.verified, isTrue);
+  expect(verified.devices.single.safetyNumber, peerDevice.safetyNumber);
+
+  final closeButton = find.widgetWithText(TextButton, 'Close');
+  await tester.ensureVisible(closeButton);
+  await tester.tap(closeButton);
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('peer-trust-dialog')).evaluate().isEmpty,
+    label: 'closed peer-identity dialog',
   );
 }
 
@@ -644,6 +713,17 @@ Future<void> _enableMcpProfileConsent(
     find.byKey(const Key('account-mcp-profile-consent')),
     label: 'MCP profile consent',
   );
+  final accessDialog = find.byKey(const Key('mcp-access-dialog'));
+  await _pumpUntil(
+    tester,
+    () => accessDialog.evaluate().isNotEmpty,
+    label: 'MCP access dialog',
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('mcp-access-profile-switch')),
+    label: 'MCP public-profile access switch',
+  );
   await _tapWhenReady(
     tester,
     find.byKey(const Key('mcp-profile-consent-confirm')),
@@ -656,6 +736,19 @@ Future<void> _enableMcpProfileConsent(
     label: 'persisted MCP profile consent',
   );
   expect(controller.mcpConsentError, isNull);
+  await _tapWhenReady(
+    tester,
+    find.descendant(
+      of: accessDialog,
+      matching: find.widgetWithText(TextButton, 'Close'),
+    ),
+    label: 'MCP access dialog close',
+  );
+  await _pumpUntil(
+    tester,
+    () => accessDialog.evaluate().isEmpty,
+    label: 'closed MCP access dialog',
+  );
 }
 
 Future<void> _exportLocalBackup(

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:wamp_app/src/app.dart';
+import 'package:wamp_app/src/application/call_controller.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
@@ -20,127 +21,263 @@ const _groupInboundText = String.fromEnvironment(
   'WAMP_APP_SMOKE_GROUP_INBOUND',
 );
 const _oneTimeText = String.fromEnvironment('WAMP_APP_SMOKE_VIEW_ONCE');
+const _callReadyOutbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_CALL_READY_OUTBOUND',
+);
+const _callReadyInbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_CALL_READY_INBOUND',
+);
 const _password = 'wamp-app-native-smoke-password';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets(
-    'exchanges encrypted direct, group, sticker, and view-once messages',
-    (tester) async {
-      _validateConfiguration();
-      final controller = WampAppController(deviceName: '$_username device');
-      addTearDown(controller.dispose);
+  testWidgets('exchanges encrypted chat and completes a WebRTC voice call', (
+    tester,
+  ) async {
+    _validateConfiguration();
+    final controller = WampAppController(deviceName: '$_username device');
+    addTearDown(controller.dispose);
 
-      await tester.pumpWidget(WampApp(controller: controller));
-      await _pumpUntil(
-        tester,
-        () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
-        label: 'onboarding form',
-      );
+    await tester.pumpWidget(WampApp(controller: controller));
+    await _pumpUntil(
+      tester,
+      () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
+      label: 'onboarding form',
+    );
 
-      await tester.enterText(
-        find.byKey(const Key('server-address')),
-        _serverAddress,
-      );
-      await tester.enterText(find.byKey(const Key('username')), _username);
-      await tester.enterText(
-        find.byKey(const Key('display-name')),
-        'Native smoke $_username',
-      );
-      await tester.enterText(find.byKey(const Key('password')), _password);
-      final submit = find.byKey(const Key('submit-account'));
-      await tester.ensureVisible(submit);
-      await tester.tap(submit);
+    await tester.enterText(
+      find.byKey(const Key('server-address')),
+      _serverAddress,
+    );
+    await tester.enterText(find.byKey(const Key('username')), _username);
+    await tester.enterText(
+      find.byKey(const Key('display-name')),
+      'Native smoke $_username',
+    );
+    await tester.enterText(find.byKey(const Key('password')), _password);
+    final submit = find.byKey(const Key('submit-account'));
+    await tester.ensureVisible(submit);
+    await tester.tap(submit);
 
-      await _pumpUntil(
-        tester,
-        () =>
-            controller.status == WampAppStatus.connected &&
-            controller.connection?.username == _username &&
-            find.byKey(const Key('message-recipient')).evaluate().isNotEmpty,
-        label: 'authenticated conversation shell',
-        timeout: const Duration(minutes: 2),
-      );
-      await _waitForPeerDevice(tester, controller);
+    await _pumpUntil(
+      tester,
+      () =>
+          controller.status == WampAppStatus.connected &&
+          controller.connection?.username == _username &&
+          find.byKey(const Key('message-recipient')).evaluate().isNotEmpty,
+      label: 'authenticated conversation shell',
+      timeout: const Duration(minutes: 2),
+    );
+    await _waitForPeerDevice(tester, controller);
 
-      final recipient = find.byKey(const Key('message-recipient'));
-      final composer = find.byKey(const Key('message-composer'));
-      await tester.ensureVisible(recipient);
-      await tester.enterText(recipient, _peerUsername);
-      await tester.pump();
-      await _enterMessageWhenReady(
-        tester,
-        composer,
-        _outboundText,
-        label: 'direct-message composer',
-      );
-      final send = find.byKey(const Key('message-send'));
-      await tester.ensureVisible(send);
-      await _tapSendAndWaitOutbound(tester, controller, send);
-      final outbound = controller.messages.singleWhere(
+    final recipient = find.byKey(const Key('message-recipient'));
+    final composer = find.byKey(const Key('message-composer'));
+    await tester.ensureVisible(recipient);
+    await tester.enterText(recipient, _peerUsername);
+    await tester.pump();
+    await _enterMessageWhenReady(
+      tester,
+      composer,
+      _outboundText,
+      label: 'direct-message composer',
+    );
+    final send = find.byKey(const Key('message-send'));
+    await tester.ensureVisible(send);
+    await _tapSendAndWaitOutbound(tester, controller, send);
+    final outbound = controller.messages.singleWhere(
+      (message) =>
+          message.outgoing &&
+          message.peerUsername == _peerUsername &&
+          message.text == _outboundText,
+    );
+    await _pumpUntil(
+      tester,
+      () =>
+          controller.outboundMessageFor(outbound.messageId) == null &&
+          controller.messageError == null,
+      label: 'router acceptance of outbound message',
+    );
+
+    await _pumpUntil(
+      tester,
+      () => controller.messages.any(
         (message) =>
-            message.outgoing &&
+            !message.outgoing &&
             message.peerUsername == _peerUsername &&
-            message.text == _outboundText,
-      );
-      await _pumpUntil(
-        tester,
-        () =>
-            controller.outboundMessageFor(outbound.messageId) == null &&
-            controller.messageError == null,
-        label: 'router acceptance of outbound message',
-      );
+            message.text == _inboundText,
+      ),
+      label: 'mailbox wakeup and decrypted inbound message',
+      timeout: const Duration(minutes: 2),
+    );
 
-      await _pumpUntil(
-        tester,
-        () => controller.messages.any(
+    FocusManager.instance.primaryFocus?.unfocus();
+    await _pumpUntil(
+      tester,
+      () =>
+          find.text(_outboundText).evaluate().isNotEmpty ||
+          find.text(_inboundText).evaluate().isNotEmpty,
+      label: 'rendered message history',
+    );
+    final outboundRendered = find.text(_outboundText).evaluate().isNotEmpty;
+    final inboundRendered = find.text(_inboundText).evaluate().isNotEmpty;
+    if (!outboundRendered || !inboundRendered) {
+      final history = find.byKey(const Key('message-history'));
+      final scrollable = find.descendant(
+        of: history,
+        matching: find.byType(Scrollable),
+      );
+      await tester.scrollUntilVisible(
+        find.text(outboundRendered ? _inboundText : _outboundText),
+        100,
+        scrollable: scrollable,
+        maxScrolls: 20,
+      );
+    }
+    expect(controller.messageError, isNull);
+    expect(
+      outboundRendered || find.text(_outboundText).evaluate().isNotEmpty,
+      isTrue,
+    );
+    expect(
+      inboundRendered || find.text(_inboundText).evaluate().isNotEmpty,
+      isTrue,
+    );
+
+    await _exerciseEncryptedGroupSticker(tester, controller);
+    await _exerciseViewOnceMessage(tester, controller);
+    await _exerciseEncryptedVoiceCall(tester, controller);
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}
+
+Future<void> _exerciseEncryptedVoiceCall(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  await _selectDirectConversation(tester);
+  final calls = controller.calls;
+  expect(calls, isNotNull);
+  expect(calls!.phase, CallUiPhase.idle);
+
+  if (_role == 'initiator') {
+    final start = find.byKey(const Key('conversation-voice-call'));
+    await tester.ensureVisible(start);
+    await tester.tap(start);
+    await _pumpUntil(
+      tester,
+      () =>
+          calls.phase == CallUiPhase.outgoingRinging ||
+          calls.phase == CallUiPhase.connecting ||
+          calls.phase == CallUiPhase.active,
+      label: 'outgoing encrypted voice call',
+      timeout: const Duration(minutes: 2),
+    );
+    expect(find.byKey(const ValueKey('active-call')), findsOneWidget);
+  } else {
+    await _pumpUntil(
+      tester,
+      () =>
+          calls.phase == CallUiPhase.incomingRinging &&
+          find.byKey(const ValueKey('incoming-call')).evaluate().isNotEmpty,
+      label: 'incoming encrypted voice call',
+      timeout: const Duration(minutes: 2),
+    );
+    final accept = find.byKey(const Key('call-accept'));
+    await tester.ensureVisible(accept);
+    await tester.tap(accept);
+  }
+
+  await _pumpUntil(
+    tester,
+    () =>
+        calls.phase == CallUiPhase.active &&
+        calls.call?.state == CallState.active &&
+        calls.call?.media == CallMediaKind.voice &&
+        calls.mediaSession != null &&
+        calls.peerUsername == _peerUsername &&
+        find.byKey(const ValueKey('active-call')).evaluate().isNotEmpty,
+    label: 'active WebRTC voice media with $_peerUsername',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(calls.errorMessage, isNull);
+
+  await _pumpUntil(
+    tester,
+    () => !controller.messageBusy,
+    label: 'idle encrypted message channel during the active call',
+  );
+  final markerSent = await controller.sendMessage(
+    recipientUsername: _peerUsername,
+    text: _callReadyOutbound,
+  );
+  if (!markerSent) {
+    fail(
+      'Could not enqueue the active-call marker: '
+      '${controller.messageError ?? 'message channel unavailable'}.',
+    );
+  }
+  final outboundReady = controller.messages.singleWhere(
+    (message) =>
+        message.outgoing &&
+        !message.isGroup &&
+        message.peerUsername == _peerUsername &&
+        message.text == _callReadyOutbound,
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(outboundReady.messageId) == null &&
+        controller.messages.any(
           (message) =>
               !message.outgoing &&
+              !message.isGroup &&
               message.peerUsername == _peerUsername &&
-              message.text == _inboundText,
+              message.text == _callReadyInbound,
         ),
-        label: 'mailbox wakeup and decrypted inbound message',
-        timeout: const Duration(minutes: 2),
-      );
+    label: 'both devices active in the same voice call',
+    timeout: const Duration(minutes: 2),
+  );
 
-      FocusManager.instance.primaryFocus?.unfocus();
-      await _pumpUntil(
-        tester,
-        () =>
-            find.text(_outboundText).evaluate().isNotEmpty ||
-            find.text(_inboundText).evaluate().isNotEmpty,
-        label: 'rendered message history',
-      );
-      final outboundRendered = find.text(_outboundText).evaluate().isNotEmpty;
-      final inboundRendered = find.text(_inboundText).evaluate().isNotEmpty;
-      if (!outboundRendered || !inboundRendered) {
-        final history = find.byKey(const Key('message-history'));
-        final scrollable = find.descendant(
-          of: history,
-          matching: find.byType(Scrollable),
-        );
-        await tester.scrollUntilVisible(
-          find.text(outboundRendered ? _inboundText : _outboundText),
-          100,
-          scrollable: scrollable,
-          maxScrolls: 20,
-        );
-      }
-      expect(controller.messageError, isNull);
-      expect(
-        outboundRendered || find.text(_outboundText).evaluate().isNotEmpty,
-        isTrue,
-      );
-      expect(
-        inboundRendered || find.text(_inboundText).evaluate().isNotEmpty,
-        isTrue,
-      );
+  if (_role == 'initiator') {
+    final mute = find.byKey(const Key('call-mute'));
+    await tester.ensureVisible(mute);
+    await tester.tap(mute);
+    await _pumpUntil(
+      tester,
+      () => calls.mediaSession?.muted ?? false,
+      label: 'muted native voice track',
+    );
+    await tester.tap(mute);
+    await _pumpUntil(
+      tester,
+      () => !(calls.mediaSession?.muted ?? true),
+      label: 'unmuted native voice track',
+    );
+    final end = find.byKey(const Key('call-end'));
+    await tester.ensureVisible(end);
+    await tester.tap(end);
+  }
 
-      await _exerciseEncryptedGroupSticker(tester, controller);
-      await _exerciseViewOnceMessage(tester, controller);
-    },
-    timeout: const Timeout(Duration(minutes: 7)),
+  await _pumpUntil(
+    tester,
+    () =>
+        calls.phase == CallUiPhase.ended &&
+        calls.mediaSession == null &&
+        find.byKey(const ValueKey('call-result')).evaluate().isNotEmpty,
+    label: _role == 'initiator'
+        ? 'local voice-call teardown'
+        : 'remote voice-call teardown',
+    timeout: const Duration(minutes: 2),
+  );
+  expect(calls.errorMessage, isNull);
+  await tester.pump(const Duration(milliseconds: 350));
+  final dismiss = find.byKey(const Key('call-dismiss'));
+  await tester.ensureVisible(dismiss);
+  await tester.tap(dismiss);
+  await _pumpUntil(
+    tester,
+    () => calls.phase == CallUiPhase.idle && !calls.hasCall,
+    label: 'dismissed completed voice call',
   );
 }
 
@@ -598,6 +735,8 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_GROUP_OUTBOUND': _groupOutboundText,
     'WAMP_APP_SMOKE_GROUP_INBOUND': _groupInboundText,
     'WAMP_APP_SMOKE_VIEW_ONCE': _oneTimeText,
+    'WAMP_APP_SMOKE_CALL_READY_OUTBOUND': _callReadyOutbound,
+    'WAMP_APP_SMOKE_CALL_READY_INBOUND': _callReadyInbound,
   };
   for (final entry in values.entries) {
     if (entry.value.trim().isEmpty) {
@@ -613,6 +752,8 @@ void _validateConfiguration() {
     _groupOutboundText,
     _groupInboundText,
     _oneTimeText,
+    _callReadyOutbound,
+    _callReadyInbound,
   ];
   if (_username == _peerUsername ||
       messageTokens.toSet().length != messageTokens.length) {

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -5,7 +7,11 @@ import 'package:wamp_app/src/app.dart';
 import 'package:wamp_app/src/application/call_controller.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
+import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
+import 'package:wamp_app/src/ui/expression_picker.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
+
+import 'support/rich_media_fixtures.dart';
 
 const _serverAddress = String.fromEnvironment('WAMP_APP_SERVER_ADDRESS');
 const _username = String.fromEnvironment('WAMP_APP_SMOKE_USERNAME');
@@ -55,13 +61,16 @@ const _controlsReadyInbound = String.fromEnvironment(
 const _backupPassphrase = String.fromEnvironment(
   'WAMP_APP_SMOKE_BACKUP_PASSPHRASE',
 );
+const _richMediaToken = String.fromEnvironment('WAMP_APP_SMOKE_RICH_MEDIA');
+const _richMediaText = '$_richMediaToken 🚀';
+const _richMediaAck = String.fromEnvironment('WAMP_APP_SMOKE_RICH_MEDIA_ACK');
 const _password = 'wamp-app-native-smoke-password';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'exchanges encrypted chat, account controls, backup, and WebRTC calls',
+    'exchanges encrypted chat, rich media, controls, backup, and WebRTC calls',
     (tester) async {
       _validateConfiguration();
       final controller = WampAppController(deviceName: '$_username device');
@@ -173,6 +182,7 @@ void main() {
       );
 
       await _exerciseEncryptedGroupSticker(tester, controller);
+      await _exerciseEncryptedRichMedia(tester, controller);
       await _exerciseViewOnceMessage(tester, controller);
       await _exerciseWebRtcCall(
         tester,
@@ -906,30 +916,7 @@ Future<void> _receiveStickerAndReply(
   );
 
   final attachment = groupMessage.attachments.single;
-  final attachmentCard = find.byKey(
-    ValueKey('attachment-open-${attachment.attachmentId}'),
-  );
-  await _pumpUntil(
-    tester,
-    () => attachmentCard.evaluate().isNotEmpty,
-    label: 'rendered encrypted sticker attachment card',
-  );
-  await Scrollable.ensureVisible(
-    attachmentCard.evaluate().single,
-    alignment: 0.5,
-  );
-  await tester.pump();
-  final attachmentRect = tester.getRect(attachmentCard);
-  final historyRect = tester.getRect(find.byKey(const Key('message-history')));
-  final visibleAttachmentRect = attachmentRect.intersect(historyRect);
-  expect(
-    visibleAttachmentRect.height,
-    greaterThanOrEqualTo(24),
-    reason:
-        'The encrypted sticker attachment must have a usable tap target in '
-        'history (attachment: $attachmentRect, history: $historyRect).',
-  );
-  await tester.tapAt(visibleAttachmentRect.center);
+  await _tapEncryptedAttachmentCard(tester, attachment, label: 'sticker');
   final preview = find.byKey(
     ValueKey('attachment-preview-${attachment.attachmentId}'),
   );
@@ -982,6 +969,283 @@ Future<void> _receiveStickerAndReply(
     timeout: const Duration(minutes: 2),
   );
   expect(controller.messageError, isNull);
+}
+
+Future<void> _exerciseEncryptedRichMedia(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  await _selectDirectConversation(tester);
+  if (_role == 'initiator') {
+    await _sendEncryptedRichMedia(tester, controller);
+    return;
+  }
+  await _receiveEncryptedRichMedia(tester, controller);
+}
+
+Future<void> _sendEncryptedRichMedia(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  final imageBytes = await const BundledStickerRenderer().render(
+    wampAppStickers.first,
+  );
+  final gifBytes = nativeAnimatedGifBytes();
+  final voiceBytes = nativeVoiceNoteBytes();
+  var sourcesOpen = true;
+  AttachmentPlaintextSource source({
+    required String name,
+    required String contentType,
+    required ChatAttachmentKind kind,
+    required Uint8List bytes,
+    int? durationMilliseconds,
+  }) => AttachmentPlaintextSource(
+    name: name,
+    contentType: contentType,
+    kind: kind,
+    byteCount: bytes.length,
+    durationMilliseconds: durationMilliseconds,
+    openRead: () {
+      if (!sourcesOpen) {
+        throw StateError('The native rich-media source was already released.');
+      }
+      return Stream<List<int>>.value(bytes);
+    },
+  );
+
+  bool sent;
+  try {
+    sent = await controller.sendMessage(
+      recipientUsername: _peerUsername,
+      text: _richMediaText,
+      attachmentSources: [
+        source(
+          name: 'native-photo.png',
+          contentType: 'image/png',
+          kind: ChatAttachmentKind.image,
+          bytes: imageBytes,
+        ),
+        source(
+          name: 'native-animation.gif',
+          contentType: 'image/gif',
+          kind: ChatAttachmentKind.gif,
+          bytes: gifBytes,
+        ),
+        source(
+          name: 'native-voice-note.wav',
+          contentType: 'audio/wav',
+          kind: ChatAttachmentKind.voiceNote,
+          bytes: voiceBytes,
+          durationMilliseconds: nativeVoiceNoteDurationMilliseconds,
+        ),
+      ],
+    );
+  } finally {
+    sourcesOpen = false;
+    imageBytes.fillRange(0, imageBytes.length, 0);
+    gifBytes.fillRange(0, gifBytes.length, 0);
+    voiceBytes.fillRange(0, voiceBytes.length, 0);
+  }
+  if (!sent) {
+    fail(
+      'Could not send native rich media '
+      '(${controller.messageError ?? 'message channel unavailable'}).',
+    );
+  }
+
+  final outbound = controller.messages.singleWhere(
+    (message) =>
+        message.outgoing &&
+        message.peerUsername == _peerUsername &&
+        message.text == _richMediaText,
+  );
+  expect(outbound.attachments.map((attachment) => attachment.kind).toSet(), {
+    ChatAttachmentKind.image,
+    ChatAttachmentKind.gif,
+    ChatAttachmentKind.voiceNote,
+  });
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(outbound.messageId) == null &&
+        controller.messageError == null,
+    label: 'router acceptance of encrypted image, GIF, and voice note',
+    timeout: const Duration(minutes: 2),
+  );
+  await _pumpUntil(
+    tester,
+    () => controller.messages.any(
+      (message) => !message.outgoing && message.text == _richMediaAck,
+    ),
+    label: 'peer rich-media decryption and playback acknowledgement',
+    timeout: const Duration(minutes: 3),
+  );
+}
+
+Future<void> _receiveEncryptedRichMedia(
+  WidgetTester tester,
+  WampAppController controller,
+) async {
+  LocalChatMessage? received;
+  await _pumpUntil(
+    tester,
+    () {
+      for (final message in controller.messages) {
+        final kinds = message.attachments
+            .map((attachment) => attachment.kind)
+            .toSet();
+        if (!message.outgoing &&
+            message.peerUsername == _peerUsername &&
+            message.text == _richMediaText &&
+            kinds.containsAll({
+              ChatAttachmentKind.image,
+              ChatAttachmentKind.gif,
+              ChatAttachmentKind.voiceNote,
+            })) {
+          received = message;
+          return true;
+        }
+      }
+      return false;
+    },
+    label: 'decrypted inbound image, GIF, and voice note',
+    timeout: const Duration(minutes: 3),
+  );
+  final message = received!;
+  expect(message.attachments, hasLength(3));
+  await _openRichMediaPreview(
+    tester,
+    message.attachments.singleWhere(
+      (attachment) => attachment.kind == ChatAttachmentKind.image,
+    ),
+    label: 'image',
+  );
+  await _openRichMediaPreview(
+    tester,
+    message.attachments.singleWhere(
+      (attachment) => attachment.kind == ChatAttachmentKind.gif,
+    ),
+    label: 'animated GIF',
+  );
+  await _playRichMediaVoiceNote(
+    tester,
+    message.attachments.singleWhere(
+      (attachment) => attachment.kind == ChatAttachmentKind.voiceNote,
+    ),
+  );
+
+  final sent = await controller.sendMessage(
+    recipientUsername: _peerUsername,
+    text: _richMediaAck,
+  );
+  if (!sent) {
+    fail(
+      'Could not acknowledge native rich media '
+      '(${controller.messageError ?? 'message channel unavailable'}).',
+    );
+  }
+  final acknowledgement = controller.messages.singleWhere(
+    (message) => message.outgoing && message.text == _richMediaAck,
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        controller.outboundMessageFor(acknowledgement.messageId) == null &&
+        controller.messageError == null,
+    label: 'router acceptance of rich-media acknowledgement',
+  );
+}
+
+Future<void> _tapEncryptedAttachmentCard(
+  WidgetTester tester,
+  EncryptedAttachmentDescriptor attachment, {
+  required String label,
+}) async {
+  final card = find.byKey(
+    ValueKey('attachment-open-${attachment.attachmentId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => card.evaluate().isNotEmpty,
+    label: 'rendered encrypted $label attachment card',
+  );
+  await Scrollable.ensureVisible(card.evaluate().single, alignment: 0.5);
+  await tester.pump();
+  final cardRect = tester.getRect(card);
+  final historyRect = tester.getRect(find.byKey(const Key('message-history')));
+  final visibleCardRect = cardRect.intersect(historyRect);
+  expect(
+    visibleCardRect.height,
+    greaterThanOrEqualTo(24),
+    reason:
+        'The encrypted $label attachment must have a usable tap target in '
+        'history (attachment: $cardRect, history: $historyRect).',
+  );
+  await tester.tapAt(visibleCardRect.center);
+}
+
+Future<void> _openRichMediaPreview(
+  WidgetTester tester,
+  EncryptedAttachmentDescriptor attachment, {
+  required String label,
+}) async {
+  await _tapEncryptedAttachmentCard(tester, attachment, label: label);
+  final preview = find.byKey(
+    ValueKey('attachment-preview-${attachment.attachmentId}'),
+  );
+  await _pumpUntil(
+    tester,
+    () => preview.evaluate().isNotEmpty,
+    label: 'downloaded, authenticated, and decoded $label',
+    timeout: const Duration(minutes: 2),
+  );
+  await tester.pump(const Duration(milliseconds: 400));
+  expect(tester.takeException(), isNull);
+  await tester.tap(find.widgetWithText(FilledButton, 'Close'));
+  await _pumpUntil(
+    tester,
+    () => preview.evaluate().isEmpty,
+    label: 'closed $label preview',
+  );
+}
+
+Future<void> _playRichMediaVoiceNote(
+  WidgetTester tester,
+  EncryptedAttachmentDescriptor attachment,
+) async {
+  await _tapEncryptedAttachmentCard(tester, attachment, label: 'voice-note');
+  final play = find.byKey(ValueKey('voice-play-${attachment.attachmentId}'));
+  await _pumpUntil(
+    tester,
+    () => play.evaluate().isNotEmpty,
+    label: 'downloaded and authenticated voice-note player',
+    timeout: const Duration(minutes: 2),
+  );
+  await tester.tap(play);
+  await _pumpUntil(
+    tester,
+    () => find
+        .descendant(of: play, matching: find.byIcon(Icons.pause_rounded))
+        .evaluate()
+        .isNotEmpty,
+    label: 'native voice-note playback',
+  );
+  expect(tester.takeException(), isNull);
+  await tester.tap(play);
+  await _pumpUntil(
+    tester,
+    () => find
+        .descendant(of: play, matching: find.byIcon(Icons.play_arrow_rounded))
+        .evaluate()
+        .isNotEmpty,
+    label: 'paused native voice-note playback',
+  );
+  await tester.tap(find.widgetWithText(FilledButton, 'Close'));
+  await _pumpUntil(
+    tester,
+    () => play.evaluate().isEmpty,
+    label: 'closed voice-note player',
+  );
 }
 
 Future<void> _exerciseViewOnceMessage(
@@ -1098,6 +1362,14 @@ Future<void> _receiveViewOnceMessage(
   final viewOnce = received!;
   expect(find.text(_oneTimeText), findsNothing);
 
+  final historyScrollable = find.descendant(
+    of: find.byKey(const Key('message-history')),
+    matching: find.byType(Scrollable),
+  );
+  final historyState = tester.state<ScrollableState>(historyScrollable);
+  historyState.position.jumpTo(historyState.position.minScrollExtent);
+  await tester.pump();
+
   final reveal = find.byKey(
     ValueKey('message-view-once-${viewOnce.messageId}'),
   );
@@ -1198,6 +1470,8 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND': _controlsReadyOutbound,
     'WAMP_APP_SMOKE_CONTROLS_READY_INBOUND': _controlsReadyInbound,
     'WAMP_APP_SMOKE_BACKUP_PASSPHRASE': _backupPassphrase,
+    'WAMP_APP_SMOKE_RICH_MEDIA': _richMediaToken,
+    'WAMP_APP_SMOKE_RICH_MEDIA_ACK': _richMediaAck,
   };
   for (final entry in values.entries) {
     if (entry.value.trim().isEmpty) {
@@ -1219,6 +1493,8 @@ void _validateConfiguration() {
     _videoCallReadyInbound,
     _controlsReadyOutbound,
     _controlsReadyInbound,
+    _richMediaText,
+    _richMediaAck,
   ];
   if (_username == _peerUsername ||
       messageTokens.toSet().length != messageTokens.length) {

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -251,6 +251,14 @@ void main() {
         find.byKey(const Key('server-address')),
         _serverAddress,
       );
+      await _pumpUntil(
+        tester,
+        () => find
+            .byKey(const Key('server-probe-reachable'))
+            .evaluate()
+            .isNotEmpty,
+        label: 'router readiness probe',
+      );
       await tester.enterText(find.byKey(const Key('username')), _username);
       await tester.enterText(
         find.byKey(const Key('display-name')),
@@ -1014,6 +1022,11 @@ Future<String> _prepareDestructiveBackupRestore(
   await tester.enterText(
     find.byKey(const Key('server-address')),
     _serverAddress,
+  );
+  await _pumpUntil(
+    tester,
+    () => find.byKey(const Key('server-probe-reachable')).evaluate().isNotEmpty,
+    label: 'backup recovery router readiness probe',
   );
   await tester.enterText(find.byKey(const Key('username')), _username);
   await tester.enterText(find.byKey(const Key('password')), _password);

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -10,6 +10,7 @@ import 'package:wamp_app/src/application/wamp_app_controller.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
 import 'package:wamp_app/src/infrastructure/contact_importer.dart';
+import 'package:wamp_app/src/infrastructure/device_backup_file.dart';
 import 'package:wamp_app/src/infrastructure/device_vault.dart';
 import 'package:wamp_app/src/infrastructure/profile_avatar_picker.dart';
 import 'package:wamp_app/src/infrastructure/vault_storage.dart';
@@ -86,6 +87,59 @@ final class _SmokeProfileAvatarPicker implements ProfileAvatarPicker {
   Future<ProfileAvatarSelection?> pickAvatar() async {
     calls += 1;
     return ProfileAvatarSelection(name: 'native-avatar.png', bytes: bytes);
+  }
+}
+
+final class _SmokeBackupFiles implements DeviceBackupFileGateway {
+  Uint8List? _archive;
+  String? suggestedName;
+  int saveCalls = 0;
+  int openCalls = 0;
+
+  int get archiveLength => _archive?.length ?? 0;
+
+  @override
+  Future<bool> save(Uint8List archive, {required String suggestedName}) async {
+    _wipeArchive();
+    _archive = Uint8List.fromList(archive);
+    this.suggestedName = suggestedName;
+    saveCalls += 1;
+    return true;
+  }
+
+  @override
+  Future<Uint8List?> open() async {
+    openCalls += 1;
+    final archive = _archive;
+    return archive == null ? null : Uint8List.fromList(archive);
+  }
+
+  bool containsUtf8(String value) {
+    final archive = _archive;
+    if (archive == null) return false;
+    final needle = utf8.encode(value);
+    if (needle.isEmpty || needle.length > archive.length) return false;
+    for (var offset = 0; offset <= archive.length - needle.length; offset++) {
+      var matches = true;
+      for (var index = 0; index < needle.length; index++) {
+        if (archive[offset + index] != needle[index]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) return true;
+    }
+    return false;
+  }
+
+  void dispose() {
+    _wipeArchive();
+    suggestedName = null;
+  }
+
+  void _wipeArchive() {
+    _archive?.fillRange(0, _archive!.length, 0);
+    _archive = null;
   }
 }
 
@@ -169,8 +223,11 @@ void main() {
       );
       final avatarPicker = _SmokeProfileAvatarPicker(avatarBytes);
       final contactImporter = _SmokeContactImporter(_contactDisplayName);
+      final backupFiles = _SmokeBackupFiles();
+      addTearDown(backupFiles.dispose);
       final controller = WampAppController(
         trustStore: EncryptedDeviceVault(storage: vaultStorage),
+        backupFiles: backupFiles,
         deviceName: '$_username device',
       );
       addTearDown(controller.dispose);
@@ -310,6 +367,7 @@ void main() {
         avatarBytes,
         avatarPicker,
         contactImporter,
+        backupFiles,
       );
     },
     timeout: const Timeout(Duration(minutes: 24)),
@@ -323,6 +381,7 @@ Future<void> _exerciseAccountPrivacyControls(
   Uint8List avatarBytes,
   _SmokeProfileAvatarPicker avatarPicker,
   _SmokeContactImporter contactImporter,
+  _SmokeBackupFiles backupFiles,
 ) async {
   await _selectDirectConversation(tester);
   await _updatePublicProfile(tester, controller, avatarBytes, avatarPicker);
@@ -331,6 +390,8 @@ Future<void> _exerciseAccountPrivacyControls(
   await _enableMcpProfileConsent(tester, controller);
   if (_role == 'initiator') {
     await _uploadRemoteBackup(tester, controller);
+  } else {
+    await _exportLocalBackup(tester, controller, backupFiles);
   }
 
   final sent = await controller.sendMessage(
@@ -366,6 +427,14 @@ Future<void> _exerciseAccountPrivacyControls(
       controller,
       vaultStorage,
       avatarBytes,
+    );
+  } else {
+    await _restoreLocalBackupAfterLocalVaultDeletion(
+      tester,
+      controller,
+      vaultStorage,
+      avatarBytes,
+      backupFiles,
     );
   }
   await _exchangeBackupRecoveryMarkers(tester, controller);
@@ -572,6 +641,90 @@ Future<void> _enableMcpProfileConsent(
   expect(controller.mcpConsentError, isNull);
 }
 
+Future<void> _exportLocalBackup(
+  WidgetTester tester,
+  WampAppController controller,
+  _SmokeBackupFiles backupFiles,
+) async {
+  final compact = find.byKey(const Key('account-backup-compact'));
+  await _tapWhenReady(
+    tester,
+    compact.evaluate().isNotEmpty
+        ? compact
+        : find.byKey(const Key('account-backup')),
+    label: 'local backup options',
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('backup-action-local')),
+    label: 'local encrypted backup action',
+  );
+  await _pumpUntil(
+    tester,
+    () => find
+        .byKey(const Key('backup-recovery-confirmation'))
+        .evaluate()
+        .isNotEmpty,
+    label: 'local backup recovery phrase dialog',
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-passphrase')),
+    _backupPassphrase,
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-confirmation')),
+    _backupPassphrase,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('backup-passphrase-submit')),
+    label: 'local encrypted backup creation',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.backupBusy &&
+        backupFiles.saveCalls == 1 &&
+        find.text('Encrypted device backup saved.').evaluate().isNotEmpty,
+    label: 'local encrypted backup export',
+    timeout: const Duration(minutes: 2),
+  );
+
+  expect(controller.backupError, isNull);
+  expect(backupFiles.openCalls, 0);
+  expect(backupFiles.archiveLength, greaterThan(0));
+  expect(
+    backupFiles.archiveLength,
+    lessThanOrEqualTo(WampAppBackupLimits.maximumArchiveBytes),
+  );
+  expect(backupFiles.suggestedName, endsWith('.wampbackup'));
+  for (final plaintext in [
+    _password,
+    _backupPassphrase,
+    _contactDisplayName,
+    _outboundText,
+    _inboundText,
+    _groupTitle,
+    _groupOutboundText,
+    _groupInboundText,
+    _controlsReadyOutbound,
+    _controlsReadyInbound,
+  ]) {
+    expect(
+      backupFiles.containsUtf8(plaintext),
+      isFalse,
+      reason: 'The local backup exposed protected application plaintext.',
+    );
+    expect(
+      backupFiles.containsUtf8(base64Encode(utf8.encode(plaintext))),
+      isFalse,
+      reason: 'The local backup exposed encoded application plaintext.',
+    );
+  }
+}
+
 Future<void> _uploadRemoteBackup(
   WidgetTester tester,
   WampAppController controller,
@@ -634,6 +787,100 @@ Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
   _TrackedVaultStorage vaultStorage,
   Uint8List avatarBytes,
 ) async {
+  final originalDeviceId = await _prepareDestructiveBackupRestore(
+    tester,
+    controller,
+    vaultStorage,
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('restore-remote-backup')),
+    label: 'remote backup restore action',
+  );
+  await _pumpUntil(
+    tester,
+    () => find
+        .byKey(const Key('backup-recovery-passphrase'))
+        .evaluate()
+        .isNotEmpty,
+    label: 'remote backup recovery phrase dialog',
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-passphrase')),
+    _backupPassphrase,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('backup-passphrase-submit')),
+    label: 'remote backup recovery',
+  );
+
+  await _expectDestructiveBackupRecovery(
+    tester,
+    controller,
+    originalDeviceId: originalDeviceId,
+    avatarBytes: avatarBytes,
+    label: 'destructive encrypted cloud-backup recovery',
+  );
+}
+
+Future<void> _restoreLocalBackupAfterLocalVaultDeletion(
+  WidgetTester tester,
+  WampAppController controller,
+  _TrackedVaultStorage vaultStorage,
+  Uint8List avatarBytes,
+  _SmokeBackupFiles backupFiles,
+) async {
+  expect(backupFiles.saveCalls, 1);
+  expect(backupFiles.openCalls, 0);
+  final originalDeviceId = await _prepareDestructiveBackupRestore(
+    tester,
+    controller,
+    vaultStorage,
+  );
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('restore-local-backup')),
+    label: 'local backup restore action',
+  );
+  await _pumpUntil(
+    tester,
+    () => find
+        .byKey(const Key('backup-recovery-passphrase'))
+        .evaluate()
+        .isNotEmpty,
+    label: 'local backup recovery phrase dialog',
+  );
+  await tester.enterText(
+    find.byKey(const Key('backup-recovery-passphrase')),
+    _backupPassphrase,
+  );
+  FocusManager.instance.primaryFocus?.unfocus();
+  await tester.pump(const Duration(milliseconds: 400));
+  await _tapWhenReady(
+    tester,
+    find.byKey(const Key('backup-passphrase-submit')),
+    label: 'local backup recovery',
+  );
+
+  await _expectDestructiveBackupRecovery(
+    tester,
+    controller,
+    originalDeviceId: originalDeviceId,
+    avatarBytes: avatarBytes,
+    label: 'destructive encrypted local-backup recovery',
+  );
+  expect(backupFiles.openCalls, 1);
+  expect(backupFiles.archiveLength, greaterThan(0));
+}
+
+Future<String> _prepareDestructiveBackupRestore(
+  WidgetTester tester,
+  WampAppController controller,
+  _TrackedVaultStorage vaultStorage,
+) async {
   final originalDeviceId = controller.localDevice?.deviceId;
   if (originalDeviceId == null) {
     fail('The encrypted backup source device was unavailable.');
@@ -662,31 +909,16 @@ Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
   await tester.enterText(find.byKey(const Key('password')), _password);
   FocusManager.instance.primaryFocus?.unfocus();
   await tester.pump(const Duration(milliseconds: 400));
-  await _tapWhenReady(
-    tester,
-    find.byKey(const Key('restore-remote-backup')),
-    label: 'remote backup restore action',
-  );
-  await _pumpUntil(
-    tester,
-    () => find
-        .byKey(const Key('backup-recovery-passphrase'))
-        .evaluate()
-        .isNotEmpty,
-    label: 'remote backup recovery phrase dialog',
-  );
-  await tester.enterText(
-    find.byKey(const Key('backup-recovery-passphrase')),
-    _backupPassphrase,
-  );
-  FocusManager.instance.primaryFocus?.unfocus();
-  await tester.pump(const Duration(milliseconds: 400));
-  await _tapWhenReady(
-    tester,
-    find.byKey(const Key('backup-passphrase-submit')),
-    label: 'remote backup recovery',
-  );
+  return originalDeviceId;
+}
 
+Future<void> _expectDestructiveBackupRecovery(
+  WidgetTester tester,
+  WampAppController controller, {
+  required String originalDeviceId,
+  required Uint8List avatarBytes,
+  required String label,
+}) async {
   await _pumpUntil(
     tester,
     () {
@@ -732,7 +964,7 @@ Future<void> _restoreRemoteBackupAfterLocalVaultDeletion(
             ),
           );
     },
-    label: 'destructive encrypted cloud-backup recovery',
+    label: label,
     timeout: const Duration(minutes: 3),
   );
   expect(controller.backupError, isNull);

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -21,146 +21,174 @@ const _groupInboundText = String.fromEnvironment(
   'WAMP_APP_SMOKE_GROUP_INBOUND',
 );
 const _oneTimeText = String.fromEnvironment('WAMP_APP_SMOKE_VIEW_ONCE');
-const _callReadyOutbound = String.fromEnvironment(
+const _voiceCallReadyOutbound = String.fromEnvironment(
   'WAMP_APP_SMOKE_CALL_READY_OUTBOUND',
 );
-const _callReadyInbound = String.fromEnvironment(
+const _voiceCallReadyInbound = String.fromEnvironment(
   'WAMP_APP_SMOKE_CALL_READY_INBOUND',
+);
+const _videoCallReadyOutbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND',
+);
+const _videoCallReadyInbound = String.fromEnvironment(
+  'WAMP_APP_SMOKE_VIDEO_READY_INBOUND',
 );
 const _password = 'wamp-app-native-smoke-password';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('exchanges encrypted chat and completes a WebRTC voice call', (
-    tester,
-  ) async {
-    _validateConfiguration();
-    final controller = WampAppController(deviceName: '$_username device');
-    addTearDown(controller.dispose);
+  testWidgets(
+    'exchanges encrypted chat and completes WebRTC voice and video calls',
+    (tester) async {
+      _validateConfiguration();
+      final controller = WampAppController(deviceName: '$_username device');
+      addTearDown(controller.dispose);
 
-    await tester.pumpWidget(WampApp(controller: controller));
-    await _pumpUntil(
-      tester,
-      () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
-      label: 'onboarding form',
-    );
+      await tester.pumpWidget(WampApp(controller: controller));
+      await _pumpUntil(
+        tester,
+        () => find.byKey(const Key('submit-account')).evaluate().isNotEmpty,
+        label: 'onboarding form',
+      );
 
-    await tester.enterText(
-      find.byKey(const Key('server-address')),
-      _serverAddress,
-    );
-    await tester.enterText(find.byKey(const Key('username')), _username);
-    await tester.enterText(
-      find.byKey(const Key('display-name')),
-      'Native smoke $_username',
-    );
-    await tester.enterText(find.byKey(const Key('password')), _password);
-    final submit = find.byKey(const Key('submit-account'));
-    await tester.ensureVisible(submit);
-    await tester.tap(submit);
+      await tester.enterText(
+        find.byKey(const Key('server-address')),
+        _serverAddress,
+      );
+      await tester.enterText(find.byKey(const Key('username')), _username);
+      await tester.enterText(
+        find.byKey(const Key('display-name')),
+        'Native smoke $_username',
+      );
+      await tester.enterText(find.byKey(const Key('password')), _password);
+      final submit = find.byKey(const Key('submit-account'));
+      await tester.ensureVisible(submit);
+      await tester.tap(submit);
 
-    await _pumpUntil(
-      tester,
-      () =>
-          controller.status == WampAppStatus.connected &&
-          controller.connection?.username == _username &&
-          find.byKey(const Key('message-recipient')).evaluate().isNotEmpty,
-      label: 'authenticated conversation shell',
-      timeout: const Duration(minutes: 2),
-    );
-    await _waitForPeerDevice(tester, controller);
+      await _pumpUntil(
+        tester,
+        () =>
+            controller.status == WampAppStatus.connected &&
+            controller.connection?.username == _username &&
+            find.byKey(const Key('message-recipient')).evaluate().isNotEmpty,
+        label: 'authenticated conversation shell',
+        timeout: const Duration(minutes: 2),
+      );
+      await _waitForPeerDevice(tester, controller);
 
-    final recipient = find.byKey(const Key('message-recipient'));
-    final composer = find.byKey(const Key('message-composer'));
-    await tester.ensureVisible(recipient);
-    await tester.enterText(recipient, _peerUsername);
-    await tester.pump();
-    await _enterMessageWhenReady(
-      tester,
-      composer,
-      _outboundText,
-      label: 'direct-message composer',
-    );
-    final send = find.byKey(const Key('message-send'));
-    await tester.ensureVisible(send);
-    await _tapSendAndWaitOutbound(tester, controller, send);
-    final outbound = controller.messages.singleWhere(
-      (message) =>
-          message.outgoing &&
-          message.peerUsername == _peerUsername &&
-          message.text == _outboundText,
-    );
-    await _pumpUntil(
-      tester,
-      () =>
-          controller.outboundMessageFor(outbound.messageId) == null &&
-          controller.messageError == null,
-      label: 'router acceptance of outbound message',
-    );
-
-    await _pumpUntil(
-      tester,
-      () => controller.messages.any(
+      final recipient = find.byKey(const Key('message-recipient'));
+      final composer = find.byKey(const Key('message-composer'));
+      await tester.ensureVisible(recipient);
+      await tester.enterText(recipient, _peerUsername);
+      await tester.pump();
+      await _enterMessageWhenReady(
+        tester,
+        composer,
+        _outboundText,
+        label: 'direct-message composer',
+      );
+      final send = find.byKey(const Key('message-send'));
+      await tester.ensureVisible(send);
+      await _tapSendAndWaitOutbound(tester, controller, send);
+      final outbound = controller.messages.singleWhere(
         (message) =>
-            !message.outgoing &&
+            message.outgoing &&
             message.peerUsername == _peerUsername &&
-            message.text == _inboundText,
-      ),
-      label: 'mailbox wakeup and decrypted inbound message',
-      timeout: const Duration(minutes: 2),
-    );
-
-    FocusManager.instance.primaryFocus?.unfocus();
-    await _pumpUntil(
-      tester,
-      () =>
-          find.text(_outboundText).evaluate().isNotEmpty ||
-          find.text(_inboundText).evaluate().isNotEmpty,
-      label: 'rendered message history',
-    );
-    final outboundRendered = find.text(_outboundText).evaluate().isNotEmpty;
-    final inboundRendered = find.text(_inboundText).evaluate().isNotEmpty;
-    if (!outboundRendered || !inboundRendered) {
-      final history = find.byKey(const Key('message-history'));
-      final scrollable = find.descendant(
-        of: history,
-        matching: find.byType(Scrollable),
+            message.text == _outboundText,
       );
-      await tester.scrollUntilVisible(
-        find.text(outboundRendered ? _inboundText : _outboundText),
-        100,
-        scrollable: scrollable,
-        maxScrolls: 20,
+      await _pumpUntil(
+        tester,
+        () =>
+            controller.outboundMessageFor(outbound.messageId) == null &&
+            controller.messageError == null,
+        label: 'router acceptance of outbound message',
       );
-    }
-    expect(controller.messageError, isNull);
-    expect(
-      outboundRendered || find.text(_outboundText).evaluate().isNotEmpty,
-      isTrue,
-    );
-    expect(
-      inboundRendered || find.text(_inboundText).evaluate().isNotEmpty,
-      isTrue,
-    );
 
-    await _exerciseEncryptedGroupSticker(tester, controller);
-    await _exerciseViewOnceMessage(tester, controller);
-    await _exerciseEncryptedVoiceCall(tester, controller);
-  }, timeout: const Timeout(Duration(minutes: 10)));
+      await _pumpUntil(
+        tester,
+        () => controller.messages.any(
+          (message) =>
+              !message.outgoing &&
+              message.peerUsername == _peerUsername &&
+              message.text == _inboundText,
+        ),
+        label: 'mailbox wakeup and decrypted inbound message',
+        timeout: const Duration(minutes: 2),
+      );
+
+      FocusManager.instance.primaryFocus?.unfocus();
+      await _pumpUntil(
+        tester,
+        () =>
+            find.text(_outboundText).evaluate().isNotEmpty ||
+            find.text(_inboundText).evaluate().isNotEmpty,
+        label: 'rendered message history',
+      );
+      final outboundRendered = find.text(_outboundText).evaluate().isNotEmpty;
+      final inboundRendered = find.text(_inboundText).evaluate().isNotEmpty;
+      if (!outboundRendered || !inboundRendered) {
+        final history = find.byKey(const Key('message-history'));
+        final scrollable = find.descendant(
+          of: history,
+          matching: find.byType(Scrollable),
+        );
+        await tester.scrollUntilVisible(
+          find.text(outboundRendered ? _inboundText : _outboundText),
+          100,
+          scrollable: scrollable,
+          maxScrolls: 20,
+        );
+      }
+      expect(controller.messageError, isNull);
+      expect(
+        outboundRendered || find.text(_outboundText).evaluate().isNotEmpty,
+        isTrue,
+      );
+      expect(
+        inboundRendered || find.text(_inboundText).evaluate().isNotEmpty,
+        isTrue,
+      );
+
+      await _exerciseEncryptedGroupSticker(tester, controller);
+      await _exerciseViewOnceMessage(tester, controller);
+      await _exerciseWebRtcCall(
+        tester,
+        controller,
+        media: CallMediaKind.voice,
+        readyOutbound: _voiceCallReadyOutbound,
+        readyInbound: _voiceCallReadyInbound,
+      );
+      await _exerciseWebRtcCall(
+        tester,
+        controller,
+        media: CallMediaKind.video,
+        readyOutbound: _videoCallReadyOutbound,
+        readyInbound: _videoCallReadyInbound,
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
 }
 
-Future<void> _exerciseEncryptedVoiceCall(
+Future<void> _exerciseWebRtcCall(
   WidgetTester tester,
-  WampAppController controller,
-) async {
+  WampAppController controller, {
+  required CallMediaKind media,
+  required String readyOutbound,
+  required String readyInbound,
+}) async {
   await _selectDirectConversation(tester);
   final calls = controller.calls;
   expect(calls, isNotNull);
   expect(calls!.phase, CallUiPhase.idle);
+  final label = media == CallMediaKind.voice ? 'voice' : 'video';
+  final startKey = media == CallMediaKind.voice
+      ? 'conversation-voice-call'
+      : 'conversation-video-call';
 
   if (_role == 'initiator') {
-    final start = find.byKey(const Key('conversation-voice-call'));
+    final start = find.byKey(Key(startKey));
     await tester.ensureVisible(start);
     await tester.tap(start);
     await _pumpUntil(
@@ -169,7 +197,7 @@ Future<void> _exerciseEncryptedVoiceCall(
           calls.phase == CallUiPhase.outgoingRinging ||
           calls.phase == CallUiPhase.connecting ||
           calls.phase == CallUiPhase.active,
-      label: 'outgoing encrypted voice call',
+      label: 'outgoing secured $label call',
       timeout: const Duration(minutes: 2),
     );
     expect(find.byKey(const ValueKey('active-call')), findsOneWidget);
@@ -179,7 +207,7 @@ Future<void> _exerciseEncryptedVoiceCall(
       () =>
           calls.phase == CallUiPhase.incomingRinging &&
           find.byKey(const ValueKey('incoming-call')).evaluate().isNotEmpty,
-      label: 'incoming encrypted voice call',
+      label: 'incoming secured $label call',
       timeout: const Duration(minutes: 2),
     );
     final accept = find.byKey(const Key('call-accept'));
@@ -192,11 +220,14 @@ Future<void> _exerciseEncryptedVoiceCall(
     () =>
         calls.phase == CallUiPhase.active &&
         calls.call?.state == CallState.active &&
-        calls.call?.media == CallMediaKind.voice &&
+        calls.call?.media == media &&
         calls.mediaSession != null &&
+        calls.mediaSession?.media == media &&
         calls.peerUsername == _peerUsername &&
-        find.byKey(const ValueKey('active-call')).evaluate().isNotEmpty,
-    label: 'active WebRTC voice media with $_peerUsername',
+        find.byKey(const ValueKey('active-call')).evaluate().isNotEmpty &&
+        (media == CallMediaKind.voice ||
+            find.byKey(const Key('call-local-video')).evaluate().isNotEmpty),
+    label: 'active WebRTC $label media with $_peerUsername',
     timeout: const Duration(minutes: 2),
   );
   expect(calls.errorMessage, isNull);
@@ -208,7 +239,7 @@ Future<void> _exerciseEncryptedVoiceCall(
   );
   final markerSent = await controller.sendMessage(
     recipientUsername: _peerUsername,
-    text: _callReadyOutbound,
+    text: readyOutbound,
   );
   if (!markerSent) {
     fail(
@@ -221,7 +252,7 @@ Future<void> _exerciseEncryptedVoiceCall(
         message.outgoing &&
         !message.isGroup &&
         message.peerUsername == _peerUsername &&
-        message.text == _callReadyOutbound,
+        message.text == readyOutbound,
   );
   await _pumpUntil(
     tester,
@@ -232,27 +263,45 @@ Future<void> _exerciseEncryptedVoiceCall(
               !message.outgoing &&
               !message.isGroup &&
               message.peerUsername == _peerUsername &&
-              message.text == _callReadyInbound,
+              message.text == readyInbound,
         ),
-    label: 'both devices active in the same voice call',
+    label: 'both devices active in the same $label call',
     timeout: const Duration(minutes: 2),
   );
 
   if (_role == 'initiator') {
-    final mute = find.byKey(const Key('call-mute'));
-    await tester.ensureVisible(mute);
-    await tester.tap(mute);
-    await _pumpUntil(
-      tester,
-      () => calls.mediaSession?.muted ?? false,
-      label: 'muted native voice track',
-    );
-    await tester.tap(mute);
-    await _pumpUntil(
-      tester,
-      () => !(calls.mediaSession?.muted ?? true),
-      label: 'unmuted native voice track',
-    );
+    if (media == CallMediaKind.voice) {
+      final mute = find.byKey(const Key('call-mute'));
+      await tester.ensureVisible(mute);
+      await tester.tap(mute);
+      await _pumpUntil(
+        tester,
+        () => calls.mediaSession?.muted ?? false,
+        label: 'muted native voice track',
+      );
+      await tester.tap(mute);
+      await _pumpUntil(
+        tester,
+        () => !(calls.mediaSession?.muted ?? true),
+        label: 'unmuted native voice track',
+      );
+    } else {
+      expect(calls.mediaSession?.cameraEnabled, isTrue);
+      final camera = find.byKey(const Key('call-camera'));
+      await tester.ensureVisible(camera);
+      await tester.tap(camera);
+      await _pumpUntil(
+        tester,
+        () => !(calls.mediaSession?.cameraEnabled ?? true),
+        label: 'disabled native video track',
+      );
+      await tester.tap(camera);
+      await _pumpUntil(
+        tester,
+        () => calls.mediaSession?.cameraEnabled ?? false,
+        label: 're-enabled native video track',
+      );
+    }
     final end = find.byKey(const Key('call-end'));
     await tester.ensureVisible(end);
     await tester.tap(end);
@@ -265,19 +314,22 @@ Future<void> _exerciseEncryptedVoiceCall(
         calls.mediaSession == null &&
         find.byKey(const ValueKey('call-result')).evaluate().isNotEmpty,
     label: _role == 'initiator'
-        ? 'local voice-call teardown'
-        : 'remote voice-call teardown',
+        ? 'local $label-call teardown'
+        : 'remote $label-call teardown',
     timeout: const Duration(minutes: 2),
   );
   expect(calls.errorMessage, isNull);
   await tester.pump(const Duration(milliseconds: 350));
+  if (media == CallMediaKind.video) {
+    expect(find.byKey(const Key('call-local-video')), findsNothing);
+  }
   final dismiss = find.byKey(const Key('call-dismiss'));
   await tester.ensureVisible(dismiss);
   await tester.tap(dismiss);
   await _pumpUntil(
     tester,
     () => calls.phase == CallUiPhase.idle && !calls.hasCall,
-    label: 'dismissed completed voice call',
+    label: 'dismissed completed $label call',
   );
 }
 
@@ -337,12 +389,13 @@ Future<void> _createGroupAndSendSticker(
   final expression = find.byKey(const Key('message-expression'));
   await tester.ensureVisible(expression);
   await tester.tap(expression);
+  final stickerTab = find.byKey(const Key('expression-sticker-tab'));
   await _pumpUntil(
     tester,
-    () => find.byKey(const Key('expression-sticker-tab')).evaluate().isNotEmpty,
+    () => stickerTab.hitTestable().evaluate().isNotEmpty,
     label: 'expression picker',
   );
-  await tester.tap(find.byKey(const Key('expression-sticker-tab')));
+  await tester.tap(stickerTab);
   await tester.pump(const Duration(milliseconds: 400));
   final sticker = find.byKey(const ValueKey('sticker-nice'));
   await tester.ensureVisible(sticker);
@@ -477,8 +530,22 @@ Future<void> _receiveStickerAndReply(
     () => attachmentCard.evaluate().isNotEmpty,
     label: 'rendered encrypted sticker attachment card',
   );
-  await tester.ensureVisible(attachmentCard);
-  await tester.tap(attachmentCard);
+  await Scrollable.ensureVisible(
+    attachmentCard.evaluate().single,
+    alignment: 0.5,
+  );
+  await tester.pump();
+  final attachmentRect = tester.getRect(attachmentCard);
+  final historyRect = tester.getRect(find.byKey(const Key('message-history')));
+  final visibleAttachmentRect = attachmentRect.intersect(historyRect);
+  expect(
+    visibleAttachmentRect.height,
+    greaterThanOrEqualTo(24),
+    reason:
+        'The encrypted sticker attachment must have a usable tap target in '
+        'history (attachment: $attachmentRect, history: $historyRect).',
+  );
+  await tester.tapAt(visibleAttachmentRect.center);
   final preview = find.byKey(
     ValueKey('attachment-preview-${attachment.attachmentId}'),
   );
@@ -735,8 +802,10 @@ void _validateConfiguration() {
     'WAMP_APP_SMOKE_GROUP_OUTBOUND': _groupOutboundText,
     'WAMP_APP_SMOKE_GROUP_INBOUND': _groupInboundText,
     'WAMP_APP_SMOKE_VIEW_ONCE': _oneTimeText,
-    'WAMP_APP_SMOKE_CALL_READY_OUTBOUND': _callReadyOutbound,
-    'WAMP_APP_SMOKE_CALL_READY_INBOUND': _callReadyInbound,
+    'WAMP_APP_SMOKE_CALL_READY_OUTBOUND': _voiceCallReadyOutbound,
+    'WAMP_APP_SMOKE_CALL_READY_INBOUND': _voiceCallReadyInbound,
+    'WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND': _videoCallReadyOutbound,
+    'WAMP_APP_SMOKE_VIDEO_READY_INBOUND': _videoCallReadyInbound,
   };
   for (final entry in values.entries) {
     if (entry.value.trim().isEmpty) {
@@ -752,8 +821,10 @@ void _validateConfiguration() {
     _groupOutboundText,
     _groupInboundText,
     _oneTimeText,
-    _callReadyOutbound,
-    _callReadyInbound,
+    _voiceCallReadyOutbound,
+    _voiceCallReadyInbound,
+    _videoCallReadyOutbound,
+    _videoCallReadyInbound,
   ];
   if (_username == _peerUsername ||
       messageTokens.toSet().length != messageTokens.length) {

--- a/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
+++ b/examples/wamp_app/client/integration_test/two_device_smoke_test.dart
@@ -7,6 +7,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:wamp_app/src/app.dart';
 import 'package:wamp_app/src/application/call_controller.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
+import 'package:wamp_app/src/domain/local_app_preferences.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
 import 'package:wamp_app/src/infrastructure/contact_importer.dart';
@@ -532,6 +533,21 @@ Future<void> _setLocalConversationPreferences(
   if (conversationId == null) {
     fail('The direct conversation was unavailable for local preferences.');
   }
+  final appearance = find.byKey(const Key('conversation-appearance-menu'));
+  await _tapWhenReady(tester, appearance, label: 'chat appearance menu');
+  await _tapWhenReady(
+    tester,
+    find.byKey(const ValueKey('conversation-appearance-ocean')),
+    label: 'ocean chat appearance',
+  );
+  await _pumpUntil(
+    tester,
+    () =>
+        !controller.preferenceBusy &&
+        controller.conversationAppearanceFor(conversationId) ==
+            WampAppConversationAppearance.ocean,
+    label: 'persisted chat appearance',
+  );
   final mute = find.byKey(const Key('conversation-mute'));
   await _tapWhenReady(tester, mute, label: 'conversation mute');
   await _pumpUntil(
@@ -930,6 +946,8 @@ Future<void> _expectDestructiveBackupRecovery(
           controller.localDevice?.deviceId == originalDeviceId &&
           controller.themePreference.wireName == 'dark' &&
           conversationId != null &&
+          controller.conversationAppearanceFor(conversationId) ==
+              WampAppConversationAppearance.ocean &&
           controller.isConversationMuted(conversationId) &&
           controller.disappearingMessagesFor(conversationId) ==
               const Duration(hours: 1) &&

--- a/examples/wamp_app/client/lib/src/app.dart
+++ b/examples/wamp_app/client/lib/src/app.dart
@@ -4,6 +4,7 @@ import 'application/wamp_app_controller.dart';
 import 'domain/local_app_preferences.dart';
 import 'infrastructure/contact_importer.dart';
 import 'infrastructure/platform_push_token_source.dart';
+import 'infrastructure/profile_avatar_picker.dart';
 import 'ui/home_page.dart';
 import 'ui/onboarding_page.dart';
 import 'ui/wamp_app_theme.dart';
@@ -14,11 +15,13 @@ class WampApp extends StatefulWidget {
     this.controller,
     this.platformPushTokenSource,
     this.contactImporter,
+    this.profileAvatarPicker,
   }) : assert(controller == null || platformPushTokenSource == null);
 
   final WampAppController? controller;
   final PlatformPushTokenSource? platformPushTokenSource;
   final ContactImporter? contactImporter;
+  final ProfileAvatarPicker? profileAvatarPicker;
 
   @override
   State<WampApp> createState() => _WampAppState();
@@ -69,6 +72,7 @@ class _WampAppState extends State<WampApp> {
                   controller: _controller,
                   connection: connection,
                   contactImporter: widget.contactImporter,
+                  profileAvatarPicker: widget.profileAvatarPicker,
                 );
               }
               return OnboardingPage(controller: _controller);

--- a/examples/wamp_app/client/lib/src/application/call_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/call_controller.dart
@@ -436,7 +436,9 @@ final class CallController extends ChangeNotifier {
     }
     await _applySignals(update);
     if (record.state == CallState.active && _mediaSession != null) {
-      _phase = CallUiPhase.connecting;
+      if (_phase != CallUiPhase.active) {
+        _phase = CallUiPhase.connecting;
+      }
       await _flushLocalCandidates();
       notifyListeners();
     }
@@ -459,8 +461,8 @@ final class CallController extends ChangeNotifier {
           final media = _mediaSession;
           if (media == null) continue;
           _remoteDevice = sender;
-          await media.applyAnswer(description);
           _phase = CallUiPhase.connecting;
+          await media.applyAnswer(description);
           await _flushLocalCandidates();
         case CallCandidateSignalPayload(:final candidate):
           await _mediaSession?.addRemoteCandidate(candidate);

--- a/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
@@ -85,6 +85,7 @@ class WampAppController extends ChangeNotifier {
   int _pendingMailboxWakeupCursor = 0;
   bool _automaticSyncRunning = false;
   int _operationGeneration = 0;
+  Future<void>? _signOutOperation;
   bool _disposed = false;
 
   WampAppStatus get status => _status;
@@ -463,6 +464,23 @@ class WampAppController extends ChangeNotifier {
   }
 
   Future<void> signOut() async {
+    final activeOperation = _signOutOperation;
+    if (activeOperation != null) {
+      await activeOperation;
+      return;
+    }
+    final operation = _performSignOut();
+    _signOutOperation = operation;
+    try {
+      await operation;
+    } finally {
+      if (identical(_signOutOperation, operation)) {
+        _signOutOperation = null;
+      }
+    }
+  }
+
+  Future<void> _performSignOut() async {
     if (_backupBusy) return;
     _operationGeneration += 1;
     _messageExpiryTimer?.cancel();

--- a/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
@@ -91,6 +91,7 @@ class WampAppController extends ChangeNotifier {
   Object? _messageExpiryError;
   Object? _profileError;
   Object? _contactError;
+  Object? _mcpAccessError;
   Object? _mcpConsentError;
   Object? _preferenceError;
   Object? _platformPushError;
@@ -101,6 +102,7 @@ class WampAppController extends ChangeNotifier {
   bool _messageBusy = false;
   bool _profileBusy = false;
   bool _contactBusy = false;
+  bool _mcpAccessBusy = false;
   bool _mcpConsentBusy = false;
   bool _preferenceBusy = false;
   bool _backupBusy = false;
@@ -129,6 +131,7 @@ class WampAppController extends ChangeNotifier {
   bool get messageBusy => _messageBusy;
   bool get profileBusy => _profileBusy;
   bool get contactBusy => _contactBusy;
+  bool get mcpAccessBusy => _mcpAccessBusy;
   bool get mcpConsentBusy => _mcpConsentBusy;
   WampAppMcpConsent get mcpConsent =>
       _connection?.mcpConsent ?? WampAppMcpConsent.denied;
@@ -160,6 +163,14 @@ class WampAppController extends ChangeNotifier {
   String? get contactError => switch (_contactError) {
     FormatException(:final message) => message,
     _ when _contactError != null => 'The local contact operation failed.',
+    _ => null,
+  };
+  String? get mcpAccessError => switch (_mcpAccessError) {
+    FormatException(:final message) => message,
+    McpAccessException() => _mcpAccessError.toString(),
+    StateError() => 'MCP access discovery is unavailable.',
+    _ when _mcpAccessError != null =>
+      'Could not load MCP connection information.',
     _ => null,
   };
   String? get mcpConsentError => switch (_mcpConsentError) {
@@ -553,6 +564,7 @@ class WampAppController extends ChangeNotifier {
     _messageExpiryError = null;
     _profileError = null;
     _contactError = null;
+    _mcpAccessError = null;
     _mcpConsentError = null;
     _preferenceError = null;
     _platformPushError = null;
@@ -562,6 +574,7 @@ class WampAppController extends ChangeNotifier {
     _messageBusy = false;
     _profileBusy = false;
     _contactBusy = false;
+    _mcpAccessBusy = false;
     _mcpConsentBusy = false;
     _preferenceBusy = false;
     _backupBusy = false;
@@ -611,6 +624,31 @@ class WampAppController extends ChangeNotifier {
     } finally {
       if (isCurrent()) {
         _profileBusy = false;
+        notifyListeners();
+      }
+    }
+  }
+
+  Future<WampAppMcpAccessConfiguration?> loadMcpAccessConfiguration() async {
+    final connection = _connection;
+    if (_disposed || _mcpAccessBusy || connection == null) return null;
+    final generation = _operationGeneration;
+    bool isCurrent() =>
+        !_disposed &&
+        generation == _operationGeneration &&
+        identical(connection, _connection);
+    _mcpAccessBusy = true;
+    _mcpAccessError = null;
+    notifyListeners();
+    try {
+      final configuration = await connection.getMcpAccessConfiguration();
+      return isCurrent() ? configuration : null;
+    } catch (error) {
+      if (isCurrent()) _mcpAccessError = error;
+      return null;
+    } finally {
+      if (isCurrent()) {
+        _mcpAccessBusy = false;
         notifyListeners();
       }
     }
@@ -822,6 +860,7 @@ class WampAppController extends ChangeNotifier {
     _error = null;
     _messageError = null;
     _contactError = null;
+    _mcpAccessError = null;
     _mcpConsentError = null;
     _status = WampAppStatus.busy;
     notifyListeners();
@@ -939,12 +978,14 @@ class WampAppController extends ChangeNotifier {
     _replaceMessages(nextMessages);
     _messageError = nextWakeupError;
     _messageExpiryError = null;
+    _mcpAccessError = null;
     _mcpConsentError = null;
     _contactError = null;
     _preferenceError = null;
     _platformPushError = null;
     _preferenceBusy = false;
     _contactBusy = false;
+    _mcpAccessBusy = false;
     _mcpConsentBusy = false;
     _status = WampAppStatus.connected;
     notifyListeners();

--- a/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
@@ -173,6 +173,10 @@ class WampAppController extends ChangeNotifier {
   bool isConversationMuted(String conversationId) =>
       _preferences.isMuted(conversationId);
 
+  WampAppConversationAppearance conversationAppearanceFor(
+    String conversationId,
+  ) => _preferences.conversationAppearanceFor(conversationId);
+
   bool shouldPresentNotificationFor(LocalChatMessage message) =>
       _connection != null &&
       !message.outgoing &&
@@ -190,6 +194,24 @@ class WampAppController extends ChangeNotifier {
     try {
       return _savePreferences(
         _preferences.withConversationMuted(conversationId, muted),
+      );
+    } on FormatException catch (error) {
+      _preferenceError = error;
+      if (!_disposed) notifyListeners();
+      return Future<bool>.value(false);
+    }
+  }
+
+  Future<bool> setConversationAppearance(
+    String conversationId,
+    WampAppConversationAppearance appearance,
+  ) {
+    if (_preferences.conversationAppearanceFor(conversationId) == appearance) {
+      return Future<bool>.value(true);
+    }
+    try {
+      return _savePreferences(
+        _preferences.withConversationAppearance(conversationId, appearance),
       );
     } on FormatException catch (error) {
       _preferenceError = error;

--- a/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
@@ -23,6 +23,41 @@ import 'call_controller.dart';
 
 enum WampAppStatus { signedOut, busy, connected, failed }
 
+enum PeerTrustStatus { unverified, verified, changed }
+
+final class PeerDeviceTrust {
+  const PeerDeviceTrust({
+    required this.device,
+    required this.safetyNumber,
+    required this.verified,
+  });
+
+  final DeviceRecord device;
+  final String safetyNumber;
+  final bool verified;
+}
+
+final class PeerTrustSummary {
+  PeerTrustSummary({
+    required this.username,
+    required Iterable<PeerDeviceTrust> devices,
+    required this.previouslyVerified,
+  }) : devices = List<PeerDeviceTrust>.unmodifiable(devices);
+
+  final String username;
+  final List<PeerDeviceTrust> devices;
+  final bool previouslyVerified;
+
+  PeerTrustStatus get status {
+    if (devices.isNotEmpty && devices.every((device) => device.verified)) {
+      return PeerTrustStatus.verified;
+    }
+    return previouslyVerified
+        ? PeerTrustStatus.changed
+        : PeerTrustStatus.unverified;
+  }
+}
+
 final class OpenedOneTimeMessage {
   OpenedOneTimeMessage._({
     required this.messageId,
@@ -1053,6 +1088,17 @@ class WampAppController extends ChangeNotifier {
       final recipientDevices = await connection.lookupDevices(
         recipientUsername,
       );
+      if (recipientDevices.devices.isEmpty) {
+        final username = AccountRegistration.normalizeUsername(
+          recipientUsername,
+        );
+        throw FormatException('@$username has no active device.');
+      }
+      _ensurePeerTrustAllowsSending(
+        trust,
+        recipientUsername,
+        recipientDevices.devices,
+      );
       final participants = <String, DeviceRecord>{
         for (final device in [
           ...ownDevices.devices,
@@ -1291,6 +1337,9 @@ class WampAppController extends ChangeNotifier {
         if (directory.devices.isEmpty) {
           throw FormatException('@$username has no active device.');
         }
+        if (username != connection.username) {
+          _ensurePeerTrustAllowsSending(trust, username, directory.devices);
+        }
         for (final device in directory.devices) {
           participants['${device.username}\n${device.deviceId}'] = device;
         }
@@ -1403,6 +1452,92 @@ class WampAppController extends ChangeNotifier {
         }
       }
     }
+  }
+
+  Future<PeerTrustSummary?> inspectPeerTrust(String username) async {
+    final connection = _connection;
+    final trust = _trustSession;
+    if (_disposed || connection == null || trust == null) return null;
+    final normalized = AccountRegistration.normalizeUsername(username);
+    final generation = _operationGeneration;
+    bool isCurrent() =>
+        !_disposed &&
+        generation == _operationGeneration &&
+        identical(connection, _connection) &&
+        identical(trust, _trustSession);
+    final directory = normalized == connection.username
+        ? await connection.listDevices()
+        : await connection.lookupDevices(normalized);
+    if (!isCurrent()) return null;
+    if (directory.devices.isEmpty) {
+      throw FormatException('@$normalized has no active device.');
+    }
+    return _peerTrustSummary(trust, normalized, directory.devices);
+  }
+
+  Future<PeerTrustSummary?> verifyPeerDevice(PeerDeviceTrust expected) async {
+    final connection = _connection;
+    final trust = _trustSession;
+    if (_disposed || connection == null || trust == null) return null;
+    final username = AccountRegistration.normalizeUsername(
+      expected.device.username,
+    );
+    final generation = _operationGeneration;
+    bool isCurrent() =>
+        !_disposed &&
+        generation == _operationGeneration &&
+        identical(connection, _connection) &&
+        identical(trust, _trustSession);
+    final directory = username == connection.username
+        ? await connection.listDevices()
+        : await connection.lookupDevices(username);
+    if (!isCurrent()) return null;
+    final current = directory.devices
+        .where((device) => device.deviceId == expected.device.deviceId)
+        .firstOrNull;
+    if (current == null ||
+        trust.safetyNumberFor(current) != expected.safetyNumber) {
+      throw const FormatException(
+        'That device identity changed before verification completed.',
+      );
+    }
+    await trust.markVerified(current);
+    if (!isCurrent()) return null;
+    return _peerTrustSummary(trust, username, directory.devices);
+  }
+
+  PeerTrustSummary _peerTrustSummary(
+    DeviceTrustSession trust,
+    String username,
+    Iterable<DeviceRecord> devices,
+  ) {
+    return PeerTrustSummary(
+      username: username,
+      devices: devices.map(
+        (device) => PeerDeviceTrust(
+          device: device,
+          safetyNumber: trust.safetyNumberFor(device),
+          verified: trust.isVerified(device),
+        ),
+      ),
+      previouslyVerified: trust.hasVerifiedContact(username),
+    );
+  }
+
+  void _ensurePeerTrustAllowsSending(
+    DeviceTrustSession trust,
+    String username,
+    Iterable<DeviceRecord> devices,
+  ) {
+    final normalized = AccountRegistration.normalizeUsername(username);
+    if (!trust.hasVerifiedContact(normalized) ||
+        devices.every(trust.isVerified)) {
+      return;
+    }
+    throw FormatException(
+      'Encryption identity changed for @$normalized. Review and verify every '
+      'active device before sending.',
+    );
   }
 
   Future<bool> retryMessage(String messageId) async {

--- a/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
@@ -21,6 +22,29 @@ import '../infrastructure/wamp_account_gateway.dart';
 import 'call_controller.dart';
 
 enum WampAppStatus { signedOut, busy, connected, failed }
+
+final class OpenedOneTimeMessage {
+  OpenedOneTimeMessage._({
+    required this.messageId,
+    required this.text,
+    required Iterable<EncryptedAttachmentDescriptor> attachments,
+    required this._scope,
+    required this._senderUsername,
+  }) : _attachments = attachments.toList(growable: true) {
+    this.attachments = UnmodifiableListView<EncryptedAttachmentDescriptor>(
+      _attachments,
+    );
+  }
+
+  final String messageId;
+  final String text;
+  late final List<EncryptedAttachmentDescriptor> attachments;
+  final List<EncryptedAttachmentDescriptor> _attachments;
+  final String _scope;
+  final String _senderUsername;
+
+  void _invalidate() => _attachments.clear();
+}
 
 class WampAppController extends ChangeNotifier {
   WampAppController({
@@ -86,6 +110,7 @@ class WampAppController extends ChangeNotifier {
   bool _automaticSyncRunning = false;
   int _operationGeneration = 0;
   Future<void>? _signOutOperation;
+  OpenedOneTimeMessage? _openedOneTimeMessage;
   bool _disposed = false;
 
   WampAppStatus get status => _status;
@@ -511,6 +536,10 @@ class WampAppController extends ChangeNotifier {
     final trustSession = _trustSession;
     final wakeupSubscription = _mailboxWakeupSubscription;
     final calls = _calls;
+    final openedOneTimeMessage = _openedOneTimeMessage;
+    final openedOneTimeMessageHasAttachments =
+        openedOneTimeMessage?.attachments.isNotEmpty ?? false;
+    openedOneTimeMessage?._invalidate();
     _connection = null;
     _trustSession = null;
     _localDevice = null;
@@ -518,6 +547,7 @@ class WampAppController extends ChangeNotifier {
     _mailboxWakeupSubscription = null;
     _pendingMailboxWakeupCursor = 0;
     _automaticSyncRunning = false;
+    _openedOneTimeMessage = null;
     _error = null;
     _messageError = null;
     _messageExpiryError = null;
@@ -538,8 +568,18 @@ class WampAppController extends ChangeNotifier {
     _preferences = LocalAppPreferences.defaults;
     _status = WampAppStatus.signedOut;
     if (!_disposed) notifyListeners();
-    await _platformPush.clear();
-    await _closeState(connection, trustSession, wakeupSubscription, calls);
+    try {
+      await Future.wait<void>([
+        _platformPush.clear(),
+        if (openedOneTimeMessage != null && openedOneTimeMessageHasAttachments)
+          _attachmentCache.removeMessage(
+            scope: openedOneTimeMessage._scope,
+            messageId: openedOneTimeMessage.messageId,
+          ),
+      ]);
+    } finally {
+      await _closeState(connection, trustSession, wakeupSubscription, calls);
+    }
   }
 
   Future<bool> updateProfile(AccountProfileUpdate update) async {
@@ -967,11 +1007,6 @@ class WampAppController extends ChangeNotifier {
       if (effectiveExpiresAfter != null &&
           effectiveExpiresAfter <= Duration.zero) {
         throw const FormatException('Message expiry must be positive.');
-      }
-      if (oneTime && attachmentSources.isNotEmpty) {
-        throw const FormatException(
-          'View-once attachments are not supported yet.',
-        );
       }
       final ownDevices = await connection.listDevices();
       final recipientDevices = await connection.lookupDevices(
@@ -1544,7 +1579,7 @@ class WampAppController extends ChangeNotifier {
     }
   }
 
-  Future<String?> consumeOneTimeMessage(String messageId) async {
+  Future<OpenedOneTimeMessage?> consumeOneTimeMessage(String messageId) async {
     final connection = _connection;
     final trust = _trustSession;
     final localDevice = _localDevice;
@@ -1563,26 +1598,76 @@ class WampAppController extends ChangeNotifier {
     }
     final generation = _operationGeneration;
     var synchronized = false;
+    OpenedOneTimeMessage? opened;
     _messageBusy = true;
     _messageError = null;
     notifyListeners();
     try {
+      await _discardOpenedOneTimeMessage();
+      final scope = attachmentCacheScope(
+        connection.endpoint,
+        connection.username,
+      );
+      final senderUsername = message.peerUsername;
+      for (final attachment in message.attachments) {
+        await _attachmentCipher.cacheEncryptedChunks(
+          scope: scope,
+          senderUsername: senderUsername,
+          messageId: message.messageId,
+          attachment: attachment,
+          cache: _attachmentCache,
+          fetchChunk: (chunkIndex) => connection.getAttachmentChunk(
+            messageId: message.messageId,
+            attachmentId: attachment.attachmentId,
+            chunkIndex: chunkIndex,
+          ),
+          isCancelled: () =>
+              _disposed ||
+              generation != _operationGeneration ||
+              connection != _connection ||
+              trust != _trustSession,
+        );
+      }
       final consumption = trust.signOneTimeConsumption(messageId);
       if (consumption.deviceId != localDevice.deviceId) {
         throw StateError('The local device identity changed unexpectedly.');
       }
       await connection.consumeOneTime(consumption);
+      opened = OpenedOneTimeMessage._(
+        messageId: message.messageId,
+        text: message.text,
+        attachments: message.attachments,
+        scope: scope,
+        senderUsername: senderUsername,
+      );
+      _openedOneTimeMessage = opened;
       final updated = await _synchronize(connection, trust, localDevice);
       if (_disposed ||
           generation != _operationGeneration ||
           connection != _connection ||
           trust != _trustSession) {
+        await _discardOpenedOneTimeMessage(only: opened);
         return null;
       }
       _replaceMessages(updated);
       synchronized = true;
-      return message.text;
+      return opened;
     } catch (error) {
+      try {
+        if (opened != null) {
+          await _discardOpenedOneTimeMessage(only: opened);
+        } else if (message.attachments.isNotEmpty) {
+          await _attachmentCache.removeMessage(
+            scope: attachmentCacheScope(
+              connection.endpoint,
+              connection.username,
+            ),
+            messageId: message.messageId,
+          );
+        }
+      } catch (_) {
+        // Preserve the consumption or synchronization error for the UI.
+      }
       if (!_disposed &&
           generation == _operationGeneration &&
           connection == _connection) {
@@ -1600,6 +1685,89 @@ class WampAppController extends ChangeNotifier {
         }
       }
     }
+  }
+
+  Future<Uint8List?> loadOpenedOneTimeAttachment({
+    required OpenedOneTimeMessage message,
+    required String attachmentId,
+  }) async {
+    final connection = _connection;
+    final trust = _trustSession;
+    final attachment = message.attachments
+        .where((candidate) => candidate.attachmentId == attachmentId)
+        .firstOrNull;
+    if (_disposed ||
+        _messageBusy ||
+        connection == null ||
+        trust == null ||
+        !identical(_openedOneTimeMessage, message) ||
+        attachment == null) {
+      return null;
+    }
+    final generation = _operationGeneration;
+    bool isCurrent() =>
+        !_disposed &&
+        generation == _operationGeneration &&
+        identical(connection, _connection) &&
+        identical(trust, _trustSession) &&
+        identical(_openedOneTimeMessage, message);
+    _messageBusy = true;
+    _messageError = null;
+    notifyListeners();
+    try {
+      final opened = await _attachmentCipher.decryptToBytes(
+        scope: message._scope,
+        senderUsername: message._senderUsername,
+        messageId: message.messageId,
+        attachment: attachment,
+        cache: _attachmentCache,
+        isCancelled: () => !isCurrent(),
+      );
+      if (!isCurrent()) {
+        opened.fillRange(0, opened.length, 0);
+        return null;
+      }
+      return opened;
+    } catch (error) {
+      if (isCurrent()) _messageError = error;
+      return null;
+    } finally {
+      if (isCurrent()) {
+        _messageBusy = false;
+        notifyListeners();
+        _startAutomaticSyncIfNeeded();
+      }
+    }
+  }
+
+  Future<void> closeOpenedOneTimeMessage(OpenedOneTimeMessage message) async {
+    if (!identical(_openedOneTimeMessage, message)) return;
+    try {
+      await _discardOpenedOneTimeMessage(only: message);
+    } catch (error) {
+      if (!_disposed) _messageError = error;
+    } finally {
+      if (!_disposed) {
+        _messageBusy = false;
+        notifyListeners();
+        _startAutomaticSyncIfNeeded();
+      }
+    }
+  }
+
+  Future<void> _discardOpenedOneTimeMessage({
+    OpenedOneTimeMessage? only,
+  }) async {
+    final opened = _openedOneTimeMessage;
+    if (opened == null || (only != null && !identical(opened, only))) return;
+    _openedOneTimeMessage = null;
+    final hasAttachments = opened.attachments.isNotEmpty;
+    opened._invalidate();
+    if (!hasAttachments) return;
+    await _attachmentCache.removeMessage(
+      scope: opened._scope,
+      messageId: opened.messageId,
+    );
   }
 
   Future<void> refreshMessages() async {
@@ -2053,6 +2221,7 @@ class WampAppController extends ChangeNotifier {
     final groupsById = <String, LocalChatGroup>{
       for (final group in trust.groups) group.conversationId: group,
     };
+    final consumedOneTimeMessageIds = <String>{};
     for (var page = 0; page < 20; page += 1) {
       final batch = await connection.syncMessages(afterCursor: cursor);
       if (batch.nextCursor < cursor) {
@@ -2065,6 +2234,9 @@ class WampAppController extends ChangeNotifier {
             encrypted.oneTime &&
             encrypted.recipientUsername == connection.username &&
             recipientState?.consumedAt != null) {
+          if (encrypted.attachmentIds.isNotEmpty) {
+            consumedOneTimeMessageIds.add(encrypted.messageId);
+          }
           byId.remove(encrypted.messageId);
           outboxById.remove(encrypted.messageId);
           continue;
@@ -2158,6 +2330,15 @@ class WampAppController extends ChangeNotifier {
             ? created
             : left.conversationId.compareTo(right.conversationId);
       });
+    final activeOpenedMessageId = _openedOneTimeMessage?.messageId;
+    final scope = attachmentCacheScope(
+      connection.endpoint,
+      connection.username,
+    );
+    for (final messageId in consumedOneTimeMessageIds) {
+      if (messageId == activeOpenedMessageId) continue;
+      await _attachmentCache.removeMessage(scope: scope, messageId: messageId);
+    }
     await trust.saveMailboxState(
       cursor: cursor,
       messages: updated,
@@ -2184,6 +2365,8 @@ class WampAppController extends ChangeNotifier {
     _mailboxWakeupSubscription = null;
     _pendingMailboxWakeupCursor = 0;
     _automaticSyncRunning = false;
+    _openedOneTimeMessage?._invalidate();
+    _openedOneTimeMessage = null;
     unawaited(
       Future.wait<void>([
         _platformPush.dispose().then(

--- a/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
+++ b/examples/wamp_app/client/lib/src/application/wamp_app_controller.dart
@@ -370,6 +370,15 @@ class WampAppController extends ChangeNotifier {
     });
   }
 
+  Future<void> probeServer({required String serverAddress}) async {
+    if (_disposed) {
+      throw StateError('WampAppController is disposed.');
+    }
+    final endpoint = ServerEndpoint.parse(serverAddress);
+    endpoint.requireSecureRegistration();
+    await _gateway.probe(endpoint: endpoint);
+  }
+
   Future<void> login({
     required String serverAddress,
     required String username,

--- a/examples/wamp_app/client/lib/src/domain/local_app_preferences.dart
+++ b/examples/wamp_app/client/lib/src/domain/local_app_preferences.dart
@@ -18,11 +18,37 @@ enum WampAppThemePreference {
   }
 }
 
+enum WampAppConversationAppearance {
+  standard('standard'),
+  ocean('ocean'),
+  sunset('sunset');
+
+  const WampAppConversationAppearance(this.wireName);
+
+  final String wireName;
+
+  static WampAppConversationAppearance parse(Object? value) {
+    if (value is! String) {
+      throw const FormatException(
+        'A saved conversation appearance is invalid.',
+      );
+    }
+    return values
+            .where((candidate) => candidate.wireName == value)
+            .firstOrNull ??
+        (throw const FormatException(
+          'A saved conversation appearance is invalid.',
+        ));
+  }
+}
+
 final class LocalAppPreferences {
   factory LocalAppPreferences({
     WampAppThemePreference theme = WampAppThemePreference.system,
     Iterable<String> mutedConversationIds = const [],
     Map<String, Duration> disappearingMessageDurations = const {},
+    Map<String, WampAppConversationAppearance> conversationAppearances =
+        const {},
   }) {
     final rawIds = mutedConversationIds.toList(growable: false);
     final uniqueIds = rawIds.toSet();
@@ -31,10 +57,25 @@ final class LocalAppPreferences {
         'Muted conversation identifiers must be unique.',
       );
     }
+    final appearances = Map<String, WampAppConversationAppearance>.of(
+      conversationAppearances,
+    );
+    if (appearances.length > maxConversationAppearances) {
+      throw const FormatException(
+        'Too many conversation appearances are saved.',
+      );
+    }
+    for (final conversationId in appearances.keys) {
+      _validateConversationId(conversationId, 'appearance');
+    }
+    appearances.removeWhere(
+      (_, appearance) => appearance == WampAppConversationAppearance.standard,
+    );
     return LocalAppPreferences._(
       theme,
       uniqueIds,
       Map<String, Duration>.of(disappearingMessageDurations),
+      appearances,
     );
   }
 
@@ -42,15 +83,21 @@ final class LocalAppPreferences {
     this.theme,
     Set<String> mutedConversationIds,
     Map<String, Duration> disappearingMessageDurations,
+    Map<String, WampAppConversationAppearance> conversationAppearances,
   ) : mutedConversationIds = Set<String>.unmodifiable(mutedConversationIds),
       disappearingMessageDurations = Map<String, Duration>.unmodifiable(
         disappearingMessageDurations,
-      ) {
+      ),
+      conversationAppearances =
+          Map<String, WampAppConversationAppearance>.unmodifiable(
+            conversationAppearances,
+          ) {
     _validate();
   }
 
   static const maxMutedConversations = 500;
   static const maxDisappearingMessageConversations = 500;
+  static const maxConversationAppearances = 500;
   static const maxConversationIdLength = 200;
   static const supportedDisappearingMessageDurations = <Duration>[
     Duration(hours: 1),
@@ -62,6 +109,7 @@ final class LocalAppPreferences {
   final WampAppThemePreference theme;
   final Set<String> mutedConversationIds;
   final Map<String, Duration> disappearingMessageDurations;
+  final Map<String, WampAppConversationAppearance> conversationAppearances;
 
   bool isMuted(String conversationId) =>
       mutedConversationIds.contains(conversationId);
@@ -69,11 +117,18 @@ final class LocalAppPreferences {
   Duration? disappearingMessagesFor(String conversationId) =>
       disappearingMessageDurations[conversationId];
 
+  WampAppConversationAppearance conversationAppearanceFor(
+    String conversationId,
+  ) =>
+      conversationAppearances[conversationId] ??
+      WampAppConversationAppearance.standard;
+
   LocalAppPreferences withTheme(WampAppThemePreference value) =>
       LocalAppPreferences(
         theme: value,
         mutedConversationIds: mutedConversationIds,
         disappearingMessageDurations: disappearingMessageDurations,
+        conversationAppearances: conversationAppearances,
       );
 
   LocalAppPreferences withConversationMuted(String conversationId, bool muted) {
@@ -87,6 +142,7 @@ final class LocalAppPreferences {
       theme: theme,
       mutedConversationIds: updated,
       disappearingMessageDurations: disappearingMessageDurations,
+      conversationAppearances: conversationAppearances,
     );
   }
 
@@ -105,6 +161,28 @@ final class LocalAppPreferences {
       theme: theme,
       mutedConversationIds: mutedConversationIds,
       disappearingMessageDurations: updated,
+      conversationAppearances: conversationAppearances,
+    );
+  }
+
+  LocalAppPreferences withConversationAppearance(
+    String conversationId,
+    WampAppConversationAppearance appearance,
+  ) {
+    _validateConversationId(conversationId, 'appearance');
+    final updated = Map<String, WampAppConversationAppearance>.of(
+      conversationAppearances,
+    );
+    if (appearance == WampAppConversationAppearance.standard) {
+      updated.remove(conversationId);
+    } else {
+      updated[conversationId] = appearance;
+    }
+    return LocalAppPreferences(
+      theme: theme,
+      mutedConversationIds: mutedConversationIds,
+      disappearingMessageDurations: disappearingMessageDurations,
+      conversationAppearances: updated,
     );
   }
 
@@ -113,6 +191,8 @@ final class LocalAppPreferences {
     final disappearingIds = disappearingMessageDurations.keys.toList(
       growable: false,
     )..sort();
+    final appearanceIds = conversationAppearances.keys.toList(growable: false)
+      ..sort();
     return {
       'theme': theme.wireName,
       'muted_conversation_ids': muted,
@@ -120,6 +200,10 @@ final class LocalAppPreferences {
         for (final conversationId in disappearingIds)
           conversationId:
               disappearingMessageDurations[conversationId]!.inSeconds,
+      },
+      'conversation_appearances': <String, String>{
+        for (final conversationId in appearanceIds)
+          conversationId: conversationAppearances[conversationId]!.wireName,
       },
     };
   }
@@ -139,6 +223,12 @@ final class LocalAppPreferences {
         'Saved disappearing-message preferences are invalid.',
       );
     }
+    final rawAppearances = value['conversation_appearances'];
+    if (rawAppearances != null && rawAppearances is! Map) {
+      throw const FormatException(
+        'Saved conversation appearances are invalid.',
+      );
+    }
     final disappearing = <String, Duration>{};
     if (rawDisappearing case final Map values) {
       for (final entry in values.entries) {
@@ -149,6 +239,19 @@ final class LocalAppPreferences {
         }
         disappearing[entry.key as String] = Duration(
           seconds: entry.value as int,
+        );
+      }
+    }
+    final appearances = <String, WampAppConversationAppearance>{};
+    if (rawAppearances case final Map values) {
+      for (final entry in values.entries) {
+        if (entry.key is! String) {
+          throw const FormatException(
+            'Saved conversation appearances are invalid.',
+          );
+        }
+        appearances[entry.key as String] = WampAppConversationAppearance.parse(
+          entry.value,
         );
       }
     }
@@ -163,6 +266,7 @@ final class LocalAppPreferences {
         return raw;
       }),
       disappearingMessageDurations: disappearing,
+      conversationAppearances: appearances,
     );
   }
 
@@ -184,6 +288,19 @@ final class LocalAppPreferences {
       if (!supportedDisappearingMessageDurations.contains(entry.value)) {
         throw const FormatException(
           'A disappearing-message duration is invalid.',
+        );
+      }
+    }
+    if (conversationAppearances.length > maxConversationAppearances) {
+      throw const FormatException(
+        'Too many conversation appearances are saved.',
+      );
+    }
+    for (final entry in conversationAppearances.entries) {
+      _validateConversationId(entry.key, 'appearance');
+      if (entry.value == WampAppConversationAppearance.standard) {
+        throw const FormatException(
+          'Standard conversation appearances must not be saved.',
         );
       }
     }

--- a/examples/wamp_app/client/lib/src/infrastructure/attachment_cipher.dart
+++ b/examples/wamp_app/client/lib/src/infrastructure/attachment_cipher.dart
@@ -139,6 +139,68 @@ final class AttachmentCipher {
     }
   }
 
+  Future<void> cacheEncryptedChunks({
+    required String scope,
+    required String senderUsername,
+    required String messageId,
+    required EncryptedAttachmentDescriptor attachment,
+    required AttachmentChunkCache cache,
+    required Future<EncryptedAttachmentChunk> Function(int chunkIndex)
+    fetchChunk,
+    bool Function()? isCancelled,
+  }) async {
+    _throwIfDisposed();
+    attachment.validate();
+    for (
+      var chunkIndex = 0;
+      chunkIndex < attachment.chunkCount;
+      chunkIndex += 1
+    ) {
+      _throwIfCancelled(isCancelled);
+      var chunk = await cache.get(
+        scope: scope,
+        senderUsername: senderUsername,
+        messageId: messageId,
+        attachmentId: attachment.attachmentId,
+        chunkIndex: chunkIndex,
+        chunkCount: attachment.chunkCount,
+      );
+      _throwIfCancelled(isCancelled);
+      if (chunk == null) {
+        chunk = await fetchChunk(chunkIndex);
+        _throwIfCancelled(isCancelled);
+        _validateChunk(
+          chunk: chunk,
+          senderUsername: senderUsername,
+          messageId: messageId,
+          attachment: attachment,
+          chunkIndex: chunkIndex,
+        );
+        if (attachmentCacheDigest(chunk.encryptedBytes) !=
+            chunk.ciphertextSha256) {
+          throw const FormatException(
+            'Encrypted attachment chunk digest does not match.',
+          );
+        }
+        await cache.put(scope: scope, chunk: chunk);
+        _throwIfCancelled(isCancelled);
+      }
+      _validateChunk(
+        chunk: chunk,
+        senderUsername: senderUsername,
+        messageId: messageId,
+        attachment: attachment,
+        chunkIndex: chunkIndex,
+      );
+      if (attachmentCacheDigest(chunk.encryptedBytes) !=
+          chunk.ciphertextSha256) {
+        throw const FormatException(
+          'Encrypted attachment chunk digest does not match.',
+        );
+      }
+    }
+  }
+
   Future<void> decryptToSink({
     required String scope,
     required String senderUsername,

--- a/examples/wamp_app/client/lib/src/infrastructure/device_vault.dart
+++ b/examples/wamp_app/client/lib/src/infrastructure/device_vault.dart
@@ -41,6 +41,7 @@ abstract interface class DeviceTrustSession {
   String get deviceId;
   String get safetyNumber;
   String safetyNumberFor(DeviceRecord contact);
+  bool hasVerifiedContact(String username);
   bool isVerified(DeviceRecord contact);
   Future<void> markVerified(DeviceRecord contact);
   WrappedConversationKey wrapConversationKey({
@@ -677,6 +678,13 @@ final class _UnlockedDeviceVault implements DeviceTrustSession {
   }
 
   @override
+  bool hasVerifiedContact(String username) {
+    _ensureActive();
+    final normalized = AccountRegistration.normalizeUsername(username);
+    return _verifications.keys.any((key) => key.startsWith('$normalized:'));
+  }
+
+  @override
   bool isVerified(DeviceRecord contact) {
     _ensureActive();
     if (contact.isRevoked) return false;
@@ -690,11 +698,26 @@ final class _UnlockedDeviceVault implements DeviceTrustSession {
     if (contact.isRevoked) {
       throw const FormatException('Cannot verify a revoked device.');
     }
-    _verifications[_verificationKey(contact)] = _ContactVerification(
+    final key = _verificationKey(contact);
+    final verification = _ContactVerification(
       safetyNumber: safetyNumberFor(contact),
       verifiedAt: DateTime.now().toUtc(),
     );
-    await persist();
+    await _serializeWrite(() async {
+      _ensureActive();
+      final previous = _verifications[key];
+      _verifications[key] = verification;
+      try {
+        await _writeSnapshot(_preferences);
+      } catch (_) {
+        if (previous == null) {
+          _verifications.remove(key);
+        } else {
+          _verifications[key] = previous;
+        }
+        rethrow;
+      }
+    });
   }
 
   @override

--- a/examples/wamp_app/client/lib/src/infrastructure/profile_avatar_picker.dart
+++ b/examples/wamp_app/client/lib/src/infrastructure/profile_avatar_picker.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:wamp_app_protocol/wamp_app_protocol.dart';
+
+typedef ProfileAvatarFileSelector = Future<XFile?> Function();
+
+final class ProfileAvatarSelection {
+  ProfileAvatarSelection({required this.name, required Uint8List bytes})
+    : bytes = Uint8List.fromList(bytes);
+
+  final String name;
+  final Uint8List bytes;
+}
+
+abstract interface class ProfileAvatarPicker {
+  Future<ProfileAvatarSelection?> pickAvatar();
+}
+
+final class FileSelectorProfileAvatarPicker implements ProfileAvatarPicker {
+  const FileSelectorProfileAvatarPicker([
+    this._selectFile = _selectProfileAvatarFile,
+  ]);
+
+  final ProfileAvatarFileSelector _selectFile;
+
+  @override
+  Future<ProfileAvatarSelection?> pickAvatar() async {
+    try {
+      final file = await _selectFile();
+      if (file == null) return null;
+      final length = await file.length();
+      if (length <= 0 || length > AccountProfileLimits.maxAvatarBytes) {
+        throw const ProfileAvatarPickerException(
+          'Profile images must be 256 KiB or smaller.',
+        );
+      }
+      final bytes = await file.readAsBytes();
+      if (bytes.length != length ||
+          bytes.length > AccountProfileLimits.maxAvatarBytes) {
+        bytes.fillRange(0, bytes.length, 0);
+        throw const ProfileAvatarPickerException(
+          'The selected profile image could not be read.',
+        );
+      }
+      return ProfileAvatarSelection(name: file.name, bytes: bytes);
+    } on ProfileAvatarPickerException {
+      rethrow;
+    } catch (_) {
+      throw const ProfileAvatarPickerException(
+        'The selected profile image could not be read.',
+      );
+    }
+  }
+}
+
+final class ProfileAvatarPickerException implements Exception {
+  const ProfileAvatarPickerException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+Future<XFile?> _selectProfileAvatarFile() => openFile(
+  acceptedTypeGroups: const [
+    XTypeGroup(
+      label: 'Profile image',
+      extensions: ['jpg', 'jpeg', 'png', 'webp'],
+      mimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
+    ),
+  ],
+);

--- a/examples/wamp_app/client/lib/src/infrastructure/wamp_account_gateway.dart
+++ b/examples/wamp_app/client/lib/src/infrastructure/wamp_account_gateway.dart
@@ -8,6 +8,8 @@ import 'package:crypto/crypto.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
 
 abstract interface class AccountGateway {
+  Future<void> probe({required ServerEndpoint endpoint});
+
   Future<RegistrationReceipt> register({
     required ServerEndpoint endpoint,
     required AccountRegistration registration,
@@ -805,10 +807,29 @@ class WampAccountGateway implements AccountGateway {
   const WampAccountGateway({
     this.connectionTimeout = const Duration(seconds: 15),
     this.derivationTimeout = const Duration(seconds: 75),
+    this.probeTimeout = const Duration(seconds: 4),
   });
 
   final Duration connectionTimeout;
   final Duration derivationTimeout;
+  final Duration probeTimeout;
+
+  @override
+  Future<void> probe({required ServerEndpoint endpoint}) async {
+    endpoint.requireSecureRegistration();
+    final client = Client(
+      transport: WebSocketTransport.withCborSerializer(
+        endpoint.websocketUri.toString(),
+      ),
+      realm: WampAppProtocol.registrationRealm,
+    );
+    Session? session;
+    try {
+      session = await _connect(client, timeout: probeTimeout);
+    } finally {
+      await _close(client, session);
+    }
+  }
 
   @override
   Future<RegistrationReceipt> register({
@@ -1347,7 +1368,7 @@ class WampAccountGateway implements AccountGateway {
     }
   }
 
-  Future<Session> _connect(Client client) {
+  Future<Session> _connect(Client client, {Duration? timeout}) {
     return client
         .connect(
           options: ClientConnectOptions(
@@ -1356,7 +1377,7 @@ class WampAccountGateway implements AccountGateway {
           ),
         )
         .first
-        .timeout(connectionTimeout + derivationTimeout);
+        .timeout(timeout ?? connectionTimeout + derivationTimeout);
   }
 
   Future<void> _close(Client client, Session? session) async {

--- a/examples/wamp_app/client/lib/src/infrastructure/wamp_account_gateway.dart
+++ b/examples/wamp_app/client/lib/src/infrastructure/wamp_account_gateway.dart
@@ -159,6 +159,33 @@ final class McpConsentException implements Exception {
   };
 }
 
+enum McpAccessFailureKind { rejected, unavailable }
+
+final class McpAccessException implements Exception {
+  const McpAccessException(this.kind);
+
+  factory McpAccessException.fromWampError(wamp.Error error) {
+    final kind = switch (error.error) {
+      WampAppProtocol.errorInvalidMcpAccess ||
+      WampAppProtocol.errorNotAuthorized ||
+      wamp.Error.notAuthorized => McpAccessFailureKind.rejected,
+      WampAppProtocol.errorMcpUnavailable ||
+      _ => McpAccessFailureKind.unavailable,
+    };
+    return McpAccessException(kind);
+  }
+
+  final McpAccessFailureKind kind;
+
+  @override
+  String toString() => switch (kind) {
+    McpAccessFailureKind.rejected =>
+      'The server rejected MCP access discovery.',
+    McpAccessFailureKind.unavailable =>
+      'This server does not expose a usable WampApp MCP endpoint.',
+  };
+}
+
 enum PlatformPushSubscriptionFailureKind { retryable, rejected }
 
 final class PlatformPushSubscriptionException implements Exception {
@@ -299,6 +326,7 @@ class AccountConnection {
     required this.closeTransport,
     required this.getProfileCallback,
     required this.updateProfileCallback,
+    this.getMcpAccessConfigurationCallback,
     this.getMcpConsentCallback,
     this.updateMcpConsentCallback,
     required this.enrollDeviceCallback,
@@ -344,6 +372,8 @@ class AccountConnection {
   final Future<AccountProfile> Function(String username) getProfileCallback;
   final Future<AccountProfile> Function(AccountProfileUpdate update)
   updateProfileCallback;
+  final Future<WampAppMcpAccessConfiguration> Function()?
+  getMcpAccessConfigurationCallback;
   final Future<WampAppMcpConsent> Function()? getMcpConsentCallback;
   final Future<WampAppMcpConsent> Function(WampAppMcpConsentUpdate update)?
   updateMcpConsentCallback;
@@ -450,6 +480,17 @@ class AccountConnection {
     final updated = await updateProfileCallback(update);
     _profile = updated;
     return updated;
+  }
+
+  Future<WampAppMcpAccessConfiguration> getMcpAccessConfiguration() {
+    _ensureOpen();
+    final callback = getMcpAccessConfigurationCallback;
+    if (callback == null) {
+      throw StateError(
+        'MCP access discovery is unavailable on this connection.',
+      );
+    }
+    return callback();
   }
 
   Future<WampAppMcpConsent> refreshMcpConsent() async {
@@ -883,6 +924,18 @@ class WampAccountGateway implements AccountGateway {
         initialProfile: profile,
         initialMcpConsent: mcpConsent,
         getProfileCallback: getProfile,
+        getMcpAccessConfigurationCallback: () async {
+          try {
+            final result = await session
+                .callSingle(WampAppProtocol.mcpAccessGet)
+                .timeout(connectionTimeout);
+            return WampAppMcpAccessConfiguration.fromWampKeywords(
+              result.argumentsKeywords,
+            );
+          } on wamp.Error catch (error) {
+            throw McpAccessException.fromWampError(error);
+          }
+        },
         getMcpConsentCallback: getMcpConsent,
         updateMcpConsentCallback: (update) async {
           try {

--- a/examples/wamp_app/client/lib/src/ui/expression_picker.dart
+++ b/examples/wamp_app/client/lib/src/ui/expression_picker.dart
@@ -580,6 +580,12 @@ class _ExpressionPickerState extends State<ExpressionPicker> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final keyboardInset = mediaQuery.viewInsets.bottom;
+    final availableHeight = (mediaQuery.size.height - keyboardInset).clamp(
+      360.0,
+      620.0,
+    );
     final emojis = wampAppEmojis
         .where((choice) => choice.matches(_query))
         .toList(growable: false);
@@ -590,73 +596,71 @@ class _ExpressionPickerState extends State<ExpressionPicker> {
       length: 2,
       child: SafeArea(
         top: false,
-        child: SizedBox(
-          height: MediaQuery.sizeOf(context).height.clamp(360, 620) * 0.82,
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(
-              18,
-              14,
-              18,
-              10 + MediaQuery.viewInsetsOf(context).bottom,
-            ),
-            child: Column(
-              children: [
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'Emoji & stickers',
-                        style: Theme.of(context).textTheme.titleLarge,
-                      ),
-                    ),
-                    IconButton(
-                      key: const Key('expression-close'),
-                      tooltip: 'Close emoji and stickers',
-                      onPressed: () => Navigator.pop(context),
-                      icon: const Icon(Icons.close),
-                    ),
-                  ],
-                ),
-                TextField(
-                  key: const Key('expression-search'),
-                  onChanged: (value) => setState(() => _query = value),
-                  decoration: const InputDecoration(
-                    hintText: 'Search expressions',
-                    prefixIcon: Icon(Icons.search),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                const TabBar(
-                  tabs: [
-                    Tab(
-                      key: Key('expression-emoji-tab'),
-                      icon: Icon(Icons.emoji_emotions_outlined),
-                      text: 'Emoji',
-                    ),
-                    Tab(
-                      key: Key('expression-sticker-tab'),
-                      icon: Icon(Icons.auto_awesome_outlined),
-                      text: 'Stickers',
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 8),
-                Expanded(
-                  child: TabBarView(
+        child: Padding(
+          padding: EdgeInsets.only(bottom: keyboardInset),
+          child: SizedBox(
+            height: availableHeight * 0.82,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(18, 14, 18, 10),
+              child: Column(
+                children: [
+                  Row(
                     children: [
-                      _EmojiGrid(
-                        choices: emojis,
-                        onSelected: widget.onEmojiSelected,
+                      Expanded(
+                        child: Text(
+                          'Emoji & stickers',
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
                       ),
-                      _StickerGrid(
-                        designs: stickers,
-                        busyStickerId: _busyStickerId,
-                        onSelected: _selectSticker,
+                      IconButton(
+                        key: const Key('expression-close'),
+                        tooltip: 'Close emoji and stickers',
+                        onPressed: () => Navigator.pop(context),
+                        icon: const Icon(Icons.close),
                       ),
                     ],
                   ),
-                ),
-              ],
+                  TextField(
+                    key: const Key('expression-search'),
+                    onChanged: (value) => setState(() => _query = value),
+                    decoration: const InputDecoration(
+                      hintText: 'Search expressions',
+                      prefixIcon: Icon(Icons.search),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  const TabBar(
+                    tabs: [
+                      Tab(
+                        key: Key('expression-emoji-tab'),
+                        icon: Icon(Icons.emoji_emotions_outlined),
+                        text: 'Emoji',
+                      ),
+                      Tab(
+                        key: Key('expression-sticker-tab'),
+                        icon: Icon(Icons.auto_awesome_outlined),
+                        text: 'Stickers',
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: TabBarView(
+                      children: [
+                        _EmojiGrid(
+                          choices: emojis,
+                          onSelected: widget.onEmojiSelected,
+                        ),
+                        _StickerGrid(
+                          designs: stickers,
+                          busyStickerId: _busyStickerId,
+                          onSelected: _selectSticker,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -14,6 +14,7 @@ import '../domain/local_message_query.dart';
 import '../domain/outbound_chat_message.dart';
 import '../infrastructure/attachment_cipher.dart';
 import '../infrastructure/contact_importer.dart';
+import '../infrastructure/profile_avatar_picker.dart';
 import '../infrastructure/voice_note_playback.dart';
 import '../infrastructure/voice_note_recorder.dart';
 import '../infrastructure/wamp_account_gateway.dart';
@@ -30,6 +31,7 @@ class HomePage extends StatefulWidget {
     this.voiceNoteCaptureFactory,
     this.stickerRenderer,
     this.contactImporter,
+    this.profileAvatarPicker,
   });
 
   final WampAppController controller;
@@ -37,6 +39,7 @@ class HomePage extends StatefulWidget {
   final VoiceNoteCapture Function()? voiceNoteCaptureFactory;
   final StickerRenderer? stickerRenderer;
   final ContactImporter? contactImporter;
+  final ProfileAvatarPicker? profileAvatarPicker;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -543,8 +546,12 @@ class _HomePageState extends State<HomePage> {
   Future<void> _editProfile() async {
     final update = await showDialog<AccountProfileUpdate>(
       context: context,
-      builder: (context) =>
-          _EditProfileDialog(profile: widget.connection.profile),
+      builder: (context) => _EditProfileDialog(
+        profile: widget.connection.profile,
+        avatarPicker:
+            widget.profileAvatarPicker ??
+            const FileSelectorProfileAvatarPicker(),
+      ),
     );
     if (update == null || !mounted) return;
     final saved = await widget.controller.updateProfile(update);
@@ -614,7 +621,11 @@ class _HomePageState extends State<HomePage> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _ProfileAvatar(profile: profile, radius: 46),
+              _ProfileAvatar(
+                key: const Key('peer-profile-avatar'),
+                profile: profile,
+                radius: 46,
+              ),
               const SizedBox(height: 14),
               Text(
                 profile.displayName,
@@ -966,9 +977,10 @@ class _CreateGroupDialogState extends State<_CreateGroupDialog> {
 }
 
 class _EditProfileDialog extends StatefulWidget {
-  const _EditProfileDialog({required this.profile});
+  const _EditProfileDialog({required this.profile, required this.avatarPicker});
 
   final AccountProfile profile;
+  final ProfileAvatarPicker avatarPicker;
 
   @override
   State<_EditProfileDialog> createState() => _EditProfileDialogState();
@@ -1000,25 +1012,30 @@ class _EditProfileDialogState extends State<_EditProfileDialog> {
   }
 
   Future<void> _pickAvatar() async {
-    final file = await openFile(
-      acceptedTypeGroups: const [
-        XTypeGroup(
-          label: 'Profile image',
-          extensions: ['jpg', 'jpeg', 'png', 'webp'],
-          mimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
-        ),
-      ],
-    );
-    if (file == null || !mounted) return;
-    final bytes = await file.readAsBytes();
-    if (!mounted) return;
+    ProfileAvatarSelection? selection;
+    try {
+      selection = await widget.avatarPicker.pickAvatar();
+    } on ProfileAvatarPickerException catch (error) {
+      if (mounted) setState(() => _validationError = error.message);
+      return;
+    } catch (_) {
+      if (mounted) {
+        setState(
+          () => _validationError =
+              'The selected profile image could not be read.',
+        );
+      }
+      return;
+    }
+    if (selection == null || !mounted) return;
+    final bytes = selection.bytes;
     if (bytes.length > AccountProfileLimits.maxAvatarBytes) {
       setState(() {
         _validationError = 'Profile images must be 256 KiB or smaller.';
       });
       return;
     }
-    final contentType = _profileImageContentType(file.name);
+    final contentType = _profileImageContentType(selection.name);
     if (contentType == null) {
       setState(() {
         _validationError = 'Choose a JPEG, PNG, or WebP image.';
@@ -1096,7 +1113,11 @@ class _EditProfileDialogState extends State<_EditProfileDialog> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _ProfileAvatar(profile: preview, radius: 42),
+              _ProfileAvatar(
+                key: const Key('profile-avatar-preview'),
+                profile: preview,
+                radius: 42,
+              ),
               const SizedBox(height: 12),
               Wrap(
                 spacing: 8,
@@ -1285,7 +1306,11 @@ class _AccountPanel extends StatelessWidget {
                 SizedBox(height: compact ? 12 : 24),
                 Row(
                   children: [
-                    _ProfileAvatar(profile: profile, radius: 25),
+                    _ProfileAvatar(
+                      key: const Key('account-profile-avatar'),
+                      profile: profile,
+                      radius: 25,
+                    ),
                     const SizedBox(width: 13),
                     Expanded(
                       child: Column(
@@ -1494,7 +1519,11 @@ class _AccountPanel extends StatelessWidget {
 }
 
 class _ProfileAvatar extends StatelessWidget {
-  const _ProfileAvatar({required this.profile, required this.radius});
+  const _ProfileAvatar({
+    super.key,
+    required this.profile,
+    required this.radius,
+  });
 
   final AccountProfile profile;
   final double radius;

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -162,8 +162,16 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  Future<void> _showExpressionPicker() {
-    return showModalBottomSheet<void>(
+  Future<void> _showExpressionPicker() async {
+    FocusManager.instance.primaryFocus?.unfocus();
+    await SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
+    for (var attempt = 0; attempt < 20; attempt += 1) {
+      if (!mounted || MediaQuery.viewInsetsOf(context).bottom == 0) break;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    if (!mounted) return;
+    await showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       showDragHandle: true,
@@ -1285,9 +1293,15 @@ class _AccountPanel extends StatelessWidget {
                         children: [
                           Text(
                             connection.displayName,
+                            maxLines: compact ? 1 : 2,
+                            overflow: TextOverflow.ellipsis,
                             style: Theme.of(context).textTheme.titleLarge,
                           ),
-                          Text('@${connection.username}'),
+                          Text(
+                            '@${connection.username}',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
                           if (profile.status.isNotEmpty)
                             Text(
                               profile.status,
@@ -1664,6 +1678,8 @@ class _ConversationPanel extends StatelessWidget {
                   Expanded(
                     child: Text(
                       selectedGroup?.title ?? 'Encrypted messages',
+                      maxLines: compact ? 1 : 2,
+                      overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.titleLarge,
                     ),
                   ),
@@ -1715,7 +1731,7 @@ class _ConversationPanel extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(height: 12),
+              SizedBox(height: compact ? 4 : 12),
               TextField(
                 key: const Key('message-global-search'),
                 controller: searchController,
@@ -1745,7 +1761,7 @@ class _ConversationPanel extends StatelessWidget {
                 onTapOutside: (_) =>
                     FocusManager.instance.primaryFocus?.unfocus(),
               ),
-              const SizedBox(height: 10),
+              SizedBox(height: compact ? 4 : 10),
               SingleChildScrollView(
                 scrollDirection: Axis.horizontal,
                 child: Row(
@@ -1813,7 +1829,7 @@ class _ConversationPanel extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(height: 14),
+              SizedBox(height: compact ? 6 : 14),
             ],
             if (!chromeHidden &&
                 !groupMode &&
@@ -1843,7 +1859,7 @@ class _ConversationPanel extends StatelessWidget {
                   },
                 ),
               ),
-              const SizedBox(height: 10),
+              SizedBox(height: compact ? 4 : 10),
             ],
             if (!groupMode)
               TextField(
@@ -1882,7 +1898,13 @@ class _ConversationPanel extends StatelessWidget {
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ),
-            SizedBox(height: chromeHidden ? 6 : 14),
+            SizedBox(
+              height: chromeHidden
+                  ? 4
+                  : compact
+                  ? 6
+                  : 14,
+            ),
             Expanded(
               child: visibleMessages.isEmpty
                   ? _NoMessages(
@@ -1959,7 +1981,7 @@ class _ConversationPanel extends StatelessWidget {
               ),
             ],
             if (!chromeHidden) ...[
-              const SizedBox(height: 14),
+              SizedBox(height: compact ? 6 : 14),
               SingleChildScrollView(
                 scrollDirection: Axis.horizontal,
                 child: Row(
@@ -2019,7 +2041,7 @@ class _ConversationPanel extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(height: 8),
+              SizedBox(height: compact ? 4 : 8),
             ] else
               const SizedBox(height: 4),
             if (selectedAttachments.isNotEmpty) ...[

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -2286,6 +2286,7 @@ class _MessageBubble extends StatelessWidget {
           ? Alignment.centerRight
           : Alignment.centerLeft,
       child: InkWell(
+        key: ValueKey('message-bubble-${message.messageId}'),
         onTap: onTap,
         borderRadius: BorderRadius.circular(16),
         child: Container(

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -80,6 +80,7 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _send() async {
     final text = _messageController.text;
+    final sentAttachments = _attachments;
     final groupId = _selectedGroupId;
     final conversationId =
         groupId ??
@@ -87,7 +88,7 @@ class _HomePageState extends State<HomePage> {
     final expiresAfter = conversationId == null
         ? null
         : widget.controller.disappearingMessagesFor(conversationId);
-    final attachmentSources = _attachments
+    final attachmentSources = sentAttachments
         .map((attachment) => attachment.source)
         .toList(growable: false);
     final queued = groupId == null
@@ -105,10 +106,15 @@ class _HomePageState extends State<HomePage> {
             attachmentSources: attachmentSources,
           );
     if (mounted && queued) {
-      final sentAttachments = _attachments;
       setState(() {
-        _messageController.clear();
-        _attachments = const [];
+        if (_messageController.text == text) {
+          _messageController.clear();
+        }
+        _attachments = List<_SelectedAttachment>.unmodifiable(
+          _attachments.where(
+            (attachment) => !sentAttachments.contains(attachment),
+          ),
+        );
       });
       for (final attachment in sentAttachments) {
         attachment.dispose();
@@ -458,49 +464,10 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _createGroup() async {
-    final title = TextEditingController();
-    final members = TextEditingController();
     final details = await showDialog<(String, List<String>)>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('New encrypted group'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            TextField(
-              key: const Key('group-title'),
-              controller: title,
-              autofocus: true,
-              decoration: const InputDecoration(labelText: 'Group name'),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              key: const Key('group-members'),
-              controller: members,
-              decoration: const InputDecoration(
-                labelText: 'Member usernames',
-                helperText: 'Separate usernames with commas',
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            key: const Key('group-create'),
-            onPressed: () =>
-                Navigator.of(context)
-                    .pop((title.text, members.text.split(','))),
-            child: const Text('Create group'),
-          ),
-        ],
-      ),
+      builder: (context) => const _CreateGroupDialog(),
     );
-    title.dispose();
-    members.dispose();
     if (!mounted || details == null) return;
     final group = await widget.controller.createGroup(
       title: details.$1,
@@ -927,6 +894,65 @@ class _HomePageState extends State<HomePage> {
           if (calls.hasCall) CallOverlay(controller: calls),
         ],
       ),
+    );
+  }
+}
+
+class _CreateGroupDialog extends StatefulWidget {
+  const _CreateGroupDialog();
+
+  @override
+  State<_CreateGroupDialog> createState() => _CreateGroupDialogState();
+}
+
+class _CreateGroupDialogState extends State<_CreateGroupDialog> {
+  final _title = TextEditingController();
+  final _members = TextEditingController();
+
+  @override
+  void dispose() {
+    _title.dispose();
+    _members.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New encrypted group'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            key: const Key('group-title'),
+            controller: _title,
+            autofocus: true,
+            decoration: const InputDecoration(labelText: 'Group name'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const Key('group-members'),
+            controller: _members,
+            decoration: const InputDecoration(
+              labelText: 'Member usernames',
+              helperText: 'Separate usernames with commas',
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const Key('group-create'),
+          onPressed: () =>
+              Navigator.of(context)
+                  .pop((_title.text, _members.text.split(','))),
+          child: const Text('Create group'),
+        ),
+      ],
     );
   }
 }
@@ -1619,18 +1645,15 @@ class _ConversationPanel extends StatelessWidget {
     final globalSearch = query.isGlobalSearch;
     final visibleMessages = query.select(controller.messages);
     final compact = MediaQuery.sizeOf(context).width < 760;
+    final compactComposition =
+        compact && (selectedAttachments.isNotEmpty || voiceRecording);
+    final chromeHidden = keyboardVisible || compactComposition;
     return Card(
       child: Padding(
-        padding: EdgeInsets.all(
-          keyboardVisible
-              ? 8
-              : compact
-              ? 14
-              : 22,
-        ),
+        padding: EdgeInsets.all(compact || chromeHidden ? 8 : 22),
         child: Column(
           children: [
-            if (!keyboardVisible) ...[
+            if (!chromeHidden) ...[
               Row(
                 children: [
                   Icon(
@@ -1792,7 +1815,7 @@ class _ConversationPanel extends StatelessWidget {
               ),
               const SizedBox(height: 14),
             ],
-            if (!keyboardVisible &&
+            if (!chromeHidden &&
                 !groupMode &&
                 controller.contacts.isNotEmpty) ...[
               SizedBox(
@@ -1859,7 +1882,7 @@ class _ConversationPanel extends StatelessWidget {
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ),
-            SizedBox(height: keyboardVisible ? 6 : 14),
+            SizedBox(height: chromeHidden ? 6 : 14),
             Expanded(
               child: visibleMessages.isEmpty
                   ? _NoMessages(
@@ -1935,7 +1958,7 @@ class _ConversationPanel extends StatelessWidget {
                 ),
               ),
             ],
-            if (!keyboardVisible) ...[
+            if (!chromeHidden) ...[
               const SizedBox(height: 14),
               SingleChildScrollView(
                 scrollDirection: Axis.horizontal,

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -2293,6 +2293,9 @@ class _MessageBubble extends StatelessWidget {
                   message.oneTime && !message.outgoing
                       ? 'Tap to view once'
                       : message.text,
+                  key: message.oneTime && !message.outgoing
+                      ? ValueKey('message-view-once-${message.messageId}')
+                      : null,
                 ),
               ],
               for (final attachment in message.attachments) ...[

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -153,7 +153,6 @@ class _HomePageState extends State<HomePage> {
           ..._attachments,
           ...selected,
         ]);
-        _oneTime = false;
       });
     } catch (error) {
       if (!mounted) return;
@@ -232,7 +231,6 @@ class _HomePageState extends State<HomePage> {
           ..._attachments,
           selected,
         ]);
-        _oneTime = false;
       });
       return true;
     } catch (error) {
@@ -358,7 +356,6 @@ class _HomePageState extends State<HomePage> {
         ..._attachments,
         attachment,
       ]);
-      _oneTime = false;
     });
   }
 
@@ -399,6 +396,14 @@ class _HomePageState extends State<HomePage> {
       attachmentId: attachment.attachmentId,
     );
     if (bytes == null) return;
+    await _showAttachmentBytes(attachment, bytes, allowSaveCopy: true);
+  }
+
+  Future<void> _showAttachmentBytes(
+    EncryptedAttachmentDescriptor attachment,
+    Uint8List bytes, {
+    required bool allowSaveCopy,
+  }) async {
     if (!mounted) {
       bytes.fillRange(0, bytes.length, 0);
       return;
@@ -442,21 +447,22 @@ class _HomePageState extends State<HomePage> {
                   ),
           ),
           actions: [
-            TextButton.icon(
-              onPressed: () async {
-                final location = await getSaveLocation(
-                  suggestedName: attachment.name,
-                );
-                if (location == null) return;
-                await XFile.fromData(
-                  bytes,
-                  name: attachment.name,
-                  mimeType: attachment.contentType,
-                ).saveTo(location.path);
-              },
-              icon: const Icon(Icons.download_outlined),
-              label: const Text('Save copy'),
-            ),
+            if (allowSaveCopy)
+              TextButton.icon(
+                onPressed: () async {
+                  final location = await getSaveLocation(
+                    suggestedName: attachment.name,
+                  );
+                  if (location == null) return;
+                  await XFile.fromData(
+                    bytes,
+                    name: attachment.name,
+                    mimeType: attachment.contentType,
+                  ).saveTo(location.path);
+                },
+                icon: const Icon(Icons.download_outlined),
+                label: const Text('Save copy'),
+              ),
             FilledButton(
               onPressed: () => Navigator.of(dialogContext).pop(),
               child: const Text('Close'),
@@ -498,23 +504,67 @@ class _HomePageState extends State<HomePage> {
       await widget.controller.markMessageRead(message.messageId);
       return;
     }
-    final text = await widget.controller.consumeOneTimeMessage(
+    final opened = await widget.controller.consumeOneTimeMessage(
       message.messageId,
     );
-    if (!mounted || text == null) return;
-    await showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('View-once message'),
-        content: Text(text, key: const Key('one-time-message-content')),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Close'),
+    if (opened == null) return;
+    if (!mounted) {
+      await widget.controller.closeOpenedOneTimeMessage(opened);
+      return;
+    }
+    try {
+      await showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('View-once message'),
+          content: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560, maxHeight: 560),
+            child: SingleChildScrollView(
+              child: Column(
+                key: const Key('one-time-message-content'),
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (opened.text.isNotEmpty) Text(opened.text),
+                  for (final attachment in opened.attachments) ...[
+                    if (opened.text.isNotEmpty) const SizedBox(height: 10),
+                    _AttachmentCard(
+                      attachment: attachment,
+                      onOpen: () async {
+                        final bytes = await widget.controller
+                            .loadOpenedOneTimeAttachment(
+                              message: opened,
+                              attachmentId: attachment.attachmentId,
+                            );
+                        if (bytes == null) {
+                          _showMessage(
+                            'The view-once attachment could not be opened.',
+                          );
+                          return;
+                        }
+                        await _showAttachmentBytes(
+                          attachment,
+                          bytes,
+                          allowSaveCopy: false,
+                        );
+                      },
+                    ),
+                  ],
+                ],
+              ),
+            ),
           ),
-        ],
-      ),
-    );
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      );
+    } finally {
+      await widget.controller.closeOpenedOneTimeMessage(opened);
+    }
   }
 
   void _onSearchChanged(String value) {
@@ -2077,10 +2127,7 @@ class _ConversationPanel extends StatelessWidget {
                     FilterChip(
                       key: const Key('message-one-time'),
                       selected: !groupMode && oneTime,
-                      onSelected:
-                          controller.messageBusy ||
-                              groupMode ||
-                              selectedAttachments.isNotEmpty
+                      onSelected: controller.messageBusy || groupMode
                           ? null
                           : onOneTimeChanged,
                       avatar: const Icon(
@@ -2502,7 +2549,10 @@ class _MessageBubble extends StatelessWidget {
                         : null,
                   ),
                 ],
-                for (final attachment in message.attachments) ...[
+                for (final attachment
+                    in message.oneTime && !message.outgoing
+                        ? const <EncryptedAttachmentDescriptor>[]
+                        : message.attachments) ...[
                   const SizedBox(height: 7),
                   _AttachmentCard(
                     attachment: attachment,

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -648,6 +648,124 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  Future<void> _showMcpAccess() async {
+    final configuration = await widget.controller.loadMcpAccessConfiguration();
+    if (!mounted) return;
+    if (configuration == null) {
+      _showMessage(
+        widget.controller.mcpAccessError ??
+            'Could not load MCP connection information.',
+      );
+      return;
+    }
+    final endpoint = configuration.mcpUriFor(widget.connection.endpoint);
+    final authEndpoint = configuration.authUriFor(widget.connection.endpoint);
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AnimatedBuilder(
+        animation: widget.controller,
+        builder: (context, _) => AlertDialog(
+          key: const Key('mcp-access-dialog'),
+          scrollable: true,
+          title: const Row(
+            children: [
+              Icon(Icons.smart_toy_outlined),
+              SizedBox(width: 10),
+              Expanded(child: Text('Connect an AI service')),
+            ],
+          ),
+          content: SizedBox(
+            width: 520,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text(
+                  'Use the endpoint below with an MCP client that supports '
+                  'Streamable HTTP or direct JSON. The client authenticates '
+                  'as this WampApp account using a WAMP-SCRAM access grant.',
+                ),
+                const SizedBox(height: 16),
+                _McpEndpointField(
+                  label: 'MCP endpoint',
+                  keyName: 'mcp-access-endpoint',
+                  uri: endpoint,
+                  onCopy: () async {
+                    await Clipboard.setData(
+                      ClipboardData(text: endpoint.toString()),
+                    );
+                    if (mounted) {
+                      ScaffoldMessenger.of(this.context).showSnackBar(
+                        const SnackBar(content: Text('MCP endpoint copied.')),
+                      );
+                    }
+                  },
+                ),
+                const SizedBox(height: 12),
+                _McpEndpointField(
+                  label: 'Authentication endpoint',
+                  keyName: 'mcp-auth-endpoint',
+                  uri: authEndpoint,
+                  onCopy: () async {
+                    await Clipboard.setData(
+                      ClipboardData(text: authEndpoint.toString()),
+                    );
+                    if (mounted) {
+                      ScaffoldMessenger.of(this.context).showSnackBar(
+                        const SnackBar(content: Text('Auth endpoint copied.')),
+                      );
+                    }
+                  },
+                ),
+                const SizedBox(height: 14),
+                Text('Account: @${widget.connection.username}'),
+                const Text('Realm: ${WampAppProtocol.appRealm}'),
+                const Text('Authentication: WAMP-SCRAM access grant'),
+                const SizedBox(height: 14),
+                const Text(
+                  'Catalogs: tools, resources, and prompts · Transports: '
+                  'Streamable HTTP and direct JSON',
+                ),
+                const SizedBox(height: 14),
+                SwitchListTile.adaptive(
+                  key: const Key('mcp-access-profile-switch'),
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Allow public-profile access'),
+                  subtitle: Text(
+                    widget.controller.mcpConsent.profileReadAllowed
+                        ? 'Enabled. Revocation takes effect immediately.'
+                        : 'Disabled by default.',
+                  ),
+                  value: widget.controller.mcpConsent.profileReadAllowed,
+                  onChanged: widget.controller.mcpConsentBusy
+                      ? null
+                      : _setMcpProfileReadAllowed,
+                ),
+                Text(
+                  'Visible fields: ${configuration.profileFields.join(', ')}.',
+                  key: const Key('mcp-access-profile-fields'),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Chats, messages, attachments, backups, devices, calls, '
+                  'encryption keys, and avatars remain unavailable. WampApp '
+                  'never displays or copies your password, access token, or '
+                  'refresh token.',
+                  key: Key('mcp-access-data-boundary'),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Future<void> _showPeerProfile() async {
     final username = _recipientController.text.trim();
     if (username.isEmpty) {
@@ -883,6 +1001,7 @@ class _HomePageState extends State<HomePage> {
                     compact: !wide,
                     profileBusy: widget.controller.profileBusy,
                     mcpConsent: widget.controller.mcpConsent,
+                    mcpAccessBusy: widget.controller.mcpAccessBusy,
                     mcpConsentBusy: widget.controller.mcpConsentBusy,
                     preferenceBusy: widget.controller.preferenceBusy,
                     backupBusy: widget.controller.backupBusy,
@@ -890,7 +1009,7 @@ class _HomePageState extends State<HomePage> {
                     contactCount: widget.controller.contacts.length,
                     themePreference: widget.controller.themePreference,
                     onEditProfile: _editProfile,
-                    onMcpProfileReadAllowedChanged: _setMcpProfileReadAllowed,
+                    onOpenMcpAccess: _showMcpAccess,
                     onThemeChanged: _setThemePreference,
                     onBackup: _showBackupMenu,
                     onRemoteBackup: _uploadRemoteBackup,
@@ -1255,6 +1374,55 @@ class _EditProfileDialogState extends State<_EditProfileDialog> {
   }
 }
 
+class _McpEndpointField extends StatelessWidget {
+  const _McpEndpointField({
+    required this.label,
+    required this.keyName,
+    required this.uri,
+    required this.onCopy,
+  });
+
+  final String label;
+  final String keyName;
+  final Uri uri;
+  final Future<void> Function() onCopy;
+
+  @override
+  Widget build(BuildContext context) => DecoratedBox(
+    decoration: BoxDecoration(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      borderRadius: BorderRadius.circular(12),
+    ),
+    child: Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 4, 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: Theme.of(context).textTheme.labelMedium),
+                const SizedBox(height: 4),
+                SelectableText(
+                  uri.toString(),
+                  key: ValueKey(keyName),
+                  style: const TextStyle(fontFamily: 'monospace'),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            key: ValueKey('$keyName-copy'),
+            tooltip: 'Copy $label',
+            onPressed: onCopy,
+            icon: const Icon(Icons.copy_outlined),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 class _AccountPanel extends StatelessWidget {
   const _AccountPanel({
     required this.connection,
@@ -1263,6 +1431,7 @@ class _AccountPanel extends StatelessWidget {
     required this.compact,
     required this.profileBusy,
     required this.mcpConsent,
+    required this.mcpAccessBusy,
     required this.mcpConsentBusy,
     required this.preferenceBusy,
     required this.backupBusy,
@@ -1270,7 +1439,7 @@ class _AccountPanel extends StatelessWidget {
     required this.contactCount,
     required this.themePreference,
     required this.onEditProfile,
-    required this.onMcpProfileReadAllowedChanged,
+    required this.onOpenMcpAccess,
     required this.onThemeChanged,
     required this.onBackup,
     required this.onRemoteBackup,
@@ -1284,6 +1453,7 @@ class _AccountPanel extends StatelessWidget {
   final bool compact;
   final bool profileBusy;
   final WampAppMcpConsent mcpConsent;
+  final bool mcpAccessBusy;
   final bool mcpConsentBusy;
   final bool preferenceBusy;
   final bool backupBusy;
@@ -1291,7 +1461,7 @@ class _AccountPanel extends StatelessWidget {
   final int contactCount;
   final WampAppThemePreference themePreference;
   final VoidCallback onEditProfile;
-  final ValueChanged<bool> onMcpProfileReadAllowedChanged;
+  final VoidCallback onOpenMcpAccess;
   final ValueChanged<WampAppThemePreference> onThemeChanged;
   final VoidCallback onBackup;
   final VoidCallback onRemoteBackup;
@@ -1461,21 +1631,17 @@ class _AccountPanel extends StatelessWidget {
                     const SizedBox(width: 6),
                     IconButton(
                       key: const Key('account-mcp-profile-consent'),
-                      tooltip: mcpConsent.profileReadAllowed
-                          ? 'Disable MCP public-profile access'
-                          : 'Enable MCP public-profile access',
+                      tooltip: 'MCP access settings',
                       constraints: const BoxConstraints.tightFor(
                         width: 28,
                         height: 28,
                       ),
                       padding: EdgeInsets.zero,
                       visualDensity: VisualDensity.compact,
-                      onPressed: mcpConsentBusy
+                      onPressed: mcpAccessBusy || mcpConsentBusy
                           ? null
-                          : () => onMcpProfileReadAllowedChanged(
-                              !mcpConsent.profileReadAllowed,
-                            ),
-                      icon: mcpConsentBusy
+                          : onOpenMcpAccess,
+                      icon: mcpAccessBusy || mcpConsentBusy
                           ? const SizedBox.square(
                               dimension: 16,
                               child: CircularProgressIndicator(strokeWidth: 2),

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -819,6 +819,19 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  Future<void> _showPeerTrust() async {
+    final username = _recipientController.text.trim();
+    if (username.isEmpty) {
+      _showMessage('Enter a recipient username first.');
+      return;
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (context) =>
+          _PeerTrustDialog(controller: widget.controller, username: username),
+    );
+  }
+
   Future<void> _setThemePreference(WampAppThemePreference value) async {
     final saved = await widget.controller.setThemePreference(value);
     if (!mounted) return;
@@ -1032,6 +1045,7 @@ class _HomePageState extends State<HomePage> {
                     onSearchResultSelected: _selectSearchResult,
                     onSend: _send,
                     onViewProfile: _showPeerProfile,
+                    onVerifyIdentity: _showPeerTrust,
                     onStartVoiceCall: () => _startCall(CallMediaKind.voice),
                     onStartVideoCall: () => _startCall(CallMediaKind.video),
                     oneTime: _oneTime,
@@ -1811,6 +1825,306 @@ class _OnlineBadge extends StatelessWidget {
   }
 }
 
+class _PeerTrustDialog extends StatefulWidget {
+  const _PeerTrustDialog({required this.controller, required this.username});
+
+  final WampAppController controller;
+  final String username;
+
+  @override
+  State<_PeerTrustDialog> createState() => _PeerTrustDialogState();
+}
+
+class _PeerTrustDialogState extends State<_PeerTrustDialog> {
+  PeerTrustSummary? _summary;
+  Object? _error;
+  bool _loading = true;
+  String? _verifyingDeviceId;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_load());
+  }
+
+  Future<void> _load() async {
+    try {
+      final summary = await widget.controller.inspectPeerTrust(widget.username);
+      if (!mounted) return;
+      setState(() {
+        _summary = summary;
+        _error = summary == null
+            ? StateError('The account session changed.')
+            : null;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _verify(PeerDeviceTrust device) async {
+    final accepted = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Confirm safety number'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(device.device.enrollment.deviceName),
+            const SizedBox(height: 8),
+            SelectableText(
+              device.safetyNumber,
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              'Only continue after comparing this number with your contact '
+              'through another trusted channel.',
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            key: const Key('peer-trust-confirm'),
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Numbers match'),
+          ),
+        ],
+      ),
+    );
+    if (accepted != true || !mounted) return;
+    setState(() {
+      _verifyingDeviceId = device.device.deviceId;
+      _error = null;
+    });
+    try {
+      final summary = await widget.controller.verifyPeerDevice(device);
+      if (!mounted) return;
+      setState(() {
+        _summary = summary;
+        _error = summary == null
+            ? StateError('The account session changed.')
+            : null;
+        _verifyingDeviceId = null;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _verifyingDeviceId = null;
+      });
+    }
+  }
+
+  String get _errorMessage => switch (_error) {
+    FormatException(:final message) => message,
+    _ => 'Could not load or verify this encryption identity.',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = _summary;
+    return AlertDialog(
+      key: const Key('peer-trust-dialog'),
+      title: Text(
+        summary == null
+            ? 'Encryption identity'
+            : 'Encryption identity · @${summary.username}',
+      ),
+      content: SizedBox(
+        width: 440,
+        child: _loading
+            ? const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24),
+                  child: CircularProgressIndicator(),
+                ),
+              )
+            : SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (summary != null) ...[
+                      _PeerTrustStatusBanner(summary: summary),
+                      const SizedBox(height: 12),
+                      const Text(
+                        'Compare each active device safety number through '
+                        'another trusted channel. Verification detects later '
+                        'identity changes but does not replace that first '
+                        'comparison.',
+                      ),
+                      const SizedBox(height: 16),
+                      for (final device in summary.devices) ...[
+                        DecoratedBox(
+                          key: ValueKey(
+                            'peer-trust-device-${device.device.deviceId}',
+                          ),
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .outlineVariant,
+                            ),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(12),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Expanded(
+                                      child: Text(
+                                        device.device.enrollment.deviceName,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .titleSmall,
+                                      ),
+                                    ),
+                                    if (device.verified)
+                                      const Chip(
+                                        avatar: Icon(Icons.verified, size: 18),
+                                        label: Text('Verified'),
+                                      ),
+                                  ],
+                                ),
+                                SelectableText(
+                                  device.safetyNumber,
+                                  key: ValueKey(
+                                    'peer-trust-number-${device.device.deviceId}',
+                                  ),
+                                  style: const TextStyle(
+                                    fontFamily: 'monospace',
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: FilledButton.tonalIcon(
+                                    key: ValueKey(
+                                      'peer-trust-verify-${device.device.deviceId}',
+                                    ),
+                                    onPressed:
+                                        device.verified ||
+                                            _verifyingDeviceId != null
+                                        ? null
+                                        : () => _verify(device),
+                                    icon:
+                                        _verifyingDeviceId ==
+                                            device.device.deviceId
+                                        ? const SizedBox.square(
+                                            dimension: 16,
+                                            child: CircularProgressIndicator(
+                                              strokeWidth: 2,
+                                            ),
+                                          )
+                                        : const Icon(Icons.fact_check_outlined),
+                                    label: Text(
+                                      device.verified
+                                          ? 'Verified'
+                                          : 'Verify device',
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                      ],
+                    ],
+                    if (_error != null) ...[
+                      Text(
+                        _errorMessage,
+                        key: const Key('peer-trust-error'),
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      OutlinedButton.icon(
+                        onPressed: _verifyingDeviceId == null ? _load : null,
+                        icon: const Icon(Icons.refresh),
+                        label: const Text('Refresh'),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+class _PeerTrustStatusBanner extends StatelessWidget {
+  const _PeerTrustStatusBanner({required this.summary});
+
+  final PeerTrustSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, color, text) = switch (summary.status) {
+      PeerTrustStatus.unverified => (
+        Icons.shield_outlined,
+        Theme.of(context).colorScheme.secondary,
+        'Not verified yet. Messages can be sent, but compare every active '
+            'device before relying on this identity.',
+      ),
+      PeerTrustStatus.verified => (
+        Icons.verified_user,
+        const Color(0xFF197A52),
+        'Every active device is verified.',
+      ),
+      PeerTrustStatus.changed => (
+        Icons.gpp_bad_outlined,
+        Theme.of(context).colorScheme.error,
+        'Encryption identity changed. Sending is blocked until every active '
+            'device is reviewed and verified.',
+      ),
+    };
+    return DecoratedBox(
+      key: const Key('peer-trust-status'),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: color),
+            const SizedBox(width: 10),
+            Expanded(child: Text(text)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _ConversationPanel extends StatelessWidget {
   const _ConversationPanel({
     required this.controller,
@@ -1827,6 +2141,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.onSearchResultSelected,
     required this.onSend,
     required this.onViewProfile,
+    required this.onVerifyIdentity,
     required this.onStartVoiceCall,
     required this.onStartVideoCall,
     required this.oneTime,
@@ -1867,6 +2182,7 @@ class _ConversationPanel extends StatelessWidget {
   final Future<void> Function(LocalChatMessage message) onSearchResultSelected;
   final Future<void> Function() onSend;
   final Future<void> Function() onViewProfile;
+  final Future<void> Function() onVerifyIdentity;
   final VoidCallback onStartVoiceCall;
   final VoidCallback onStartVideoCall;
   final bool oneTime;
@@ -2170,16 +2486,31 @@ class _ConversationPanel extends StatelessWidget {
                 decoration: InputDecoration(
                   labelText: 'Recipient username',
                   prefixIcon: const Icon(Icons.alternate_email),
-                  suffixIcon: IconButton(
-                    key: const Key('recipient-profile-view'),
-                    tooltip: 'View public profile',
-                    onPressed: controller.profileBusy ? null : onViewProfile,
-                    icon: controller.profileBusy
-                        ? const SizedBox.square(
-                            dimension: 18,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.account_circle_outlined),
+                  suffixIcon: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        key: const Key('recipient-identity-view'),
+                        tooltip: 'Verify encryption identity',
+                        onPressed: onVerifyIdentity,
+                        icon: const Icon(Icons.verified_user_outlined),
+                      ),
+                      IconButton(
+                        key: const Key('recipient-profile-view'),
+                        tooltip: 'View public profile',
+                        onPressed: controller.profileBusy
+                            ? null
+                            : onViewProfile,
+                        icon: controller.profileBusy
+                            ? const SizedBox.square(
+                                dimension: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.account_circle_outlined),
+                      ),
+                    ],
                   ),
                 ),
                 onChanged: (_) => onRecipientChanged(),

--- a/examples/wamp_app/client/lib/src/ui/home_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/home_page.dart
@@ -678,6 +678,23 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  Future<void> _setConversationAppearance(
+    String conversationId,
+    WampAppConversationAppearance appearance,
+  ) async {
+    final saved = await widget.controller.setConversationAppearance(
+      conversationId,
+      appearance,
+    );
+    if (!mounted) return;
+    _showMessage(
+      saved
+          ? '${_ConversationPanel._appearanceLabel(appearance)} chat appearance saved on this account.'
+          : widget.controller.preferenceError ??
+                'Could not save the chat appearance.',
+    );
+  }
+
   Future<void> _setConversationDisappearingMessages(
     String conversationId,
     Duration? duration,
@@ -870,6 +887,7 @@ class _HomePageState extends State<HomePage> {
                     }),
                     onCreateGroup: _createGroup,
                     onMuteChanged: _setConversationMuted,
+                    onAppearanceChanged: _setConversationAppearance,
                     onOneTimeChanged: (value) =>
                         setState(() => _oneTime = value),
                     onExpiresAfterChanged: _setConversationDisappearingMessages,
@@ -1602,6 +1620,7 @@ class _ConversationPanel extends StatelessWidget {
     required this.onConversationChanged,
     required this.onCreateGroup,
     required this.onMuteChanged,
+    required this.onAppearanceChanged,
     required this.onOneTimeChanged,
     required this.onExpiresAfterChanged,
     required this.onOpenMessage,
@@ -1641,6 +1660,11 @@ class _ConversationPanel extends StatelessWidget {
   final ValueChanged<String?> onConversationChanged;
   final Future<void> Function() onCreateGroup;
   final Future<void> Function(String conversationId, bool muted) onMuteChanged;
+  final Future<void> Function(
+    String conversationId,
+    WampAppConversationAppearance appearance,
+  )
+  onAppearanceChanged;
   final ValueChanged<bool> onOneTimeChanged;
   final Future<void> Function(String conversationId, Duration? duration)
   onExpiresAfterChanged;
@@ -1675,6 +1699,9 @@ class _ConversationPanel extends StatelessWidget {
     final conversationMuted =
         activeConversationId != null &&
         controller.isConversationMuted(activeConversationId);
+    final conversationAppearance = activeConversationId == null
+        ? WampAppConversationAppearance.standard
+        : controller.conversationAppearanceFor(activeConversationId);
     final canStartCall =
         !groupMode &&
         recipientController.text.trim().isNotEmpty &&
@@ -1751,6 +1778,35 @@ class _ConversationPanel extends StatelessWidget {
                                   : Icons.notifications_none,
                             ),
                     ),
+                  PopupMenuButton<WampAppConversationAppearance>(
+                    key: const Key('conversation-appearance-menu'),
+                    enabled:
+                        activeConversationId != null &&
+                        !controller.preferenceBusy,
+                    tooltip:
+                        'Chat appearance: ${_appearanceLabel(conversationAppearance)}',
+                    onSelected: activeConversationId == null
+                        ? null
+                        : (appearance) => unawaited(
+                            onAppearanceChanged(
+                              activeConversationId,
+                              appearance,
+                            ),
+                          ),
+                    itemBuilder: (context) => [
+                      for (final appearance
+                          in WampAppConversationAppearance.values)
+                        CheckedPopupMenuItem<WampAppConversationAppearance>(
+                          key: ValueKey(
+                            'conversation-appearance-${appearance.wireName}',
+                          ),
+                          value: appearance,
+                          checked: conversationAppearance == appearance,
+                          child: Text(_appearanceLabel(appearance)),
+                        ),
+                    ],
+                    icon: const Icon(Icons.palette_outlined),
+                  ),
                   IconButton(
                     tooltip: 'Sync messages',
                     onPressed: controller.messageBusy
@@ -1955,6 +2011,9 @@ class _ConversationPanel extends StatelessWidget {
                             visibleMessages[visibleMessages.length - index - 1];
                         return _MessageBubble(
                           message: message,
+                          appearance: controller.conversationAppearanceFor(
+                            message.conversationId,
+                          ),
                           outbound: controller.outboundMessageFor(
                             message.messageId,
                           ),
@@ -2243,6 +2302,13 @@ class _ConversationPanel extends StatelessWidget {
     const Duration(days: 7) => 'Delete after 7 days',
     _ => 'Auto-delete enabled',
   };
+
+  static String _appearanceLabel(WampAppConversationAppearance appearance) =>
+      switch (appearance) {
+        WampAppConversationAppearance.standard => 'Standard',
+        WampAppConversationAppearance.ocean => 'Ocean',
+        WampAppConversationAppearance.sunset => 'Sunset',
+      };
 }
 
 class _NoMessages extends StatelessWidget {
@@ -2261,9 +2327,91 @@ class _NoMessages extends StatelessWidget {
   }
 }
 
+final class _ConversationAppearancePalette {
+  const _ConversationAppearancePalette({
+    required this.outgoingBackground,
+    required this.incomingBackground,
+    required this.outgoingForeground,
+    required this.incomingForeground,
+    required this.radius,
+    required this.tailRadius,
+  });
+
+  final Color outgoingBackground;
+  final Color incomingBackground;
+  final Color outgoingForeground;
+  final Color incomingForeground;
+  final double radius;
+  final double tailRadius;
+
+  Color background(bool outgoing) =>
+      outgoing ? outgoingBackground : incomingBackground;
+
+  Color foreground(bool outgoing) =>
+      outgoing ? outgoingForeground : incomingForeground;
+
+  BorderRadius borderRadius(bool outgoing) => BorderRadius.only(
+    topLeft: Radius.circular(radius),
+    topRight: Radius.circular(radius),
+    bottomLeft: Radius.circular(outgoing ? radius : tailRadius),
+    bottomRight: Radius.circular(outgoing ? tailRadius : radius),
+  );
+
+  static _ConversationAppearancePalette resolve(
+    BuildContext context,
+    WampAppConversationAppearance appearance,
+  ) {
+    final theme = Theme.of(context);
+    final dark = theme.brightness == Brightness.dark;
+    return switch (appearance) {
+      WampAppConversationAppearance.standard => _ConversationAppearancePalette(
+        outgoingBackground: theme.colorScheme.primaryContainer,
+        incomingBackground: theme.colorScheme.surfaceContainerHighest,
+        outgoingForeground: theme.colorScheme.onPrimaryContainer,
+        incomingForeground: theme.colorScheme.onSurface,
+        radius: 16,
+        tailRadius: 16,
+      ),
+      WampAppConversationAppearance.ocean => _ConversationAppearancePalette(
+        outgoingBackground: dark
+            ? const Color(0xFF145766)
+            : const Color(0xFFB7E5EA),
+        incomingBackground: dark
+            ? const Color(0xFF243E48)
+            : const Color(0xFFD5EEF2),
+        outgoingForeground: dark
+            ? const Color(0xFFD6F7FA)
+            : const Color(0xFF08363E),
+        incomingForeground: dark
+            ? const Color(0xFFE1F1F4)
+            : const Color(0xFF17343B),
+        radius: 22,
+        tailRadius: 6,
+      ),
+      WampAppConversationAppearance.sunset => _ConversationAppearancePalette(
+        outgoingBackground: dark
+            ? const Color(0xFF74451F)
+            : const Color(0xFFFFD29B),
+        incomingBackground: dark
+            ? const Color(0xFF51372A)
+            : const Color(0xFFFFE7CC),
+        outgoingForeground: dark
+            ? const Color(0xFFFFE9D2)
+            : const Color(0xFF4C2A06),
+        incomingForeground: dark
+            ? const Color(0xFFFDECE4)
+            : const Color(0xFF452C16),
+        radius: 12,
+        tailRadius: 3,
+      ),
+    };
+  }
+}
+
 class _MessageBubble extends StatelessWidget {
   const _MessageBubble({
     required this.message,
+    required this.appearance,
     this.outbound,
     this.onTap,
     this.onRetry,
@@ -2272,6 +2420,7 @@ class _MessageBubble extends StatelessWidget {
   });
 
   final LocalChatMessage message;
+  final WampAppConversationAppearance appearance;
   final OutboundChatMessage? outbound;
   final VoidCallback? onTap;
   final Future<void> Function()? onRetry;
@@ -2310,6 +2459,8 @@ class _MessageBubble extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final pending = outbound;
+    final palette = _ConversationAppearancePalette.resolve(context, appearance);
+    final borderRadius = palette.borderRadius(message.outgoing);
     return Align(
       alignment: message.outgoing
           ? Alignment.centerRight
@@ -2317,74 +2468,77 @@ class _MessageBubble extends StatelessWidget {
       child: InkWell(
         key: ValueKey('message-bubble-${message.messageId}'),
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: borderRadius,
         child: Container(
+          key: ValueKey('message-surface-${message.messageId}'),
           constraints: const BoxConstraints(maxWidth: 520),
           padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 11),
           decoration: BoxDecoration(
-            color: message.outgoing
-                ? Theme.of(context).colorScheme.primaryContainer
-                : Theme.of(context).colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(16),
+            color: palette.background(message.outgoing),
+            borderRadius: borderRadius,
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                message.isGroup
-                    ? '${message.groupTitle} · @${message.peerUsername}'
-                    : '@${message.peerUsername}',
-                style: const TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w800,
-                ),
-              ),
-              if (message.text.isNotEmpty || message.oneTime) ...[
-                const SizedBox(height: 4),
+          child: DefaultTextStyle.merge(
+            style: TextStyle(color: palette.foreground(message.outgoing)),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 Text(
-                  message.oneTime && !message.outgoing
-                      ? 'Tap to view once'
-                      : message.text,
-                  key: message.oneTime && !message.outgoing
-                      ? ValueKey('message-view-once-${message.messageId}')
-                      : null,
+                  message.isGroup
+                      ? '${message.groupTitle} · @${message.peerUsername}'
+                      : '@${message.peerUsername}',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                  ),
                 ),
+                if (message.text.isNotEmpty || message.oneTime) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    message.oneTime && !message.outgoing
+                        ? 'Tap to view once'
+                        : message.text,
+                    key: message.oneTime && !message.outgoing
+                        ? ValueKey('message-view-once-${message.messageId}')
+                        : null,
+                  ),
+                ],
+                for (final attachment in message.attachments) ...[
+                  const SizedBox(height: 7),
+                  _AttachmentCard(
+                    attachment: attachment,
+                    onOpen: onOpenAttachment == null
+                        ? null
+                        : () => onOpenAttachment!(attachment),
+                  ),
+                ],
+                const SizedBox(height: 5),
+                Text(_statusLabel, style: const TextStyle(fontSize: 10)),
+                if (pending?.canRetry == true ||
+                    pending?.canDiscard == true) ...[
+                  const SizedBox(height: 4),
+                  Wrap(
+                    spacing: 4,
+                    runSpacing: 4,
+                    children: [
+                      if (pending?.canRetry == true)
+                        TextButton.icon(
+                          key: ValueKey('message-retry-${message.messageId}'),
+                          onPressed: onRetry,
+                          icon: const Icon(Icons.refresh, size: 16),
+                          label: const Text('Retry'),
+                        ),
+                      if (pending?.canDiscard == true)
+                        TextButton.icon(
+                          key: ValueKey('message-discard-${message.messageId}'),
+                          onPressed: onDiscard,
+                          icon: const Icon(Icons.delete_outline, size: 16),
+                          label: const Text('Discard'),
+                        ),
+                    ],
+                  ),
+                ],
               ],
-              for (final attachment in message.attachments) ...[
-                const SizedBox(height: 7),
-                _AttachmentCard(
-                  attachment: attachment,
-                  onOpen: onOpenAttachment == null
-                      ? null
-                      : () => onOpenAttachment!(attachment),
-                ),
-              ],
-              const SizedBox(height: 5),
-              Text(_statusLabel, style: const TextStyle(fontSize: 10)),
-              if (pending?.canRetry == true || pending?.canDiscard == true) ...[
-                const SizedBox(height: 4),
-                Wrap(
-                  spacing: 4,
-                  runSpacing: 4,
-                  children: [
-                    if (pending?.canRetry == true)
-                      TextButton.icon(
-                        key: ValueKey('message-retry-${message.messageId}'),
-                        onPressed: onRetry,
-                        icon: const Icon(Icons.refresh, size: 16),
-                        label: const Text('Retry'),
-                      ),
-                    if (pending?.canDiscard == true)
-                      TextButton.icon(
-                        key: ValueKey('message-discard-${message.messageId}'),
-                        onPressed: onDiscard,
-                        icon: const Icon(Icons.delete_outline, size: 16),
-                        label: const Text('Discard'),
-                      ),
-                  ],
-                ),
-              ],
-            ],
+            ),
           ),
         ),
       ),

--- a/examples/wamp_app/client/lib/src/ui/onboarding_page.dart
+++ b/examples/wamp_app/client/lib/src/ui/onboarding_page.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../application/wamp_app_controller.dart';
 import 'backup_passphrase_dialog.dart';
 
 enum _AccountMode { register, login }
+
+enum _ServerProbeState { idle, checking, reachable, unreachable }
 
 const _defaultServerAddress = String.fromEnvironment(
   'WAMP_APP_SERVER_ADDRESS',
@@ -20,19 +24,69 @@ class OnboardingPage extends StatefulWidget {
 }
 
 class _OnboardingPageState extends State<OnboardingPage> {
+  static const _serverProbeDebounce = Duration(milliseconds: 350);
+
   final _server = TextEditingController(text: _defaultServerAddress);
   final _username = TextEditingController();
   final _displayName = TextEditingController();
   final _password = TextEditingController();
   _AccountMode _mode = _AccountMode.register;
+  Timer? _serverProbeTimer;
+  int _serverProbeGeneration = 0;
+  _ServerProbeState _serverProbeState = _ServerProbeState.idle;
+
+  @override
+  void initState() {
+    super.initState();
+    _server.addListener(_onServerChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _scheduleServerProbe(immediate: true);
+    });
+  }
 
   @override
   void dispose() {
+    _serverProbeGeneration += 1;
+    _serverProbeTimer?.cancel();
+    _server.removeListener(_onServerChanged);
     _server.dispose();
     _username.dispose();
     _displayName.dispose();
     _password.dispose();
     super.dispose();
+  }
+
+  void _onServerChanged() => _scheduleServerProbe();
+
+  void _scheduleServerProbe({bool immediate = false}) {
+    if (!mounted) return;
+    _serverProbeTimer?.cancel();
+    final generation = ++_serverProbeGeneration;
+    final serverAddress = _server.text.trim();
+    if (serverAddress.isEmpty) {
+      setState(() => _serverProbeState = _ServerProbeState.idle);
+      return;
+    }
+    setState(() => _serverProbeState = _ServerProbeState.checking);
+    if (immediate) {
+      unawaited(_probeServer(serverAddress, generation));
+      return;
+    }
+    _serverProbeTimer = Timer(_serverProbeDebounce, () {
+      _serverProbeTimer = null;
+      unawaited(_probeServer(serverAddress, generation));
+    });
+  }
+
+  Future<void> _probeServer(String serverAddress, int generation) async {
+    var nextState = _ServerProbeState.reachable;
+    try {
+      await widget.controller.probeServer(serverAddress: serverAddress);
+    } catch (_) {
+      nextState = _ServerProbeState.unreachable;
+    }
+    if (!mounted || generation != _serverProbeGeneration) return;
+    setState(() => _serverProbeState = nextState);
   }
 
   Future<void> _submit() async {
@@ -183,6 +237,13 @@ class _AccountCard extends StatelessWidget {
                   prefixIcon: Icon(Icons.dns_outlined),
                 ),
               ),
+              const SizedBox(height: 8),
+              _ServerProbeStatus(
+                state: state._serverProbeState,
+                onRetry: controller.isBusy
+                    ? null
+                    : () => state._scheduleServerProbe(immediate: true),
+              ),
               const SizedBox(height: 14),
               TextField(
                 key: const Key('username'),
@@ -290,6 +351,77 @@ class _AccountCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _ServerProbeStatus extends StatelessWidget {
+  const _ServerProbeStatus({required this.state, required this.onRetry});
+
+  final _ServerProbeState state;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 180),
+      child: switch (state) {
+        _ServerProbeState.idle => const SizedBox.shrink(
+          key: Key('server-probe-idle'),
+        ),
+        _ServerProbeState.checking => Semantics(
+          key: const Key('server-probe-checking'),
+          liveRegion: true,
+          child: const Row(
+            children: [
+              SizedBox.square(
+                dimension: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              SizedBox(width: 8),
+              Expanded(child: Text('Checking router availability...')),
+            ],
+          ),
+        ),
+        _ServerProbeState.reachable => Semantics(
+          key: const Key('server-probe-reachable'),
+          liveRegion: true,
+          child: Row(
+            children: [
+              Icon(
+                Icons.check_circle_outline,
+                size: 18,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text('Router ready for secure WAMP onboarding.'),
+              ),
+            ],
+          ),
+        ),
+        _ServerProbeState.unreachable => Semantics(
+          key: const Key('server-probe-unreachable'),
+          liveRegion: true,
+          child: Row(
+            children: [
+              Icon(Icons.error_outline, size: 18, color: colorScheme.error),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'Router not reachable. Check the address or start the server.',
+                ),
+              ),
+              TextButton(
+                key: const Key('server-probe-retry'),
+                onPressed: onRetry,
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      },
     );
   }
 }

--- a/examples/wamp_app/client/test/attachment_cipher_test.dart
+++ b/examples/wamp_app/client/test/attachment_cipher_test.dart
@@ -139,6 +139,69 @@ void main() {
     },
   );
 
+  test(
+    'prefetch authenticates ciphertext for later offline decryption',
+    () async {
+      final plaintext = Uint8List.fromList(
+        List<int>.generate(65537, (index) => (index * 17) % 251),
+      );
+      final producer = MemoryAttachmentChunkCache();
+      final consumer = MemoryAttachmentChunkCache();
+      addTearDown(producer.dispose);
+      addTearDown(consumer.dispose);
+      final cipher = AttachmentCipher(random: Random(9));
+      addTearDown(cipher.dispose);
+      final attachment = (await cipher.encryptSources(
+        scope: 'producer',
+        senderUsername: 'alice',
+        messageId: messageId,
+        sources: [
+          AttachmentPlaintextSource(
+            name: 'view-once.bin',
+            contentType: 'application/octet-stream',
+            kind: ChatAttachmentKind.file,
+            byteCount: plaintext.length,
+            openRead: () => Stream.value(plaintext),
+          ),
+        ],
+        cache: producer,
+      )).single;
+      var fetches = 0;
+
+      await cipher.cacheEncryptedChunks(
+        scope: scope,
+        senderUsername: 'alice',
+        messageId: messageId,
+        attachment: attachment,
+        cache: consumer,
+        fetchChunk: (chunkIndex) async {
+          fetches += 1;
+          return (await producer.get(
+            scope: 'producer',
+            senderUsername: 'alice',
+            messageId: messageId,
+            attachmentId: attachment.attachmentId,
+            chunkIndex: chunkIndex,
+            chunkCount: attachment.chunkCount,
+          ))!;
+        },
+      );
+      await producer.removeMessage(scope: 'producer', messageId: messageId);
+
+      expect(fetches, attachment.chunkCount);
+      expect(
+        await cipher.decryptToBytes(
+          scope: scope,
+          senderUsername: 'alice',
+          messageId: messageId,
+          attachment: attachment,
+          cache: consumer,
+        ),
+        plaintext,
+      );
+    },
+  );
+
   test('native ciphertext cache survives a new cache instance', () async {
     final root = await Directory.systemTemp.createTemp('wamp-app-cache-');
     addTearDown(() => root.delete(recursive: true));

--- a/examples/wamp_app/client/test/call_controller_test.dart
+++ b/examples/wamp_app/client/test/call_controller_test.dart
@@ -61,6 +61,7 @@ void main() {
       ),
     );
     expect(harness.sentSignals, isEmpty);
+    media.stateOnApplyAnswer = CallMediaConnectionState.connected;
 
     final answer = harness.remoteSignal(
       callId: controller.call!.callId,
@@ -87,9 +88,7 @@ void main() {
 
     expect(media.appliedAnswers.single.sdp, contains('answer'));
     expect(harness.sentSignals.single.kind, CallSignalKind.iceCandidate);
-    expect(controller.phase, CallUiPhase.connecting);
-    media.emitState(CallMediaConnectionState.connected);
-    await _waitFor(() => controller.phase == CallUiPhase.active);
+    expect(controller.phase, CallUiPhase.active);
   });
 
   test('first answer on another callee device disposes local media', () async {
@@ -510,6 +509,7 @@ final class _FakeCallMediaSession implements CallMediaSession {
   bool _muted = false;
   bool _cameraEnabled = true;
   bool _speakerEnabled = false;
+  CallMediaConnectionState? stateOnApplyAnswer;
 
   @override
   Stream<CallIceCandidate> get localCandidates => _candidates.stream;
@@ -545,6 +545,8 @@ final class _FakeCallMediaSession implements CallMediaSession {
   @override
   Future<void> applyAnswer(CallSessionDescription answer) async {
     appliedAnswers.add(answer);
+    final state = stateOnApplyAnswer;
+    if (state != null) emitState(state);
   }
 
   @override

--- a/examples/wamp_app/client/test/consumer_integration_test.dart
+++ b/examples/wamp_app/client/test/consumer_integration_test.dart
@@ -46,6 +46,9 @@ void main() {
       );
       addTearDown(controller.dispose);
 
+      await controller.probeServer(
+        serverAddress: server.websocketUri.toString(),
+      );
       await controller.registerAndConnect(
         serverAddress: server.websocketUri.toString(),
         username: 'alice',

--- a/examples/wamp_app/client/test/consumer_integration_test.dart
+++ b/examples/wamp_app/client/test/consumer_integration_test.dart
@@ -255,6 +255,32 @@ void main() {
             .text,
         groupPlaintext,
       );
+      const groupReplyPlaintext = 'A discovered group member can reply.';
+      expect(
+        await bob.sendGroupMessage(
+          groupId: group.conversationId,
+          text: groupReplyPlaintext,
+        ),
+        isTrue,
+        reason: '${bob.messageError}',
+      );
+      expect(bob.messageError, isNull);
+      final groupReply = bob.messages.singleWhere(
+        (message) =>
+            message.conversationId == group.conversationId &&
+            message.text == groupReplyPlaintext,
+      );
+      await _waitFor(
+        () =>
+            alice.messages.any(
+              (message) => message.messageId == groupReply.messageId,
+            ) &&
+            carol.messages.any(
+              (message) => message.messageId == groupReply.messageId,
+            ) &&
+            !alice.messageBusy &&
+            !carol.messageBusy,
+      );
       await _waitFor(
         () =>
             alice.messages
@@ -293,11 +319,12 @@ void main() {
       expect(mailboxDocument, isNot(contains(plaintext)));
       expect(mailboxDocument, isNot(contains(oneTimePlaintext)));
       expect(mailboxDocument, isNot(contains(groupPlaintext)));
+      expect(mailboxDocument, isNot(contains(groupReplyPlaintext)));
       expect(mailboxDocument, isNot(contains('Launch crew')));
       expect(mailboxDocument, contains('encrypted_payload'));
       expect(mailboxDocument, contains('consumed_by_device_id'));
 
-      await _waitFor(() => !bob.messageBusy && bob.messages.length == 2);
+      await _waitFor(() => !bob.messageBusy && bob.messages.length == 3);
       await bob.signOut();
       bob.dispose();
       bob = _controller(bobStorage, 'Bob phone');
@@ -311,7 +338,7 @@ void main() {
         WampAppStatus.connected,
         reason: '${bob.errorMessage} / ${bob.messageError}',
       );
-      expect(bob.messages, hasLength(2));
+      expect(bob.messages, hasLength(3));
       expect(
         bob.messages.any((message) => message.messageId == durableMessageId),
         isTrue,

--- a/examples/wamp_app/client/test/consumer_integration_test.dart
+++ b/examples/wamp_app/client/test/consumer_integration_test.dart
@@ -94,6 +94,85 @@ void main() {
   );
 
   test(
+    'verified peer continuity blocks a newly enrolled device until review',
+    () async {
+      final temporary = await Directory.systemTemp.createTemp(
+        'wamp-app-peer-trust-',
+      );
+      addTearDown(() => temporary.delete(recursive: true));
+      final server = await WampAppServer.start(
+        WampAppServerConfig(
+          host: '127.0.0.1',
+          port: 0,
+          websocketPath: '/ws',
+          accountStorePath: '${temporary.path}/accounts.json',
+          messageStorePath: '${temporary.path}/messages.json',
+          argonIterations: 1,
+          argonMemoryKiB: 8192,
+        ),
+      );
+      addTearDown(server.close);
+      final alice = _controller(_MemoryVaultStorage(), 'Alice phone');
+      final bobPhone = _controller(_MemoryVaultStorage(), 'Bob phone');
+      final bobTablet = _controller(_MemoryVaultStorage(), 'Bob tablet');
+      addTearDown(alice.dispose);
+      addTearDown(bobPhone.dispose);
+      addTearDown(bobTablet.dispose);
+
+      await alice.registerAndConnect(
+        serverAddress: server.websocketUri.toString(),
+        username: 'alice',
+        displayName: 'Alice Example',
+        password: 'alice secret phrase',
+      );
+      await bobPhone.registerAndConnect(
+        serverAddress: server.websocketUri.toString(),
+        username: 'bob',
+        displayName: 'Bob Example',
+        password: 'bob secret phrase',
+      );
+      final initial = await alice.inspectPeerTrust('bob');
+      expect(initial!.devices, hasLength(1));
+      expect(initial.status, PeerTrustStatus.unverified);
+      await alice.verifyPeerDevice(initial.devices.single);
+
+      await bobTablet.login(
+        serverAddress: server.websocketUri.toString(),
+        username: 'bob',
+        password: 'bob secret phrase',
+      );
+      final changed = await alice.inspectPeerTrust('bob');
+      expect(changed!.devices, hasLength(2));
+      expect(changed.status, PeerTrustStatus.changed);
+      expect(changed.devices.where((device) => device.verified), hasLength(1));
+      expect(
+        await alice.sendMessage(
+          recipientUsername: 'bob',
+          text: 'blocked before re-verification',
+        ),
+        isFalse,
+      );
+      expect(alice.messages, isEmpty);
+      expect(alice.messageError, contains('Encryption identity changed'));
+
+      final refreshed = await alice.verifyPeerDevice(
+        changed.devices.singleWhere((device) => !device.verified),
+      );
+      expect(refreshed!.status, PeerTrustStatus.verified);
+      expect(
+        await alice.sendMessage(
+          recipientUsername: 'bob',
+          text: 'sent after every active device is verified',
+        ),
+        isTrue,
+      );
+      expect(alice.messageError, isNull);
+      expect(alice.messages.single.text, contains('sent after'));
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
     'participants receive durable wakeups while unrelated users are excluded',
     () async {
       final temporary = await Directory.systemTemp.createTemp(

--- a/examples/wamp_app/client/test/consumer_integration_test.dart
+++ b/examples/wamp_app/client/test/consumer_integration_test.dart
@@ -533,6 +533,65 @@ void main() {
   );
 
   test(
+    'authenticated app session discovers configured MCP access routes',
+    () async {
+      final temporary = await Directory.systemTemp.createTemp(
+        'wamp-app-mcp-discovery-consumer-',
+      );
+      addTearDown(() => temporary.delete(recursive: true));
+      final server = await WampAppServer.start(
+        WampAppServerConfig(
+          host: '127.0.0.1',
+          port: 0,
+          websocketPath: '/ws',
+          accountStorePath: '${temporary.path}/accounts.json',
+          messageStorePath: '${temporary.path}/messages.json',
+          mcp: WampAppMcpConfig(
+            enabled: true,
+            path: '/ai/mcp',
+            authPath: '/ai/mcp/auth',
+            consentStorePath: '${temporary.path}/mcp-consent.json',
+            allowInsecureTransport: true,
+          ),
+          argonIterations: 1,
+          argonMemoryKiB: 8192,
+        ),
+      );
+      addTearDown(server.close);
+      final endpoint = ServerEndpoint.parse(server.websocketUri.toString());
+      const gateway = WampAccountGateway(
+        connectionTimeout: Duration(seconds: 15),
+        derivationTimeout: Duration(seconds: 30),
+      );
+      await gateway.register(
+        endpoint: endpoint,
+        registration: AccountRegistration(
+          username: 'alice',
+          displayName: 'Alice',
+          password: 'alice mcp discovery secret',
+        ),
+      );
+      final connection = await gateway.login(
+        endpoint: endpoint,
+        username: 'alice',
+        password: 'alice mcp discovery secret',
+      );
+      addTearDown(connection.close);
+
+      final access = await connection.getMcpAccessConfiguration();
+
+      expect(access.mcpUriFor(endpoint), server.mcpUri);
+      expect(access.authUriFor(endpoint).path, '/ai/mcp/auth');
+      expect(access.profileFields, WampAppMcpAccessContract.profileFields);
+      expect(
+        access.toWampKeywords().values,
+        isNot(contains('alice mcp discovery secret')),
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
     'typed WAMP calling signals stay encrypted and replay after reconnect',
     () async {
       final temporary = await Directory.systemTemp.createTemp(

--- a/examples/wamp_app/client/test/consumer_integration_test.dart
+++ b/examples/wamp_app/client/test/consumer_integration_test.dart
@@ -203,7 +203,7 @@ void main() {
       final revealed = await bob.consumeOneTimeMessage(
         oneTimeMessage.messageId,
       );
-      expect(revealed, oneTimePlaintext);
+      expect(revealed?.text, oneTimePlaintext);
       expect(
         bob.messages.any(
           (message) => message.messageId == oneTimeMessage.messageId,

--- a/examples/wamp_app/client/test/device_vault_test.dart
+++ b/examples/wamp_app/client/test/device_vault_test.dart
@@ -160,6 +160,7 @@ void main() {
     );
     final bobRecord = _record('bob', bob.enrollment);
 
+    expect(alice.hasVerifiedContact('bob'), isFalse);
     expect(alice.isVerified(bobRecord), isFalse);
     await alice.markVerified(bobRecord);
     await alice.dispose();
@@ -172,7 +173,58 @@ void main() {
       deviceName: 'Alice phone',
     );
     addTearDown(reopened.dispose);
+    expect(reopened.hasVerifiedContact(' BOB '), isTrue);
     expect(reopened.isVerified(bobRecord), isTrue);
+    expect(
+      reopened.isVerified(
+        _record(
+          'bob',
+          DeviceEnrollment(
+            deviceId: _token(32, 41),
+            deviceName: 'Bob replacement phone',
+            signingPublicKey: _token(32, 42),
+            exchangePublicKey: _token(32, 43),
+            attestation: _token(64, 44),
+            createdAt: DateTime.utc(2026, 8, 25),
+          ),
+        ),
+      ),
+      isFalse,
+    );
+  });
+
+  test('failed safety verification persistence rolls back trust', () async {
+    final alice = await vault.openOrCreate(
+      endpoint: endpoint,
+      username: 'alice',
+      password: 'correct horse battery',
+      deviceName: 'Alice phone',
+    );
+    final bob = await vault.openOrCreate(
+      endpoint: endpoint,
+      username: 'bob',
+      password: 'another correct horse',
+      deviceName: 'Bob phone',
+    );
+    final bobRecord = _record('bob', bob.enrollment);
+    storage.writeFailure = StateError('disk full');
+
+    await expectLater(alice.markVerified(bobRecord), throwsStateError);
+    expect(alice.hasVerifiedContact('bob'), isFalse);
+    expect(alice.isVerified(bobRecord), isFalse);
+
+    storage.writeFailure = null;
+    await alice.dispose();
+    await bob.dispose();
+    final reopened = await vault.openOrCreate(
+      endpoint: endpoint,
+      username: 'alice',
+      password: 'correct horse battery',
+      deviceName: 'Alice phone',
+    );
+    addTearDown(reopened.dispose);
+    expect(reopened.hasVerifiedContact('bob'), isFalse);
+    expect(reopened.isVerified(bobRecord), isFalse);
   });
 
   test('conversation keys are recipient-sealed and sender-signed', () async {

--- a/examples/wamp_app/client/test/device_vault_test.dart
+++ b/examples/wamp_app/client/test/device_vault_test.dart
@@ -379,11 +379,15 @@ void main() {
       LocalAppPreferences(
         theme: WampAppThemePreference.dark,
         mutedConversationIds: const ['private-conversation-id'],
+        conversationAppearances: const {
+          'private-conversation-id': WampAppConversationAppearance.ocean,
+        },
       ),
     );
     final encoded = storage.values.values.single;
     expect(encoded, isNot(contains('private-conversation-id')));
     expect(encoded, isNot(contains('dark')));
+    expect(encoded, isNot(contains('ocean')));
     await first.dispose();
 
     final reopened = await vault.openOrCreate(
@@ -395,6 +399,10 @@ void main() {
     addTearDown(reopened.dispose);
     expect(reopened.preferences.theme, WampAppThemePreference.dark);
     expect(reopened.preferences.isMuted('private-conversation-id'), isTrue);
+    expect(
+      reopened.preferences.conversationAppearanceFor('private-conversation-id'),
+      WampAppConversationAppearance.ocean,
+    );
   });
 
   test('failed preference writes leave live state unchanged', () async {

--- a/examples/wamp_app/client/test/local_app_preferences_test.dart
+++ b/examples/wamp_app/client/test/local_app_preferences_test.dart
@@ -8,6 +8,11 @@ void main() {
     expect(preferences.theme, WampAppThemePreference.system);
     expect(preferences.mutedConversationIds, isEmpty);
     expect(preferences.disappearingMessageDurations, isEmpty);
+    expect(preferences.conversationAppearances, isEmpty);
+    expect(
+      preferences.conversationAppearanceFor('direct-a'),
+      WampAppConversationAppearance.standard,
+    );
   });
 
   test('preferences round-trip with stable sorted conversation ids', () {
@@ -18,6 +23,10 @@ void main() {
         'group-z': Duration(days: 7),
         'direct-a': Duration(hours: 1),
       },
+      conversationAppearances: const {
+        'group-z': WampAppConversationAppearance.sunset,
+        'direct-a': WampAppConversationAppearance.ocean,
+      },
     );
 
     final encoded = preferences.toJson();
@@ -27,6 +36,7 @@ void main() {
       'theme': 'dark',
       'muted_conversation_ids': ['direct-a', 'group-z'],
       'disappearing_message_seconds': {'direct-a': 3600, 'group-z': 604800},
+      'conversation_appearances': {'direct-a': 'ocean', 'group-z': 'sunset'},
     });
     expect(decoded.theme, WampAppThemePreference.dark);
     expect(decoded.mutedConversationIds, {'direct-a', 'group-z'});
@@ -35,6 +45,14 @@ void main() {
       const Duration(hours: 1),
     );
     expect(decoded.disappearingMessagesFor('group-z'), const Duration(days: 7));
+    expect(
+      decoded.conversationAppearanceFor('direct-a'),
+      WampAppConversationAppearance.ocean,
+    );
+    expect(
+      decoded.conversationAppearanceFor('group-z'),
+      WampAppConversationAppearance.sunset,
+    );
   });
 
   test('saved preferences without disappearing messages migrate cleanly', () {
@@ -46,6 +64,56 @@ void main() {
     expect(preferences.theme, WampAppThemePreference.dark);
     expect(preferences.isMuted('direct-a'), isTrue);
     expect(preferences.disappearingMessageDurations, isEmpty);
+    expect(preferences.conversationAppearances, isEmpty);
+    expect(
+      preferences.conversationAppearanceFor('direct-a'),
+      WampAppConversationAppearance.standard,
+    );
+  });
+
+  test('immutable updates isolate direct and group chat appearance', () {
+    final directOcean = LocalAppPreferences.defaults.withConversationAppearance(
+      'direct-a',
+      WampAppConversationAppearance.ocean,
+    );
+    final groupSunset = directOcean.withConversationAppearance(
+      'group-b',
+      WampAppConversationAppearance.sunset,
+    );
+    final directStandard = groupSunset.withConversationAppearance(
+      'direct-a',
+      WampAppConversationAppearance.standard,
+    );
+
+    expect(LocalAppPreferences.defaults.conversationAppearances, isEmpty);
+    expect(
+      directOcean.conversationAppearanceFor('direct-a'),
+      WampAppConversationAppearance.ocean,
+    );
+    expect(
+      directOcean.conversationAppearanceFor('group-b'),
+      WampAppConversationAppearance.standard,
+    );
+    expect(
+      groupSunset.conversationAppearanceFor('group-b'),
+      WampAppConversationAppearance.sunset,
+    );
+    expect(
+      directStandard.conversationAppearanceFor('direct-a'),
+      WampAppConversationAppearance.standard,
+    );
+    expect(
+      directStandard.conversationAppearanceFor('group-b'),
+      WampAppConversationAppearance.sunset,
+    );
+    expect(directStandard.conversationAppearances, {
+      'group-b': WampAppConversationAppearance.sunset,
+    });
+    expect(
+      () => directOcean.conversationAppearances['unexpected'] =
+          WampAppConversationAppearance.sunset,
+      throwsUnsupportedError,
+    );
   });
 
   test('immutable updates isolate direct and group mute state', () {
@@ -140,6 +208,21 @@ void main() {
         'muted_conversation_ids': <String>[],
         'disappearing_message_seconds': {'direct-a': '3600'},
       },
+      {
+        'theme': 'dark',
+        'muted_conversation_ids': <String>[],
+        'conversation_appearances': 'ocean',
+      },
+      {
+        'theme': 'dark',
+        'muted_conversation_ids': <String>[],
+        'conversation_appearances': {'direct-a': 1},
+      },
+      {
+        'theme': 'dark',
+        'muted_conversation_ids': <String>[],
+        'conversation_appearances': {'direct-a': 'sepia'},
+      },
     ];
 
     for (final value in invalidValues) {
@@ -204,6 +287,33 @@ void main() {
     expect(
       () => LocalAppPreferences(
         disappearingMessageDurations: const {'direct-a': Duration(minutes: 5)},
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('chat-appearance identifiers and count remain bounded', () {
+    expect(
+      () => LocalAppPreferences(
+        conversationAppearances: {
+          List<String>.filled(
+            LocalAppPreferences.maxConversationIdLength + 1,
+            'x',
+          ).join(): WampAppConversationAppearance.ocean,
+        },
+      ),
+      throwsFormatException,
+    );
+    expect(
+      () => LocalAppPreferences(
+        conversationAppearances: {
+          for (
+            var index = 0;
+            index <= LocalAppPreferences.maxConversationAppearances;
+            index += 1
+          )
+            'conversation-$index': WampAppConversationAppearance.sunset,
+        },
       ),
       throwsFormatException,
     );

--- a/examples/wamp_app/client/test/multi_device_conflict_integration_test.dart
+++ b/examples/wamp_app/client/test/multi_device_conflict_integration_test.dart
@@ -6,6 +6,8 @@ import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wamp_app/src/application/wamp_app_controller.dart';
+import 'package:wamp_app/src/infrastructure/attachment_chunk_cache.dart';
+import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
 import 'package:wamp_app/src/infrastructure/device_vault.dart';
 import 'package:wamp_app/src/infrastructure/vault_storage.dart';
 import 'package:wamp_app/src/infrastructure/wamp_account_gateway.dart';
@@ -35,15 +37,24 @@ void main() {
       );
       addTearDown(server.close);
 
+      final prefetchBarrier = _AsyncBarrier(3);
+      final aliceCaches = List<AttachmentChunkCache>.generate(
+        3,
+        (_) => MemoryAttachmentChunkCache(),
+      );
+      final bobCaches = List<_PrefetchBarrierCache>.generate(
+        3,
+        (_) => _PrefetchBarrierCache(prefetchBarrier),
+      );
       final alice = [
-        _controller('Alice phone'),
-        _controller('Alice tablet'),
-        _controller('Alice desktop'),
+        _controller('Alice phone', attachmentCache: aliceCaches[0]),
+        _controller('Alice tablet', attachmentCache: aliceCaches[1]),
+        _controller('Alice desktop', attachmentCache: aliceCaches[2]),
       ];
       final bob = [
-        _controller('Bob phone'),
-        _controller('Bob tablet'),
-        _controller('Bob desktop'),
+        _controller('Bob phone', attachmentCache: bobCaches[0]),
+        _controller('Bob tablet', attachmentCache: bobCaches[1]),
+        _controller('Bob desktop', attachmentCache: bobCaches[2]),
       ];
       final controllers = [...alice, ...bob];
       for (final controller in controllers) {
@@ -179,6 +190,9 @@ void main() {
       );
 
       const oneTimeText = 'only one Bob device may open this';
+      final oneTimeBytes = Uint8List.fromList(
+        List<int>.generate(4096, (index) => (index * 29) & 0xff),
+      );
       await _waitFor(
         () => controllers.every((entry) => !entry.messageBusy),
         description: 'all devices idle before one-time send',
@@ -189,6 +203,15 @@ void main() {
           recipientUsername: 'bob',
           text: oneTimeText,
           oneTime: true,
+          attachmentSources: [
+            AttachmentPlaintextSource(
+              name: 'view-once.bin',
+              contentType: 'application/octet-stream',
+              kind: ChatAttachmentKind.file,
+              byteCount: oneTimeBytes.length,
+              openRead: () => Stream.value(oneTimeBytes),
+            ),
+          ],
         ),
         isTrue,
       );
@@ -204,6 +227,10 @@ void main() {
         description: 'one-time message on every Bob device',
         details: () => _controllerDetails(bob),
       );
+      final oneTimeAttachment = bob.first.messages
+          .singleWhere((message) => message.messageId == oneTimeId)
+          .attachments
+          .single;
       await _waitFor(
         () => bob.every((entry) => !entry.messageBusy),
         description: 'Bob devices idle before one-time race',
@@ -213,8 +240,24 @@ void main() {
         for (final controller in bob)
           controller.consumeOneTimeMessage(oneTimeId),
       ]);
-      expect(openings.where((text) => text == oneTimeText), hasLength(1));
-      expect(openings.where((text) => text == null), hasLength(2));
+      expect(
+        openings.where((message) => message?.text == oneTimeText),
+        hasLength(1),
+      );
+      expect(openings.where((message) => message == null), hasLength(2));
+      expect(prefetchBarrier.arrivals, 3);
+      final winnerIndex = openings.indexWhere((message) => message != null);
+      for (var index = 0; index < bob.length; index += 1) {
+        final cached = await bobCaches[index].get(
+          scope: attachmentCacheScope(bob[index].connection!.endpoint, 'bob'),
+          senderUsername: 'alice',
+          messageId: oneTimeId,
+          attachmentId: oneTimeAttachment.attachmentId,
+          chunkIndex: 0,
+          chunkCount: oneTimeAttachment.chunkCount,
+        );
+        expect(cached, index == winnerIndex ? isNotNull : isNull);
+      }
       await _waitFor(
         () => bob.every(
           (controller) => controller.messages.every(
@@ -224,6 +267,20 @@ void main() {
         description: 'one-time removal from every Bob device',
         details: () => _controllerDetails(bob),
       );
+      await bob[winnerIndex].closeOpenedOneTimeMessage(openings[winnerIndex]!);
+      for (var index = 0; index < bob.length; index += 1) {
+        expect(
+          await bobCaches[index].get(
+            scope: attachmentCacheScope(bob[index].connection!.endpoint, 'bob'),
+            senderUsername: 'alice',
+            messageId: oneTimeId,
+            attachmentId: oneTimeAttachment.attachmentId,
+            chunkIndex: 0,
+            chunkCount: oneTimeAttachment.chunkCount,
+          ),
+          isNull,
+        );
+      }
 
       final profileRevision = alice.first.connection!.profile.revision;
       final profileUpdates = await Future.wait([
@@ -313,7 +370,10 @@ void main() {
   );
 }
 
-WampAppController _controller(String deviceName) {
+WampAppController _controller(
+  String deviceName, {
+  AttachmentChunkCache? attachmentCache,
+}) {
   return WampAppController(
     trustStore: EncryptedDeviceVault(
       storage: _MemoryVaultStorage(),
@@ -321,8 +381,70 @@ WampAppController _controller(String deviceName) {
       iterations: 1,
       memoryKiB: 64,
     ),
+    attachmentCache: attachmentCache,
     deviceName: deviceName,
   );
+}
+
+final class _AsyncBarrier {
+  _AsyncBarrier(this.participants);
+
+  final int participants;
+  final Completer<void> _release = Completer<void>();
+  int arrivals = 0;
+
+  Future<void> arrive() {
+    arrivals += 1;
+    if (arrivals == participants) _release.complete();
+    if (arrivals > participants) {
+      throw StateError(
+        'Attachment prefetch barrier received too many arrivals.',
+      );
+    }
+    return _release.future;
+  }
+}
+
+final class _PrefetchBarrierCache implements AttachmentChunkCache {
+  _PrefetchBarrierCache(this._barrier);
+
+  final _AsyncBarrier _barrier;
+  final MemoryAttachmentChunkCache _delegate = MemoryAttachmentChunkCache();
+
+  @override
+  Future<void> put({
+    required String scope,
+    required EncryptedAttachmentChunk chunk,
+  }) async {
+    await _delegate.put(scope: scope, chunk: chunk);
+    await _barrier.arrive();
+  }
+
+  @override
+  Future<EncryptedAttachmentChunk?> get({
+    required String scope,
+    required String senderUsername,
+    required String messageId,
+    required String attachmentId,
+    required int chunkIndex,
+    required int chunkCount,
+  }) => _delegate.get(
+    scope: scope,
+    senderUsername: senderUsername,
+    messageId: messageId,
+    attachmentId: attachmentId,
+    chunkIndex: chunkIndex,
+    chunkCount: chunkCount,
+  );
+
+  @override
+  Future<void> removeMessage({
+    required String scope,
+    required String messageId,
+  }) => _delegate.removeMessage(scope: scope, messageId: messageId);
+
+  @override
+  Future<void> dispose() => _delegate.dispose();
 }
 
 Future<void> _waitFor(

--- a/examples/wamp_app/client/test/profile_avatar_picker_test.dart
+++ b/examples/wamp_app/client/test/profile_avatar_picker_test.dart
@@ -1,0 +1,102 @@
+import 'dart:typed_data';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wamp_app/src/infrastructure/profile_avatar_picker.dart';
+import 'package:wamp_app_protocol/wamp_app_protocol.dart';
+
+void main() {
+  test('profile avatar selection owns its bytes', () {
+    final source = Uint8List.fromList([1, 2, 3]);
+    final selection = ProfileAvatarSelection(name: 'avatar.png', bytes: source);
+
+    source[0] = 9;
+
+    expect(selection.name, 'avatar.png');
+    expect(selection.bytes, [1, 2, 3]);
+  });
+
+  test('file selector avatar picker preserves cancellation', () async {
+    const picker = FileSelectorProfileAvatarPicker(_cancelSelection);
+
+    expect(await picker.pickAvatar(), isNull);
+  });
+
+  test('file selector avatar picker returns a bounded owned image', () async {
+    final source = Uint8List.fromList([1, 2, 3, 4]);
+    final picker = FileSelectorProfileAvatarPicker(
+      () async =>
+          XFile.fromData(source, name: 'avatar.png', path: 'avatar.png'),
+    );
+
+    final selection = await picker.pickAvatar();
+    source[0] = 9;
+
+    expect(selection?.name, 'avatar.png');
+    expect(selection?.bytes, [1, 2, 3, 4]);
+  });
+
+  test('file selector avatar picker rejects oversized images', () async {
+    final picker = FileSelectorProfileAvatarPicker(
+      () async => XFile.fromData(
+        Uint8List(AccountProfileLimits.maxAvatarBytes + 1),
+        name: 'avatar.png',
+        path: 'avatar.png',
+      ),
+    );
+
+    await expectLater(
+      picker.pickAvatar(),
+      throwsA(
+        isA<ProfileAvatarPickerException>().having(
+          (error) => error.message,
+          'message',
+          'Profile images must be 256 KiB or smaller.',
+        ),
+      ),
+    );
+  });
+
+  test('file selector avatar picker rejects empty images', () async {
+    final picker = FileSelectorProfileAvatarPicker(
+      () async =>
+          XFile.fromData(Uint8List(0), name: 'avatar.png', path: 'avatar.png'),
+    );
+
+    await expectLater(
+      picker.pickAvatar(),
+      throwsA(
+        isA<ProfileAvatarPickerException>().having(
+          (error) => error.message,
+          'message',
+          'Profile images must be 256 KiB or smaller.',
+        ),
+      ),
+    );
+  });
+
+  test('file selector avatar picker redacts selector failures', () async {
+    final picker = FileSelectorProfileAvatarPicker(
+      () async => throw StateError('private path'),
+    );
+
+    await expectLater(
+      picker.pickAvatar(),
+      throwsA(
+        isA<ProfileAvatarPickerException>()
+            .having(
+              (error) => error.message,
+              'message',
+              'The selected profile image could not be read.',
+            )
+            .having(
+              (error) => error.toString(),
+              'redacted error',
+              isNot(contains('private path')),
+            ),
+      ),
+    );
+  });
+}
+
+Future<XFile?> _cancelSelection() async => null;

--- a/examples/wamp_app/client/test/rich_media_fixture_test.dart
+++ b/examples/wamp_app/client/test/rich_media_fixture_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wamp_app/src/infrastructure/voice_note_playback.dart';
+
+import '../integration_test/support/rich_media_fixtures.dart';
+
+void main() {
+  test('native GIF fixture decodes as two animated frames', () async {
+    final bytes = nativeAnimatedGifBytes();
+    expect(ascii.decode(bytes.sublist(0, 6)), 'GIF89a');
+
+    final codec = await ui.instantiateImageCodec(bytes);
+    addTearDown(codec.dispose);
+    expect(codec.frameCount, 2);
+    for (var index = 0; index < codec.frameCount; index += 1) {
+      final frame = await codec.getNextFrame();
+      expect(frame.duration, const Duration(milliseconds: 100));
+      expect(frame.image.width, 1);
+      expect(frame.image.height, 1);
+      frame.image.dispose();
+    }
+  });
+
+  test('native voice-note fixture is a non-silent two-second PCM WAV', () {
+    final bytes = nativeVoiceNoteBytes();
+    final data = ByteData.sublistView(bytes);
+    final playback = VoiceNotePlaybackController(
+      bytes,
+      expectedDuration: const Duration(
+        milliseconds: nativeVoiceNoteDurationMilliseconds,
+      ),
+      backend: const _NoopVoiceNoteBackend(),
+    );
+    addTearDown(playback.dispose);
+
+    expect(ascii.decode(bytes.sublist(0, 4)), 'RIFF');
+    expect(data.getUint32(4, Endian.little) + 8, bytes.length);
+    expect(ascii.decode(bytes.sublist(8, 12)), 'WAVE');
+    expect(ascii.decode(bytes.sublist(12, 16)), 'fmt ');
+    expect(data.getUint16(20, Endian.little), 1);
+    expect(data.getUint16(22, Endian.little), 1);
+    expect(data.getUint32(24, Endian.little), 16000);
+    expect(data.getUint32(28, Endian.little), 32000);
+    expect(data.getUint16(34, Endian.little), 16);
+    expect(ascii.decode(bytes.sublist(36, 40)), 'data');
+    expect(data.getUint32(40, Endian.little), bytes.length - 44);
+    expect(bytes.skip(44), contains(isNot(0)));
+    expect(
+      (bytes.length - 44) ~/ 2 * 1000 ~/ 16000,
+      nativeVoiceNoteDurationMilliseconds,
+    );
+  });
+}
+
+final class _NoopVoiceNoteBackend implements VoiceNotePlayerBackend {
+  const _NoopVoiceNoteBackend();
+
+  @override
+  Stream<void> get completions => const Stream.empty();
+
+  @override
+  Stream<Duration> get durationChanges => const Stream.empty();
+
+  @override
+  Stream<Duration> get positionChanges => const Stream.empty();
+
+  @override
+  Stream<PlayerState> get stateChanges => const Stream.empty();
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> play(Source source) async {}
+
+  @override
+  Future<void> release() async {}
+
+  @override
+  Future<void> resume() async {}
+
+  @override
+  Future<void> seek(Duration position) async {}
+}

--- a/examples/wamp_app/client/test/test_support.dart
+++ b/examples/wamp_app/client/test/test_support.dart
@@ -54,6 +54,7 @@ final class FakeDeviceTrustStore implements DeviceTrustStore {
       previous?.mailboxCursor ?? 0,
       previous?.preferences ?? initialPreferences,
       initialContacts: previous?.contacts ?? initialContacts,
+      initialVerifications: previous?._verifications,
     );
   }
 
@@ -82,6 +83,7 @@ final class FakeDeviceTrustSession implements DeviceTrustSession {
     this._mailboxCursor,
     this._preferences, {
     List<LocalContactAlias> initialContacts = const [],
+    Map<String, String>? initialVerifications,
     this.sealCallSignalCallback,
     this.openCallSignalCallback,
   }) {
@@ -89,6 +91,9 @@ final class FakeDeviceTrustSession implements DeviceTrustSession {
     _groups.addAll(initialGroups);
     _outbox.addAll(initialOutbox);
     _contacts.addAll(initialContacts);
+    if (initialVerifications != null) {
+      _verifications.addAll(initialVerifications);
+    }
   }
 
   final String username;
@@ -98,6 +103,7 @@ final class FakeDeviceTrustSession implements DeviceTrustSession {
   final List<LocalChatGroup> _groups = [];
   final List<OutboundChatMessage> _outbox = [];
   final List<LocalContactAlias> _contacts = [];
+  final Map<String, String> _verifications = {};
   LocalAppPreferences _preferences;
   Object? saveContactsFailure;
   Completer<void>? saveContactsGate;
@@ -166,13 +172,30 @@ final class FakeDeviceTrustSession implements DeviceTrustSession {
   }
 
   @override
-  bool isVerified(DeviceRecord contact) => false;
+  bool hasVerifiedContact(String username) {
+    final normalized = AccountRegistration.normalizeUsername(username);
+    return _verifications.keys.any((key) => key.startsWith('$normalized:'));
+  }
 
   @override
-  Future<void> markVerified(DeviceRecord contact) async {}
+  bool isVerified(DeviceRecord contact) =>
+      !contact.isRevoked &&
+      _verifications['${contact.username}:${contact.deviceId}'] ==
+          safetyNumberFor(contact);
 
   @override
-  String safetyNumberFor(DeviceRecord contact) => safetyNumber;
+  Future<void> markVerified(DeviceRecord contact) async {
+    if (contact.isRevoked) {
+      throw const FormatException('Cannot verify a revoked device.');
+    }
+    _verifications['${contact.username}:${contact.deviceId}'] = safetyNumberFor(
+      contact,
+    );
+  }
+
+  @override
+  String safetyNumberFor(DeviceRecord contact) =>
+      '$safetyNumber ${contact.username} ${contact.deviceId}';
 
   @override
   WrappedConversationKey wrapConversationKey({

--- a/examples/wamp_app/client/test/wamp_account_gateway_test.dart
+++ b/examples/wamp_app/client/test/wamp_account_gateway_test.dart
@@ -126,6 +126,28 @@ void main() {
     );
   });
 
+  test('classifies MCP discovery failures without exposing credentials', () {
+    McpAccessException classified(String? uri) =>
+        McpAccessException.fromWampError(wamp.Error(48, 1, const {}, uri));
+
+    expect(
+      classified(WampAppProtocol.errorInvalidMcpAccess).kind,
+      McpAccessFailureKind.rejected,
+    );
+    expect(
+      classified(wamp.Error.notAuthorized).kind,
+      McpAccessFailureKind.rejected,
+    );
+    expect(
+      classified(WampAppProtocol.errorMcpUnavailable).kind,
+      McpAccessFailureKind.unavailable,
+    );
+    expect(
+      classified('com.example.unknown').toString(),
+      'This server does not expose a usable WampApp MCP endpoint.',
+    );
+  });
+
   test('classifies platform push failures without exposing tokens', () {
     PlatformPushSubscriptionException classified(String? uri) =>
         PlatformPushSubscriptionException.fromWampError(

--- a/examples/wamp_app/client/test/wamp_app_controller_test.dart
+++ b/examples/wamp_app/client/test/wamp_app_controller_test.dart
@@ -44,6 +44,118 @@ void main() {
     expect(controller.localDevice?.deviceId, trustStore.session?.deviceId);
   });
 
+  test('inspects and verifies every active peer device explicitly', () async {
+    final gateway = _RecordingGateway();
+    final trustStore = FakeDeviceTrustStore();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: trustStore,
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'ws://localhost:8080',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(20, 'Bob phone')),
+    ];
+
+    final initial = await controller.inspectPeerTrust(' Bob ');
+
+    expect(initial, isNotNull);
+    expect(initial!.username, 'bob');
+    expect(initial.status, PeerTrustStatus.unverified);
+    expect(initial.previouslyVerified, isFalse);
+    expect(initial.devices.single.verified, isFalse);
+    expect(initial.devices.single.safetyNumber, isNotEmpty);
+
+    final verified = await controller.verifyPeerDevice(initial.devices.single);
+
+    expect(verified, isNotNull);
+    expect(verified!.status, PeerTrustStatus.verified);
+    expect(verified.previouslyVerified, isTrue);
+    expect(verified.devices.single.verified, isTrue);
+  });
+
+  test(
+    'verified peer replacement blocks direct sends before encryption',
+    () async {
+      final gateway = _RecordingGateway();
+      final trustStore = FakeDeviceTrustStore();
+      final controller = WampAppController(
+        gateway: gateway,
+        trustStore: trustStore,
+      );
+      addTearDown(controller.dispose);
+      await controller.login(
+        serverAddress: 'ws://localhost:8080',
+        username: 'alice',
+        password: 'correct horse battery',
+      );
+      gateway.deviceDirectories['bob'] = [
+        activeDeviceRecord('bob', _deviceEnrollment(30, 'Bob old phone')),
+      ];
+      final initial = await controller.inspectPeerTrust('bob');
+      await controller.verifyPeerDevice(initial!.devices.single);
+      gateway.deviceDirectories['bob'] = [
+        activeDeviceRecord('bob', _deviceEnrollment(40, 'Bob new phone')),
+      ];
+
+      final changed = await controller.inspectPeerTrust('bob');
+      expect(changed!.status, PeerTrustStatus.changed);
+      expect(
+        await controller.sendMessage(
+          recipientUsername: 'bob',
+          text: 'must not reach an unreviewed replacement',
+        ),
+        isFalse,
+      );
+
+      expect(gateway.sentMessages, isEmpty);
+      expect(controller.messages, isEmpty);
+      expect(
+        controller.messageError,
+        'Encryption identity changed for @bob. Review and verify every active '
+        'device before sending.',
+      );
+    },
+  );
+
+  test('stale peer verification cannot approve a replacement device', () async {
+    final gateway = _RecordingGateway();
+    final trustStore = FakeDeviceTrustStore();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: trustStore,
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'ws://localhost:8080',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(50, 'Bob old phone')),
+    ];
+    final stale = await controller.inspectPeerTrust('bob');
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(60, 'Bob new phone')),
+    ];
+
+    await expectLater(
+      controller.verifyPeerDevice(stale!.devices.single),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          'That device identity changed before verification completed.',
+        ),
+      ),
+    );
+    expect(trustStore.session!.hasVerifiedContact('bob'), isFalse);
+  });
+
   test(
     'remote cleartext endpoints fail before credentials reach a gateway',
     () async {
@@ -2067,6 +2179,48 @@ void main() {
     expect(controller.messageError, isNull);
   });
 
+  test('verified member replacement blocks an atomic group send', () async {
+    final gateway = _RecordingGateway();
+    final trustStore = FakeDeviceTrustStore();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: trustStore,
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'ws://localhost:8080',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(70, 'Bob old phone')),
+    ];
+    gateway.deviceDirectories['carol'] = [
+      activeDeviceRecord('carol', _deviceEnrollment(80, 'Carol phone')),
+    ];
+    final group = await controller.createGroup(
+      title: 'Verified group',
+      memberUsernames: const ['bob', 'carol'],
+    );
+    final bobTrust = await controller.inspectPeerTrust('bob');
+    await controller.verifyPeerDevice(bobTrust!.devices.single);
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(90, 'Bob new phone')),
+    ];
+
+    expect(
+      await controller.sendGroupMessage(
+        groupId: group!.conversationId,
+        text: 'must not partially send',
+      ),
+      isFalse,
+    );
+
+    expect(gateway.sentMessages, isEmpty);
+    expect(controller.messages, isEmpty);
+    expect(controller.messageError, contains('@bob'));
+  });
+
   test('uploads group attachments before the atomic group envelope', () async {
     final gateway = _OutboxGateway();
     final trustStore = FakeDeviceTrustStore();
@@ -2129,6 +2283,23 @@ AccountProfile _profileFor(String username) => AccountProfile(
   revision: 0,
   updatedAt: DateTime.utc(2026, 8, 24),
 );
+
+DeviceEnrollment _deviceEnrollment(int seed, String deviceName) {
+  String token(int bytes, int offset) => base64Url
+      .encode(
+        List<int>.generate(bytes, (index) => (seed + offset + index) & 0xff),
+      )
+      .replaceAll('=', '');
+
+  return DeviceEnrollment(
+    deviceId: token(32, 1),
+    deviceName: deviceName,
+    signingPublicKey: token(32, 2),
+    exchangePublicKey: token(32, 3),
+    attestation: token(64, 4),
+    createdAt: DateTime.utc(2026, 8, 24, 12),
+  );
+}
 
 class _RecordingGateway implements AccountGateway {
   _RecordingGateway({List<String>? operations})

--- a/examples/wamp_app/client/test/wamp_app_controller_test.dart
+++ b/examples/wamp_app/client/test/wamp_app_controller_test.dart
@@ -962,6 +962,60 @@ void main() {
   });
 
   test(
+    'MCP access discovery resolves server paths on the WAMP origin',
+    () async {
+      final gateway = _RecordingGateway();
+      final controller = WampAppController(
+        gateway: gateway,
+        trustStore: FakeDeviceTrustStore(),
+      );
+      addTearDown(controller.dispose);
+      await controller.login(
+        serverAddress: 'wss://chat.example:9443/ws',
+        username: 'alice',
+        password: 'correct horse battery',
+      );
+
+      final access = await controller.loadMcpAccessConfiguration();
+
+      expect(access, isNotNull);
+      expect(
+        access!.mcpUriFor(controller.connection!.endpoint),
+        Uri.parse('https://chat.example:9443/mcp'),
+      );
+      expect(gateway.mcpAccessRequests, 1);
+      expect(controller.mcpAccessBusy, isFalse);
+      expect(controller.mcpAccessError, isNull);
+    },
+  );
+
+  test('late MCP access discovery cannot cross a signed-out session', () async {
+    final gateway = _RecordingGateway();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: FakeDeviceTrustStore(),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'ws://localhost:8080',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    final gate = gateway.mcpAccessGate =
+        Completer<WampAppMcpAccessConfiguration>();
+
+    final pending = controller.loadMcpAccessConfiguration();
+    await _waitFor(() => controller.mcpAccessBusy);
+    await controller.signOut();
+    gate.complete(gateway.mcpAccessConfiguration);
+
+    expect(await pending, isNull);
+    expect(controller.mcpAccessBusy, isFalse);
+    expect(controller.mcpAccessError, isNull);
+    expect(controller.status, WampAppStatus.signedOut);
+  });
+
+  test(
     'replacement stays connected when closing the old transport fails',
     () async {
       final gateway = _RecordingGateway();
@@ -2091,6 +2145,14 @@ class _RecordingGateway implements AccountGateway {
   AccountProfile? profileLookupOverride;
   final List<String> profileLookups = [];
   WampAppMcpConsent mcpConsent = WampAppMcpConsent.denied;
+  WampAppMcpAccessConfiguration mcpAccessConfiguration =
+      WampAppMcpAccessConfiguration.standard(
+        mcpPath: '/mcp',
+        authPath: '/mcp/auth',
+      );
+  Completer<WampAppMcpAccessConfiguration>? mcpAccessGate;
+  Object? mcpAccessFailure;
+  int mcpAccessRequests = 0;
   Object? nextMcpConsentFailure;
   final List<bool> mcpConsentUpdates = [];
   final List<_GatewayConnection> connections = [];
@@ -2147,6 +2209,12 @@ class _RecordingGateway implements AccountGateway {
       username: normalizedUsername,
       initialProfile: _profileFor(normalizedUsername),
       initialMcpConsent: mcpConsent,
+      getMcpAccessConfigurationCallback: () async {
+        mcpAccessRequests += 1;
+        final failure = mcpAccessFailure;
+        if (failure != null) throw failure;
+        return mcpAccessGate?.future ?? mcpAccessConfiguration;
+      },
       getProfileCallback: (username) async {
         final normalized = AccountRegistration.normalizeUsername(username);
         profileLookups.add(normalized);

--- a/examples/wamp_app/client/test/wamp_app_controller_test.dart
+++ b/examples/wamp_app/client/test/wamp_app_controller_test.dart
@@ -20,6 +20,26 @@ import 'package:wamp_app_protocol/wamp_app_protocol.dart';
 import 'test_support.dart';
 
 void main() {
+  test('server probe validates the endpoint before delegating', () async {
+    final gateway = _RecordingGateway();
+    final controller = WampAppController(gateway: gateway);
+    addTearDown(controller.dispose);
+
+    await controller.probeServer(serverAddress: 'ws://localhost:8080');
+
+    expect(gateway.probedEndpoints, hasLength(1));
+    expect(
+      gateway.probedEndpoints.single.websocketUri.toString(),
+      'ws://localhost:8080/ws',
+    );
+
+    await expectLater(
+      controller.probeServer(serverAddress: 'ws://router.example/ws'),
+      throwsA(isA<FormatException>()),
+    );
+    expect(gateway.probedEndpoints, hasLength(1));
+  });
+
   test('registration normalizes identity and connects with the same challenge secret', () async {
     final gateway = _RecordingGateway();
     final trustStore = FakeDeviceTrustStore();
@@ -2336,6 +2356,7 @@ class _RecordingGateway implements AccountGateway {
   final List<Uint8List> backupChunks = [];
   BackupMetadata? remoteMetadata;
   Uint8List? remoteBackup;
+  final List<ServerEndpoint> probedEndpoints = [];
 
   void seedRemoteBackup(Uint8List archive) {
     remoteBackup = Uint8List.fromList(archive);
@@ -2348,6 +2369,11 @@ class _RecordingGateway implements AccountGateway {
       sha256: sha256.convert(archive).toString(),
       updatedAt: DateTime.utc(2026, 8, 25),
     );
+  }
+
+  @override
+  Future<void> probe({required ServerEndpoint endpoint}) async {
+    probedEndpoints.add(endpoint);
   }
 
   @override
@@ -2602,6 +2628,9 @@ final class _OutboxGateway implements AccountGateway {
   final List<OneTimeMessageConsumption> consumeAttempts = [];
   final List<String> operations = [];
   int? failAfterStoredChunkIndex;
+
+  @override
+  Future<void> probe({required ServerEndpoint endpoint}) async {}
 
   Completer<MessageSendReceipt> blockNextSend() =>
       _sendGate = Completer<MessageSendReceipt>();

--- a/examples/wamp_app/client/test/wamp_app_controller_test.dart
+++ b/examples/wamp_app/client/test/wamp_app_controller_test.dart
@@ -86,6 +86,36 @@ void main() {
     expect(trustStore.session?.disposed, isTrue);
   });
 
+  test('concurrent sign out calls join the same cleanup', () async {
+    final gateway = _RecordingGateway()..closeGate = Completer<void>();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: FakeDeviceTrustStore(),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'ws://localhost:8080',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+
+    final first = controller.signOut();
+    await _waitFor(() => gateway.operations.contains('transport-close'));
+    var secondCompleted = false;
+    final second = controller.signOut().then((_) => secondCompleted = true);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(secondCompleted, isFalse);
+    expect(
+      gateway.operations.where((entry) => entry == 'transport-close'),
+      hasLength(1),
+    );
+
+    gateway.closeGate!.complete();
+    await Future.wait([first, second]);
+    expect(secondCompleted, isTrue);
+  });
+
   test(
     'local backup export saves an encrypted snapshot and clears busy state',
     () async {
@@ -1844,6 +1874,7 @@ class _RecordingGateway implements AccountGateway {
   String? loginPassword;
   bool closed = false;
   bool failNextClose = false;
+  Completer<void>? closeGate;
   Object? loginFailure;
   Completer<AccountProfile>? profileUpdateGate;
   Completer<AccountProfile>? profileLookupGate;
@@ -2045,6 +2076,7 @@ class _RecordingGateway implements AccountGateway {
       latestMailboxWakeupErrorCallback: () => null,
       closeTransport: () async {
         operations.add('transport-close');
+        await closeGate?.future;
         closed = true;
         if (failNextClose) {
           failNextClose = false;

--- a/examples/wamp_app/client/test/wamp_app_controller_test.dart
+++ b/examples/wamp_app/client/test/wamp_app_controller_test.dart
@@ -424,6 +424,13 @@ void main() {
       );
       expect(await controller.setConversationMuted(directId, true), isTrue);
       expect(
+        await controller.setConversationAppearance(
+          directId,
+          WampAppConversationAppearance.ocean,
+        ),
+        isTrue,
+      );
+      expect(
         await controller.setConversationDisappearingMessages(
           directId,
           const Duration(days: 1),
@@ -433,6 +440,10 @@ void main() {
       expect(controller.themePreference, WampAppThemePreference.dark);
       expect(controller.isConversationMuted(directId), isTrue);
       expect(
+        controller.conversationAppearanceFor(directId),
+        WampAppConversationAppearance.ocean,
+      );
+      expect(
         controller.disappearingMessagesFor(directId),
         const Duration(days: 1),
       );
@@ -440,6 +451,10 @@ void main() {
       await controller.signOut();
       expect(controller.themePreference, WampAppThemePreference.system);
       expect(controller.isConversationMuted(directId), isFalse);
+      expect(
+        controller.conversationAppearanceFor(directId),
+        WampAppConversationAppearance.standard,
+      );
       expect(controller.disappearingMessagesFor(directId), isNull);
 
       await controller.login(
@@ -449,6 +464,10 @@ void main() {
       );
       expect(controller.themePreference, WampAppThemePreference.dark);
       expect(controller.isConversationMuted(directId), isTrue);
+      expect(
+        controller.conversationAppearanceFor(directId),
+        WampAppConversationAppearance.ocean,
+      );
       expect(
         controller.disappearingMessagesFor(directId),
         const Duration(days: 1),
@@ -487,6 +506,17 @@ void main() {
       isFalse,
     );
     expect(controller.disappearingMessagesFor(directId), isNull);
+    expect(
+      await controller.setConversationAppearance(
+        directId,
+        WampAppConversationAppearance.ocean,
+      ),
+      isFalse,
+    );
+    expect(
+      controller.conversationAppearanceFor(directId),
+      WampAppConversationAppearance.standard,
+    );
 
     session.savePreferencesFailure = null;
     final gate = session.savePreferencesGate = Completer<void>();

--- a/examples/wamp_app/client/test/wamp_app_controller_test.dart
+++ b/examples/wamp_app/client/test/wamp_app_controller_test.dart
@@ -12,6 +12,7 @@ import 'package:wamp_app/src/domain/outbound_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/attachment_chunk_cache.dart';
 import 'package:wamp_app/src/infrastructure/attachment_cipher.dart';
 import 'package:wamp_app/src/infrastructure/device_vault.dart';
+import 'package:wamp_app/src/infrastructure/message_cipher.dart';
 import 'package:wamp_app/src/infrastructure/platform_push_token_source.dart';
 import 'package:wamp_app/src/infrastructure/wamp_account_gateway.dart';
 import 'package:wamp_app_protocol/wamp_app_protocol.dart';
@@ -1568,6 +1569,185 @@ void main() {
     },
   );
 
+  test(
+    'view-once attachments prefetch before consume and close invalidates cache',
+    () async {
+      const messageId = 'view-once-attachment-message';
+      final plaintext = Uint8List.fromList(
+        List<int>.generate(65537, (index) => (index * 23) % 251),
+      );
+      final producerCache = MemoryAttachmentChunkCache();
+      final consumerCache = MemoryAttachmentChunkCache();
+      final attachmentCipher = AttachmentCipher();
+      addTearDown(producerCache.dispose);
+      addTearDown(consumerCache.dispose);
+      addTearDown(attachmentCipher.dispose);
+      final descriptor = (await attachmentCipher.encryptSources(
+        scope: 'producer',
+        senderUsername: 'alice',
+        messageId: messageId,
+        sources: [
+          AttachmentPlaintextSource(
+            name: 'view-once.bin',
+            contentType: 'application/octet-stream',
+            kind: ChatAttachmentKind.file,
+            byteCount: plaintext.length,
+            openRead: () => Stream.value(plaintext),
+          ),
+        ],
+        cache: producerCache,
+      )).single;
+      final gateway = _OutboxGateway();
+      for (var index = 0; index < descriptor.chunkCount; index += 1) {
+        final chunk = (await producerCache.get(
+          scope: 'producer',
+          senderUsername: 'alice',
+          messageId: messageId,
+          attachmentId: descriptor.attachmentId,
+          chunkIndex: index,
+          chunkCount: descriptor.chunkCount,
+        ))!;
+        gateway.attachmentChunks[gateway._attachmentKey(
+              messageId,
+              descriptor.attachmentId,
+              index,
+            )] =
+            chunk;
+      }
+      final aliceTrust = FakeDeviceTrustSession(
+        'alice',
+        const [],
+        const [],
+        const [],
+        0,
+        LocalAppPreferences.defaults,
+      );
+      final envelope = MessageCipher().encrypt(
+        senderUsername: 'alice',
+        recipientUsername: 'bob',
+        text: 'Open this attachment once.',
+        trust: aliceTrust,
+        participantDevices: [
+          activeDeviceRecord('alice', aliceTrust.enrollment),
+          activeDeviceRecord('bob', aliceTrust.enrollment),
+        ],
+        now: DateTime.utc(2026, 8, 25, 12),
+        oneTime: true,
+        messageId: messageId,
+        attachments: [descriptor],
+      );
+      gateway.store(envelope, deliveredTo: 'bob');
+      final controller = WampAppController(
+        gateway: gateway,
+        trustStore: FakeDeviceTrustStore(
+          initialMessages: [
+            LocalChatMessage(
+              messageId: messageId,
+              conversationId: envelope.conversationId,
+              peerUsername: 'alice',
+              text: 'Open this attachment once.',
+              sentAt: envelope.createdAt,
+              outgoing: false,
+              oneTime: true,
+              attachments: [descriptor],
+            ),
+          ],
+        ),
+        attachmentCache: consumerCache,
+      );
+      addTearDown(controller.dispose);
+      await controller.login(
+        serverAddress: 'ws://localhost:8080',
+        username: 'bob',
+        password: 'correct horse battery',
+      );
+
+      final opened = await controller.consumeOneTimeMessage(messageId);
+
+      expect(opened?.text, 'Open this attachment once.');
+      expect(opened?.attachments, [descriptor]);
+      expect(gateway.consumeAttempts, hasLength(1));
+      expect(gateway.attachmentChunks, isEmpty);
+      expect(
+        gateway.attachmentGetAttempts,
+        List<int>.generate(descriptor.chunkCount, (index) => index),
+      );
+      expect(controller.messages, isEmpty);
+      final bytes = await controller.loadOpenedOneTimeAttachment(
+        message: opened!,
+        attachmentId: descriptor.attachmentId,
+      );
+      expect(bytes, plaintext);
+      bytes!.fillRange(0, bytes.length, 0);
+      expect(gateway.attachmentGetAttempts, hasLength(descriptor.chunkCount));
+
+      await controller.closeOpenedOneTimeMessage(opened);
+
+      expect(opened.attachments, isEmpty);
+      expect(
+        await controller.loadOpenedOneTimeAttachment(
+          message: opened,
+          attachmentId: descriptor.attachmentId,
+        ),
+        isNull,
+      );
+      expect(
+        await consumerCache.get(
+          scope: attachmentCacheScope(controller.connection!.endpoint, 'bob'),
+          senderUsername: 'alice',
+          messageId: messageId,
+          attachmentId: descriptor.attachmentId,
+          chunkIndex: 0,
+          chunkCount: descriptor.chunkCount,
+        ),
+        isNull,
+      );
+    },
+  );
+
+  test('view-once attachment prefetch failure does not consume', () async {
+    const messageId = 'incomplete-view-once-attachment';
+    final descriptor = EncryptedAttachmentDescriptor(
+      attachmentId: 'incomplete-view-once-attachment-id',
+      name: 'missing.bin',
+      contentType: 'application/octet-stream',
+      kind: ChatAttachmentKind.file,
+      plaintextBytes: 1,
+      plaintextSha256: sha256.convert(const [1]).toString(),
+      chunkBytes: 1,
+      chunkCount: 1,
+      key: Uint8List(32),
+    );
+    final gateway = _OutboxGateway();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: FakeDeviceTrustStore(
+        initialMessages: [
+          LocalChatMessage(
+            messageId: messageId,
+            conversationId: 'alice-bob',
+            peerUsername: 'alice',
+            text: '',
+            sentAt: DateTime.utc(2026, 8, 25, 12),
+            outgoing: false,
+            oneTime: true,
+            attachments: [descriptor],
+          ),
+        ],
+      ),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'ws://localhost:8080',
+      username: 'bob',
+      password: 'correct horse battery',
+    );
+
+    expect(await controller.consumeOneTimeMessage(messageId), isNull);
+    expect(gateway.consumeAttempts, isEmpty);
+    expect(controller.messages.single.messageId, messageId);
+  });
+
   test('message conflicts are terminal until explicitly discarded', () async {
     final gateway = _OutboxGateway()
       ..nextFailureKind = MessageSendFailureKind.conflict;
@@ -2180,19 +2360,27 @@ final class _OutboxGateway implements AccountGateway {
   final Map<String, EncryptedAttachmentChunk> attachmentChunks = {};
   final List<int> attachmentPutAttempts = [];
   final List<int> attachmentGetAttempts = [];
+  final List<OneTimeMessageConsumption> consumeAttempts = [];
   final List<String> operations = [];
   int? failAfterStoredChunkIndex;
 
   Completer<MessageSendReceipt> blockNextSend() =>
       _sendGate = Completer<MessageSendReceipt>();
 
-  void store(EncryptedChatMessage message) {
+  void store(EncryptedChatMessage message, {String? deliveredTo}) {
     _cursor += 1;
     _mailbox.add(
       MailboxMessage(
         cursor: _cursor,
         message: message,
         acceptedAt: DateTime.utc(2026, 8, 25, 12, _cursor),
+        recipientStates: deliveredTo == null
+            ? const {}
+            : {
+                deliveredTo: MailboxRecipientState(
+                  deliveredAt: DateTime.utc(2026, 8, 25, 12, _cursor),
+                ),
+              },
       ),
     );
   }
@@ -2250,7 +2438,7 @@ final class _OutboxGateway implements AccountGateway {
         return MailboxBatch(nextCursor: _cursor, messages: messages);
       },
       markMessageReceiptCallback: (_, _) => throw UnimplementedError(),
-      consumeOneTimeCallback: (_) => throw UnimplementedError(),
+      consumeOneTimeCallback: _consumeOneTime,
       mailboxWakeups: const Stream<MailboxWakeup>.empty(),
       latestMailboxWakeupCursorCallback: () => 0,
       latestMailboxWakeupErrorCallback: () => null,
@@ -2383,6 +2571,58 @@ final class _OutboxGateway implements AccountGateway {
       );
     }
     return chunk;
+  }
+
+  Future<MessageReceipt> _consumeOneTime(
+    OneTimeMessageConsumption consumption,
+  ) async {
+    consumeAttempts.add(consumption);
+    final existing = _mailbox.reversed
+        .where((stored) => stored.message.messageId == consumption.messageId)
+        .firstOrNull;
+    if (existing == null) throw StateError('Message was not found.');
+    final recipient = existing.message.recipientUsername!;
+    final current = existing.recipientStateFor(recipient);
+    if (current?.consumedAt != null) {
+      if (current?.consumedByDeviceId != consumption.deviceId) {
+        throw StateError('Message was consumed by another device.');
+      }
+      return MessageReceipt(
+        messageId: consumption.messageId,
+        cursor: existing.cursor,
+        deliveredAt: current?.deliveredAt,
+        readAt: current?.readAt,
+        consumedAt: current?.consumedAt,
+      );
+    }
+    final consumedAt = DateTime.utc(2026, 8, 25, 12, 30);
+    final states = Map<String, MailboxRecipientState>.of(
+      existing.recipientStates,
+    );
+    states[recipient] = MailboxRecipientState(
+      deliveredAt: current?.deliveredAt ?? consumedAt,
+      readAt: consumedAt,
+      consumedAt: consumedAt,
+      consumedByDeviceId: consumption.deviceId,
+    );
+    _cursor += 1;
+    final updated = MailboxMessage(
+      cursor: _cursor,
+      message: existing.message,
+      acceptedAt: existing.acceptedAt,
+      recipientStates: states,
+    );
+    _mailbox.add(updated);
+    attachmentChunks.removeWhere(
+      (key, _) => key.startsWith('${consumption.messageId}\n'),
+    );
+    return MessageReceipt(
+      messageId: consumption.messageId,
+      cursor: updated.cursor,
+      deliveredAt: consumedAt,
+      readAt: consumedAt,
+      consumedAt: consumedAt,
+    );
   }
 
   String _attachmentKey(

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -11,6 +11,7 @@ import 'package:wamp_app/src/domain/local_chat_group.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app/src/domain/outbound_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/contact_importer_contract.dart';
+import 'package:wamp_app/src/infrastructure/profile_avatar_picker.dart';
 import 'package:wamp_app/src/infrastructure/wamp_account_gateway.dart';
 import 'package:wamp_app/src/infrastructure/voice_note_recorder.dart';
 import 'package:wamp_app/src/ui/expression_picker.dart';
@@ -246,8 +247,12 @@ void main() {
   testWidgets('edits the public profile and views a recipient profile', (
     tester,
   ) async {
+    final avatarBytes = _testAvatarBytes();
+    final avatarPicker = _FakeProfileAvatarPicker(
+      selection: ProfileAvatarSelection(name: 'avatar.png', bytes: avatarBytes),
+    );
     final controller = WampAppController(
-      gateway: _FakeGateway(),
+      gateway: _FakeGateway(peerAvatarBytes: avatarBytes),
       trustStore: FakeDeviceTrustStore(),
     );
     addTearDown(controller.dispose);
@@ -256,11 +261,23 @@ void main() {
       username: 'alice',
       password: 'correct horse battery',
     );
-    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpWidget(
+      WampApp(controller: controller, profileAvatarPicker: avatarPicker),
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const Key('account-profile-edit')));
     await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('profile-avatar-pick')));
+    await tester.pumpAndSettle();
+    expect(avatarPicker.calls, 1);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('profile-avatar-preview')),
+        matching: find.byType(Image),
+      ),
+      findsOneWidget,
+    );
     await tester.enterText(
       find.byKey(const Key('profile-display-name')),
       'Alice Updated',
@@ -275,6 +292,17 @@ void main() {
     expect(find.text('Alice Updated'), findsOneWidget);
     expect(find.byKey(const Key('account-profile-status')), findsOneWidget);
     expect(find.text('Shipping safely'), findsOneWidget);
+    expect(
+      controller.connection?.profile.avatarBytes,
+      orderedEquals(avatarBytes),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('account-profile-avatar')),
+        matching: find.byType(Image),
+      ),
+      findsOneWidget,
+    );
 
     await tester.enterText(find.byKey(const Key('message-recipient')), 'bob');
     await tester.tap(find.byKey(const Key('recipient-profile-view')));
@@ -284,6 +312,53 @@ void main() {
     expect(find.text('Bob Example'), findsOneWidget);
     expect(find.byKey(const Key('peer-profile-status')), findsOneWidget);
     expect(find.text('Testing WampApp'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('peer-profile-avatar')),
+        matching: find.byType(Image),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('keeps profile picker failures inside the editor', (
+    tester,
+  ) async {
+    final controller = WampAppController(
+      gateway: _FakeGateway(),
+      trustStore: FakeDeviceTrustStore(),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'wss://localhost/ws',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    await tester.pumpWidget(
+      WampApp(
+        controller: controller,
+        profileAvatarPicker: _FakeProfileAvatarPicker(
+          error: const ProfileAvatarPickerException(
+            'The selected profile image could not be read.',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('account-profile-edit')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('profile-avatar-pick')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('profile-validation-error')), findsOneWidget);
+    expect(
+      find.text('The selected profile image could not be read.'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('profile-save')), findsOneWidget);
+    expect(controller.connection?.profile.avatarBytes, isNull);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('imports, verifies, selects, renames, and removes a contact', (
@@ -1264,6 +1339,9 @@ Future<void> _pumpUntilFound(
 }
 
 class _FakeGateway implements AccountGateway {
+  _FakeGateway({this.peerAvatarBytes});
+
+  final Uint8List? peerAvatarBytes;
   int sendAttempts = 0;
   final Map<String, List<DeviceRecord>> deviceDirectories = {};
   bool mcpProfileReadAllowed = false;
@@ -1311,6 +1389,8 @@ class _FakeGateway implements AccountGateway {
                 status: 'Testing WampApp',
                 revision: 2,
                 updatedAt: DateTime.utc(2026, 8, 25),
+                avatarBytes: peerAvatarBytes,
+                avatarContentType: peerAvatarBytes == null ? null : 'image/png',
               );
       },
       updateProfileCallback: (update) async {
@@ -1385,6 +1465,26 @@ final class _FakeContactImporter implements ContactImporter {
     return candidates;
   }
 }
+
+final class _FakeProfileAvatarPicker implements ProfileAvatarPicker {
+  _FakeProfileAvatarPicker({this.selection, this.error});
+
+  final ProfileAvatarSelection? selection;
+  final Object? error;
+  int calls = 0;
+
+  @override
+  Future<ProfileAvatarSelection?> pickAvatar() async {
+    calls += 1;
+    if (error case final error?) throw error;
+    return selection;
+  }
+}
+
+Uint8List _testAvatarBytes() => base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC'
+  'AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+);
 
 class _FailingGateway extends _FakeGateway {
   @override

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -129,6 +129,85 @@ void main() {
     expect(find.text('Delete after 1 day'), findsOneWidget);
   });
 
+  testWidgets('group dialog owns controllers through its dismissal animation', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1200, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final controller = WampAppController(
+      gateway: _FakeGateway(),
+      trustStore: FakeDeviceTrustStore(),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'wss://localhost/ws',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('conversation-create-group')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('group-title')), 'Launch crew');
+    await tester.enterText(find.byKey(const Key('group-members')), 'bob');
+    await tester.tap(find.byKey(const Key('group-create')));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('preserves a new draft while the previous send completes', (
+    tester,
+  ) async {
+    final gateway = _FakeGateway();
+    final trustStore = FakeDeviceTrustStore();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: trustStore,
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'wss://localhost/ws',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    final enrollment = trustStore.session!.enrollment;
+    gateway.deviceDirectories['alice'] = [
+      activeDeviceRecord('alice', enrollment),
+    ];
+    gateway.deviceDirectories['bob'] = [activeDeviceRecord('bob', enrollment)];
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('message-recipient')), 'bob');
+    final composer = find.byKey(const Key('message-composer'));
+    await tester.enterText(composer, 'first draft');
+    final composerController = tester.widget<TextField>(composer).controller!;
+    var replacedDraft = false;
+    void replaceDraftOnIdle() {
+      if (replacedDraft ||
+          gateway.sendAttempts == 0 ||
+          controller.messageBusy) {
+        return;
+      }
+      replacedDraft = true;
+      composerController.text = 'next draft';
+    }
+
+    controller.addListener(replaceDraftOnIdle);
+    addTearDown(() => controller.removeListener(replaceDraftOnIdle));
+    await tester.tap(find.byKey(const Key('message-send')));
+    await tester.pumpAndSettle();
+
+    expect(replacedDraft, isTrue);
+    expect(composerController.text, 'next draft');
+    expect(gateway.sendAttempts, 1);
+  });
+
   testWidgets('direct call actions fail closed with a recoverable result', (
     tester,
   ) async {
@@ -832,6 +911,48 @@ void main() {
     expect(tester.widget<FilterChip>(oneTime).selected, isFalse);
   });
 
+  testWidgets('keeps a staged sticker usable on a compact phone', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final controller = WampAppController(
+      gateway: _FakeGateway(),
+      trustStore: FakeDeviceTrustStore(),
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'wss://localhost/ws',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HomePage(
+          controller: controller,
+          connection: controller.connection!,
+          stickerRenderer: _FakeStickerRenderer(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('message-expression')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('expression-sticker-tab')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('sticker-nice')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('selected-attachment-0')), findsOneWidget);
+    expect(find.byKey(const Key('message-global-search')), findsNothing);
+    expect(find.byKey(const Key('message-send')).hitTestable(), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('rejects a sticker beyond the attachment cap', (tester) async {
     final renderer = _FakeStickerRenderer();
     final controller = WampAppController(
@@ -1094,6 +1215,7 @@ void main() {
 
 class _FakeGateway implements AccountGateway {
   int sendAttempts = 0;
+  final Map<String, List<DeviceRecord>> deviceDirectories = {};
   bool mcpProfileReadAllowed = false;
   int mcpConsentRevision = 0;
   final List<bool> mcpConsentUpdates = [];
@@ -1177,8 +1299,10 @@ class _FakeGateway implements AccountGateway {
       },
       enrollDeviceCallback: (enrollment) async =>
           activeDeviceRecord(username, enrollment),
-      listDevicesCallback: (_) async => DeviceDirectory(const []),
-      lookupDevicesCallback: (_, _) async => DeviceDirectory(const []),
+      listDevicesCallback: (_) async =>
+          DeviceDirectory(deviceDirectories[username] ?? const []),
+      lookupDevicesCallback: (lookup, _) async =>
+          DeviceDirectory(deviceDirectories[lookup] ?? const []),
       revokeDeviceCallback: (_) => throw UnimplementedError(),
       sendMessageCallback: (_) async {
         sendAttempts += 1;

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -973,8 +973,9 @@ void main() {
     final expression = find.byKey(const Key('message-expression'));
     await tester.ensureVisible(expression);
     await tester.tap(expression);
-    await tester.pumpAndSettle();
     final stickerTab = find.byKey(const Key('expression-sticker-tab'));
+    await _pumpUntilFound(tester, stickerTab);
+    await tester.pumpAndSettle();
     expect(stickerTab.hitTestable(), findsOneWidget);
     await tester.tap(stickerTab);
     await tester.pumpAndSettle();
@@ -1247,6 +1248,19 @@ void main() {
     expect(find.text('persisted retry'), findsNothing);
     expect(find.byKey(const Key('message-history')), findsNothing);
   });
+}
+
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  const step = Duration(milliseconds: 50);
+  var elapsed = Duration.zero;
+  while (finder.evaluate().isEmpty && elapsed < timeout) {
+    await tester.pump(step);
+    elapsed += step;
+  }
 }
 
 class _FakeGateway implements AccountGateway {

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -381,6 +381,62 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('verifies peer devices and warns on identity replacement', (
+    tester,
+  ) async {
+    final gateway = _FakeGateway();
+    final trustStore = FakeDeviceTrustStore();
+    final controller = WampAppController(
+      gateway: gateway,
+      trustStore: trustStore,
+    );
+    addTearDown(controller.dispose);
+    await controller.login(
+      serverAddress: 'wss://localhost/ws',
+      username: 'alice',
+      password: 'correct horse battery',
+    );
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(100, 'Bob phone')),
+    ];
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('message-recipient')), 'bob');
+
+    await tester.tap(find.byKey(const Key('recipient-identity-view')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('peer-trust-dialog')), findsOneWidget);
+    expect(find.text('Bob phone'), findsOneWidget);
+    expect(find.textContaining('Not verified yet'), findsOneWidget);
+    await tester.tap(find.text('Verify device'));
+    await tester.pumpAndSettle();
+    expect(find.text('Confirm safety number'), findsOneWidget);
+    expect(
+      find.text(
+        'Only continue after comparing this number with your contact through '
+        'another trusted channel.',
+      ),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const Key('peer-trust-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Every active device is verified.'), findsOneWidget);
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+    gateway.deviceDirectories['bob'] = [
+      activeDeviceRecord('bob', _deviceEnrollment(110, 'Bob new phone')),
+    ];
+
+    await tester.tap(find.byKey(const Key('recipient-identity-view')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bob new phone'), findsOneWidget);
+    expect(find.textContaining('Encryption identity changed'), findsOneWidget);
+    expect(find.textContaining('Sending is blocked'), findsOneWidget);
+  });
+
   testWidgets('imports, verifies, selects, renames, and removes a contact', (
     tester,
   ) async {
@@ -1709,3 +1765,14 @@ OutboundChatMessage _retryableOutbox() {
 String _token(int length, int seed) => base64Url
     .encode(List<int>.generate(length, (index) => (seed + index) & 0xff))
     .replaceAll('=', '');
+
+DeviceEnrollment _deviceEnrollment(int seed, String deviceName) {
+  return DeviceEnrollment(
+    deviceId: _token(32, seed),
+    deviceName: deviceName,
+    signingPublicKey: _token(32, seed + 1),
+    exchangePublicKey: _token(32, seed + 2),
+    attestation: _token(64, seed + 3),
+    createdAt: DateTime.utc(2026, 8, 24, 12),
+  );
+}

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -11,6 +11,7 @@ import 'package:wamp_app/src/domain/local_chat_group.dart';
 import 'package:wamp_app/src/domain/local_chat_message.dart';
 import 'package:wamp_app/src/domain/outbound_chat_message.dart';
 import 'package:wamp_app/src/infrastructure/contact_importer_contract.dart';
+import 'package:wamp_app/src/infrastructure/message_cipher.dart';
 import 'package:wamp_app/src/infrastructure/profile_avatar_picker.dart';
 import 'package:wamp_app/src/infrastructure/wamp_account_gateway.dart';
 import 'package:wamp_app/src/infrastructure/voice_note_recorder.dart';
@@ -575,6 +576,14 @@ void main() {
       trustStore: FakeDeviceTrustStore(
         initialMessages: [
           LocalChatMessage(
+            messageId: 'compact-direct-message',
+            conversationId: MessageCipher.directConversationId('alice', 'bob'),
+            peerUsername: 'bob',
+            text: 'Direct history keeps its own appearance',
+            sentAt: DateTime.utc(2026, 8, 25, 11, 2),
+            outgoing: false,
+          ),
+          LocalChatMessage(
             messageId: 'compact-group-message',
             conversationId: 'launch-crew',
             peerUsername: 'bob',
@@ -616,6 +625,24 @@ void main() {
       await tester.pumpAndSettle();
     }
 
+    Future<void> chooseChatAppearance(
+      WampAppConversationAppearance appearance,
+    ) async {
+      await tester.tap(find.byKey(const Key('conversation-appearance-menu')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(ValueKey('conversation-appearance-${appearance.wireName}')),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    Color bubbleColor(String messageId) {
+      final container = tester.widget<Container>(
+        find.byKey(ValueKey('message-surface-$messageId')),
+      );
+      return (container.decoration! as BoxDecoration).color!;
+    }
+
     expect(
       tester.widget<MaterialApp>(find.byType(MaterialApp)).themeMode,
       ThemeMode.system,
@@ -646,6 +673,13 @@ void main() {
 
     await tester.pumpAndSettle();
     final directId = controller.directConversationIdFor('bob')!;
+    final standardDirectColor = bubbleColor('compact-direct-message');
+    await chooseChatAppearance(WampAppConversationAppearance.ocean);
+    expect(
+      controller.conversationAppearanceFor(directId),
+      WampAppConversationAppearance.ocean,
+    );
+    expect(bubbleColor('compact-direct-message'), isNot(standardDirectColor));
     expect(find.byKey(const Key('conversation-mute')), findsOneWidget);
     await tester.tap(find.byKey(const Key('conversation-mute')));
     await tester.pumpAndSettle();
@@ -660,6 +694,17 @@ void main() {
         .intersect(Offset.zero & tester.view.physicalSize);
     await tester.tapAt(visibleGroupChip.center);
     await tester.pumpAndSettle();
+    final standardGroupColor = bubbleColor('compact-group-message');
+    await chooseChatAppearance(WampAppConversationAppearance.sunset);
+    expect(
+      controller.conversationAppearanceFor('launch-crew'),
+      WampAppConversationAppearance.sunset,
+    );
+    expect(
+      controller.conversationAppearanceFor(directId),
+      WampAppConversationAppearance.ocean,
+    );
+    expect(bubbleColor('compact-group-message'), isNot(standardGroupColor));
     expect(
       tester.getSize(find.byKey(const Key('message-history'))).height,
       greaterThanOrEqualTo(24),

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -543,9 +543,13 @@ void main() {
     expect(find.byKey(const Key('message-send')).hitTestable(), findsOneWidget);
   });
 
-  testWidgets('confirms MCP profile sharing and revokes it immediately', (
+  testWidgets('discovers MCP endpoints, confirms sharing, and revokes it', (
     tester,
   ) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
     final gateway = _FakeGateway();
     final controller = WampAppController(
       gateway: gateway,
@@ -564,8 +568,24 @@ void main() {
     await tester.tap(consent);
     await tester.pumpAndSettle();
 
+    expect(find.byKey(const Key('mcp-access-dialog')), findsOneWidget);
+    expect(find.text('https://localhost/mcp'), findsOneWidget);
+    expect(find.text('https://localhost/mcp/auth'), findsOneWidget);
+    expect(find.text('Realm: ${WampAppProtocol.appRealm}'), findsOneWidget);
+    expect(
+      find.textContaining('Streamable HTTP and direct JSON'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('mcp-access-data-boundary')), findsOneWidget);
+    expect(find.text('correct horse battery'), findsNothing);
+    final profileSwitch = find.byKey(const Key('mcp-access-profile-switch'));
+    await tester.ensureVisible(profileSwitch);
+    await tester.pumpAndSettle();
+    await tester.tap(profileSwitch);
+    await tester.pumpAndSettle();
+
     expect(find.text('Allow MCP public-profile access?'), findsOneWidget);
-    expect(find.textContaining('Chats, messages, attachments'), findsOneWidget);
+    expect(find.textContaining('Chats, messages, attachments'), findsWidgets);
     expect(gateway.mcpProfileReadAllowed, isFalse);
 
     await tester.tap(find.byKey(const Key('mcp-profile-consent-confirm')));
@@ -573,7 +593,9 @@ void main() {
     expect(gateway.mcpProfileReadAllowed, isTrue);
     expect(gateway.mcpConsentUpdates, [true]);
 
-    await tester.tap(consent);
+    await tester.ensureVisible(profileSwitch);
+    await tester.pumpAndSettle();
+    await tester.tap(profileSwitch);
     await tester.pumpAndSettle();
     expect(find.text('Allow MCP public-profile access?'), findsNothing);
     expect(gateway.mcpProfileReadAllowed, isFalse);
@@ -1443,6 +1465,11 @@ class _FakeGateway implements AccountGateway {
       username: username,
       initialProfile: profile,
       initialMcpConsent: WampAppMcpConsent.denied,
+      getMcpAccessConfigurationCallback: () async =>
+          WampAppMcpAccessConfiguration.standard(
+            mcpPath: '/mcp',
+            authPath: '/mcp/auth',
+          ),
       getProfileCallback: (lookup) async {
         profileLookups.add(lookup);
         return lookup == username

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -488,17 +488,34 @@ void main() {
   testWidgets('switches appearance and mutes direct and group chats', (
     tester,
   ) async {
+    const groupTitle = 'Native group acceptance title that stays compact';
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 1.1;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
     final controller = WampAppController(
       gateway: _FakeGateway(),
       trustStore: FakeDeviceTrustStore(
+        initialMessages: [
+          LocalChatMessage(
+            messageId: 'compact-group-message',
+            conversationId: 'launch-crew',
+            peerUsername: 'bob',
+            text: 'Compact history remains usable',
+            sentAt: DateTime.utc(2026, 8, 25, 11, 1),
+            outgoing: false,
+            groupTitle: groupTitle,
+            participantUsernames: const ['alice', 'bob'],
+            groupCreatedBy: 'alice',
+            groupCreatedAt: DateTime.utc(2026, 8, 25, 11),
+          ),
+        ],
         initialGroups: [
           LocalChatGroup(
             conversationId: 'launch-crew',
-            title: 'Launch crew',
+            title: groupTitle,
             memberUsernames: const ['alice', 'bob'],
             createdBy: 'alice',
             createdAt: DateTime.utc(2026, 8, 25, 11),
@@ -559,8 +576,19 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.isConversationMuted(directId), isTrue);
 
-    await tester.tap(find.text('Launch crew'));
+    final groupChip = find.byKey(
+      const ValueKey('conversation-group-launch-crew'),
+    );
+    await tester.ensureVisible(groupChip);
+    final visibleGroupChip = tester
+        .getRect(groupChip)
+        .intersect(Offset.zero & tester.view.physicalSize);
+    await tester.tapAt(visibleGroupChip.center);
     await tester.pumpAndSettle();
+    expect(
+      tester.getSize(find.byKey(const Key('message-history'))).height,
+      greaterThanOrEqualTo(24),
+    );
     await tester.tap(find.byKey(const Key('conversation-mute')));
     await tester.pumpAndSettle();
     expect(controller.isConversationMuted('launch-crew'), isTrue);
@@ -911,13 +939,15 @@ void main() {
     expect(tester.widget<FilterChip>(oneTime).selected, isFalse);
   });
 
-  testWidgets('keeps a staged sticker usable on a compact phone', (
+  testWidgets('keeps a staged sticker usable above a compact keyboard', (
     tester,
   ) async {
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
+    tester.view.viewInsets = const FakeViewPadding(bottom: 400);
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
     final controller = WampAppController(
       gateway: _FakeGateway(),
       trustStore: FakeDeviceTrustStore(),
@@ -940,11 +970,17 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('message-expression')));
+    final expression = find.byKey(const Key('message-expression'));
+    await tester.ensureVisible(expression);
+    await tester.tap(expression);
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('expression-sticker-tab')));
+    final stickerTab = find.byKey(const Key('expression-sticker-tab'));
+    expect(stickerTab.hitTestable(), findsOneWidget);
+    await tester.tap(stickerTab);
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('sticker-nice')));
+    final sticker = find.byKey(const ValueKey('sticker-nice'));
+    expect(sticker.hitTestable(), findsOneWidget);
+    await tester.tap(sticker);
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('selected-attachment-0')), findsOneWidget);

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -22,6 +22,115 @@ import 'package:wamp_app_protocol/wamp_app_protocol.dart';
 import 'test_support.dart';
 
 void main() {
+  testWidgets('probes the default router endpoint on onboarding', (
+    tester,
+  ) async {
+    final gateway = _FakeGateway();
+    final controller = WampAppController(gateway: gateway);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('server-probe-reachable')), findsOneWidget);
+    expect(gateway.probedEndpoints, hasLength(1));
+    expect(
+      gateway.probedEndpoints.single.websocketUri.toString(),
+      const String.fromEnvironment(
+        'WAMP_APP_SERVER_ADDRESS',
+        defaultValue: 'ws://localhost:8080/ws',
+      ),
+    );
+  });
+
+  testWidgets('debounces probes and ignores stale endpoint failures', (
+    tester,
+  ) async {
+    final firstProbe = Completer<void>();
+    final secondProbe = Completer<void>();
+    var probeCount = 0;
+    final gateway = _FakeGateway(
+      probeCallback: (_) =>
+          probeCount++ == 0 ? firstProbe.future : secondProbe.future,
+    );
+    final controller = WampAppController(gateway: gateway);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pump();
+    expect(gateway.probedEndpoints, hasLength(1));
+
+    await tester.enterText(
+      find.byKey(const Key('server-address')),
+      'wss://router.example/ws',
+    );
+    await tester.pump(const Duration(milliseconds: 349));
+    expect(gateway.probedEndpoints, hasLength(1));
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(gateway.probedEndpoints, hasLength(2));
+
+    secondProbe.complete();
+    await tester.pump();
+    expect(find.byKey(const Key('server-probe-reachable')), findsOneWidget);
+
+    firstProbe.completeError(StateError('stale failure'));
+    await tester.pump();
+    expect(find.byKey(const Key('server-probe-reachable')), findsOneWidget);
+    expect(find.byKey(const Key('server-probe-unreachable')), findsNothing);
+  });
+
+  testWidgets('failed router probe can retry without disabling submit', (
+    tester,
+  ) async {
+    var failProbe = true;
+    final gateway = _FakeGateway(
+      probeCallback: (_) async {
+        if (failProbe) throw StateError('offline');
+      },
+    );
+    final controller = WampAppController(gateway: gateway);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('server-probe-unreachable')), findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(find.byKey(const Key('submit-account')))
+          .onPressed,
+      isNotNull,
+    );
+
+    failProbe = false;
+    final retry = find.byKey(const Key('server-probe-retry'));
+    await tester.ensureVisible(retry);
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('server-probe-reachable')), findsOneWidget);
+    expect(gateway.probedEndpoints, hasLength(2));
+  });
+
+  testWidgets('late router probe failure is ignored after disposal', (
+    tester,
+  ) async {
+    final probe = Completer<void>();
+    final gateway = _FakeGateway(probeCallback: (_) => probe.future);
+    final controller = WampAppController(gateway: gateway);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(WampApp(controller: controller));
+    await tester.pump();
+    expect(gateway.probedEndpoints, hasLength(1));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    probe.completeError(StateError('late failure'));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('registers and opens the authenticated shell', (tester) async {
     final oneTimeAttachmentId = _token(16, 39);
     final oneTimeMessage = LocalChatMessage(
@@ -1481,15 +1590,23 @@ Future<void> _pumpUntilFound(
 }
 
 class _FakeGateway implements AccountGateway {
-  _FakeGateway({this.peerAvatarBytes});
+  _FakeGateway({this.peerAvatarBytes, this.probeCallback});
 
   final Uint8List? peerAvatarBytes;
+  Future<void> Function(ServerEndpoint endpoint)? probeCallback;
+  final List<ServerEndpoint> probedEndpoints = [];
   int sendAttempts = 0;
   final Map<String, List<DeviceRecord>> deviceDirectories = {};
   bool mcpProfileReadAllowed = false;
   int mcpConsentRevision = 0;
   final List<bool> mcpConsentUpdates = [];
   final List<String> profileLookups = [];
+
+  @override
+  Future<void> probe({required ServerEndpoint endpoint}) async {
+    probedEndpoints.add(endpoint);
+    await probeCallback?.call(endpoint);
+  }
 
   @override
   Future<RegistrationReceipt> register({

--- a/examples/wamp_app/client/test/widget_test.dart
+++ b/examples/wamp_app/client/test/widget_test.dart
@@ -23,6 +23,7 @@ import 'test_support.dart';
 
 void main() {
   testWidgets('registers and opens the authenticated shell', (tester) async {
+    final oneTimeAttachmentId = _token(16, 39);
     final oneTimeMessage = LocalChatMessage(
       messageId: 'one-time-message',
       conversationId: 'alice-bob',
@@ -31,6 +32,19 @@ void main() {
       sentAt: DateTime.utc(2026, 8, 24, 12),
       outgoing: false,
       oneTime: true,
+      attachments: [
+        EncryptedAttachmentDescriptor(
+          attachmentId: oneTimeAttachmentId,
+          kind: ChatAttachmentKind.image,
+          name: 'hidden-view-once.png',
+          contentType: 'image/png',
+          plaintextBytes: 128,
+          chunkBytes: WampAppAttachmentLimits.defaultChunkBytes,
+          chunkCount: 1,
+          plaintextSha256: List<String>.filled(64, '0').join(),
+          key: Uint8List(32),
+        ),
+      ],
     );
     final controller = WampAppController(
       gateway: _FakeGateway(),
@@ -86,6 +100,11 @@ void main() {
     expect(find.text('Encrypted device vault'), findsOneWidget);
     expect(find.text('Test device'), findsOneWidget);
     expect(find.text('hidden until consumed'), findsNothing);
+    expect(find.text('hidden-view-once.png'), findsNothing);
+    expect(
+      find.byKey(ValueKey('attachment-open-$oneTimeAttachmentId')),
+      findsNothing,
+    );
     expect(find.text('Tap to view once'), findsOneWidget);
     expect(find.byKey(const Key('message-attach')), findsOneWidget);
 
@@ -1056,7 +1075,7 @@ void main() {
     expect(renderer.renderedDesigns.single.id, 'nice');
     expect(find.byKey(const Key('selected-attachment-0')), findsOneWidget);
     expect(find.textContaining('sticker-nice-'), findsOneWidget);
-    expect(tester.widget<FilterChip>(oneTime).selected, isFalse);
+    expect(tester.widget<FilterChip>(oneTime).selected, isTrue);
   });
 
   testWidgets('keeps a staged sticker usable above a compact keyboard', (

--- a/examples/wamp_app/server/lib/src/attachment_retention.dart
+++ b/examples/wamp_app/server/lib/src/attachment_retention.dart
@@ -45,6 +45,8 @@ final class AttachmentRetentionController {
         .prune(
           loadActiveMessages: () =>
               mailbox.activeAttachmentMessages(now: timestamp),
+          loadImmediatelyRemovableMessages: () =>
+              mailbox.consumedOneTimeAttachmentMessages(),
           now: timestamp,
         )
         .then<void>((_) {})

--- a/examples/wamp_app/server/lib/src/attachment_service.dart
+++ b/examples/wamp_app/server/lib/src/attachment_service.dart
@@ -49,6 +49,10 @@ final class AttachmentService {
       now: now,
     );
     if (message == null ||
+        (message.message.oneTime &&
+            message.recipientStates.values.any(
+              (state) => state.consumedAt != null,
+            )) ||
         !message.message.attachmentIds.contains(attachmentId)) {
       throw AttachmentNotFound(attachmentId);
     }

--- a/examples/wamp_app/server/lib/src/attachment_store.dart
+++ b/examples/wamp_app/server/lib/src/attachment_store.dart
@@ -358,6 +358,70 @@ final class AttachmentStore {
     });
   }
 
+  Future<T> consumeOneTimeMessage<T>(
+    EncryptedChatMessage message, {
+    required Future<bool> Function() isAlreadyConsumed,
+    required Future<T> Function() commit,
+  }) {
+    _ensureInitialized();
+    return _serializeMutation(() async {
+      if (!await isAlreadyConsumed()) {
+        try {
+          await _requireCompleteLocked(message);
+        } catch (error) {
+          if (error is! AttachmentIncomplete &&
+              error is! AttachmentUnavailable) {
+            rethrow;
+          }
+          if (!await isAlreadyConsumed()) rethrow;
+        }
+      }
+      try {
+        final result = await commit();
+        await _deleteMessageAttachmentsLocked(message);
+        return result;
+      } catch (_) {
+        if (await isAlreadyConsumed()) {
+          await _deleteMessageAttachmentsLocked(message);
+        }
+        rethrow;
+      }
+    });
+  }
+
+  Future<void> _deleteMessageAttachmentsLocked(
+    EncryptedChatMessage message,
+  ) async {
+    for (final attachmentId in message.attachmentIds) {
+      final key = _storageKey(
+        message.senderUsername,
+        message.messageId,
+        attachmentId,
+      );
+      await _serialize(key, () async {
+        final record = _records[key];
+        final attachmentDirectory =
+            record?.directory ??
+            _attachmentDirectory(
+              message.senderUsername,
+              message.messageId,
+              attachmentId,
+            );
+        final manifest = await _readManifest(
+          File(p.join(attachmentDirectory.path, 'manifest.json')),
+        );
+        if (await attachmentDirectory.exists()) {
+          await attachmentDirectory.delete(recursive: true);
+        }
+        _records.remove(key);
+        final bytes =
+            manifest?.storedBytes ?? record?.manifest.storedBytes ?? 0;
+        if (bytes > 0) _removeUsage(message.senderUsername, bytes);
+        await _deleteEmptyParents(attachmentDirectory);
+      });
+    }
+  }
+
   Future<void> _requireCompleteLocked(EncryptedChatMessage message) async {
     for (final attachmentId in message.attachmentIds) {
       final key = _storageKey(
@@ -392,6 +456,8 @@ final class AttachmentStore {
   Future<AttachmentPruneResult> prune({
     required Future<Iterable<EncryptedChatMessage>> Function()
     loadActiveMessages,
+    Future<Iterable<EncryptedChatMessage>> Function()?
+    loadImmediatelyRemovableMessages,
     DateTime? now,
   }) {
     _ensureInitialized();
@@ -410,24 +476,47 @@ final class AttachmentStore {
           );
         }
       }
+      final immediatelyRemovableKeys = <String>{};
+      for (final message
+          in await loadImmediatelyRemovableMessages?.call() ??
+              const <EncryptedChatMessage>[]) {
+        for (final attachmentId in message.attachmentIds) {
+          immediatelyRemovableKeys.add(
+            _storageKey(
+              message.senderUsername,
+              message.messageId,
+              attachmentId,
+            ),
+          );
+        }
+      }
       final cutoff = timestamp.subtract(stagingTtl);
       var removedAttachments = 0;
       var removedBytes = 0;
       for (final entry in List<MapEntry<String, _AttachmentRecord>>.of(
         _records.entries,
       )) {
-        if (activeKeys.contains(entry.key) ||
-            entry.value.manifest.updatedAt.isAfter(cutoff)) {
+        final removeImmediately = immediatelyRemovableKeys.contains(entry.key);
+        if (!removeImmediately &&
+            (activeKeys.contains(entry.key) ||
+                entry.value.manifest.updatedAt.isAfter(cutoff))) {
           continue;
         }
         await _serialize(entry.key, () async {
           final record = _records[entry.key];
-          if (record == null || activeKeys.contains(entry.key)) return;
+          if (record == null ||
+              (!removeImmediately && activeKeys.contains(entry.key))) {
+            return;
+          }
           final manifestFile = File(
             p.join(record.directory.path, 'manifest.json'),
           );
           final manifest = await _readManifest(manifestFile);
-          if (manifest != null && manifest.updatedAt.isAfter(cutoff)) return;
+          if (!removeImmediately &&
+              manifest != null &&
+              manifest.updatedAt.isAfter(cutoff)) {
+            return;
+          }
           if (await record.directory.exists()) {
             await record.directory.delete(recursive: true);
           }

--- a/examples/wamp_app/server/lib/src/mailbox_store.dart
+++ b/examples/wamp_app/server/lib/src/mailbox_store.dart
@@ -154,16 +154,45 @@ class MailboxStore {
   }) => _serializeWrite(() async {
     final timestamp = (now ?? DateTime.now()).toUtc();
     final document = await _readDocument();
+    final latestById = <String, MailboxMessage>{};
+    for (final entry in document.messages) {
+      latestById[entry.message.messageId] = entry;
+    }
     return List<EncryptedChatMessage>.unmodifiable(
-      document.messages
-          .map((entry) => entry.message)
+      latestById.values
           .where(
-            (message) =>
-                message.attachmentIds.isNotEmpty &&
-                !message.isExpiredAt(timestamp),
-          ),
+            (entry) =>
+                entry.message.attachmentIds.isNotEmpty &&
+                !entry.message.isExpiredAt(timestamp) &&
+                !(entry.message.oneTime &&
+                    entry.recipientStates.values.any(
+                      (state) => state.consumedAt != null,
+                    )),
+          )
+          .map((entry) => entry.message),
     );
   });
+
+  Future<List<EncryptedChatMessage>> consumedOneTimeAttachmentMessages() =>
+      _serializeWrite(() async {
+        final document = await _readDocument();
+        final latestById = <String, MailboxMessage>{};
+        for (final entry in document.messages) {
+          latestById[entry.message.messageId] = entry;
+        }
+        return List<EncryptedChatMessage>.unmodifiable(
+          latestById.values
+              .where(
+                (entry) =>
+                    entry.message.oneTime &&
+                    entry.message.attachmentIds.isNotEmpty &&
+                    entry.recipientStates.values.any(
+                      (state) => state.consumedAt != null,
+                    ),
+              )
+              .map((entry) => entry.message),
+        );
+      });
 
   Future<MailboxMessage?> findVisibleMessage(
     String username,

--- a/examples/wamp_app/server/lib/src/mcp_service.dart
+++ b/examples/wamp_app/server/lib/src/mcp_service.dart
@@ -7,11 +7,31 @@ final class McpConsentRequired implements Exception {
   const McpConsentRequired();
 }
 
+final class McpEndpointUnavailable implements Exception {
+  const McpEndpointUnavailable();
+}
+
+final class McpAccessRequestInvalid implements Exception {
+  const McpAccessRequestInvalid();
+}
+
 final class WampAppMcpService {
-  const WampAppMcpService({required this.accounts, required this.consents});
+  const WampAppMcpService({
+    required this.accounts,
+    required this.consents,
+    required this.accessConfiguration,
+  });
 
   final AccountStore accounts;
   final McpConsentStore consents;
+  final WampAppMcpAccessConfiguration? accessConfiguration;
+
+  Future<WampAppMcpAccessConfiguration> getAccessConfiguration(
+    String username,
+  ) async {
+    await _requireAccount(username);
+    return accessConfiguration ?? (throw const McpEndpointUnavailable());
+  }
 
   Future<WampAppMcpConsent> getConsent(String username) async {
     await _requireAccount(username);

--- a/examples/wamp_app/server/lib/src/message_service.dart
+++ b/examples/wamp_app/server/lib/src/message_service.dart
@@ -155,11 +155,40 @@ class MessageService {
     } catch (_) {
       throw StateError('The one-time consumption signature is invalid.');
     }
-    return mailbox.consumeOneTime(
+    final message = await mailbox.findVisibleMessage(
       caller,
-      consumption.deviceId,
       consumption.messageId,
       now: now,
+    );
+    if (message == null) throw MessageNotFound(consumption.messageId);
+    final attachmentStore = attachments;
+    if (message.message.attachmentIds.isEmpty) {
+      return mailbox.consumeOneTime(
+        caller,
+        consumption.deviceId,
+        consumption.messageId,
+        now: now,
+      );
+    }
+    if (attachmentStore == null) {
+      throw const AttachmentUnavailable('attachment-storage-unavailable');
+    }
+    return attachmentStore.consumeOneTimeMessage(
+      message.message,
+      isAlreadyConsumed: () async {
+        final latest = await mailbox.findVisibleMessage(
+          caller,
+          consumption.messageId,
+          now: now,
+        );
+        return latest?.recipientStateFor(caller)?.consumedAt != null;
+      },
+      commit: () => mailbox.consumeOneTime(
+        caller,
+        consumption.deviceId,
+        consumption.messageId,
+        now: now,
+      ),
     );
   }
 

--- a/examples/wamp_app/server/lib/src/server.dart
+++ b/examples/wamp_app/server/lib/src/server.dart
@@ -232,7 +232,16 @@ class WampAppServer {
       );
       await _registerMcpHandlers(
         appServiceSession,
-        WampAppMcpService(accounts: store, consents: mcpConsentStore),
+        WampAppMcpService(
+          accounts: store,
+          consents: mcpConsentStore,
+          accessConfiguration: config.mcp.enabled
+              ? WampAppMcpAccessConfiguration.standard(
+                  mcpPath: config.mcp.path,
+                  authPath: config.mcp.authPath,
+                )
+              : null,
+        ),
         abuseGuard,
       );
       await _registerAttachmentHandlers(
@@ -418,6 +427,10 @@ class WampAppServer {
                 ..allowOperations(const ['call']),
             )
             ..addPermissionFromBuilder(
+              PermissionSettingsBuilder(WampAppProtocol.mcpAccessGet)
+                ..allowOperations(const ['call']),
+            )
+            ..addPermissionFromBuilder(
               PermissionSettingsBuilder(WampAppProtocol.mcpConsentGet)
                 ..allowOperations(const ['call']),
             )
@@ -548,6 +561,10 @@ class WampAppServer {
             )
             ..addPermissionFromBuilder(
               PermissionSettingsBuilder(WampAppProtocol.profileUpdate)
+                ..allowOperations(const ['register', 'unregister']),
+            )
+            ..addPermissionFromBuilder(
+              PermissionSettingsBuilder(WampAppProtocol.mcpAccessGet)
                 ..allowOperations(const ['register', 'unregister']),
             )
             ..addPermissionFromBuilder(
@@ -1133,6 +1150,27 @@ Future<void> _registerMcpHandlers(
   WampAppMcpService mcp,
   WampAppAbuseGuard abuseGuard,
 ) async {
+  await _registerAuthenticatedHandler(
+    session,
+    abuseGuard,
+    WampAppOperationClass.control,
+    WampAppProtocol.mcpAccessGet,
+    (invocation) async {
+      try {
+        if ((invocation.arguments?.isNotEmpty ?? false) ||
+            (invocation.argumentsKeywords?.isNotEmpty ?? false)) {
+          throw const McpAccessRequestInvalid();
+        }
+        final username = _callerUsername(invocation);
+        final configuration = await mcp.getAccessConfiguration(username);
+        invocation.respondWith(
+          argumentsKeywords: configuration.toWampKeywords(),
+        );
+      } catch (error) {
+        _respondWithMcpError(invocation, error);
+      }
+    },
+  );
   await _registerAuthenticatedHandler(
     session,
     abuseGuard,
@@ -1851,6 +1889,16 @@ void _respondWithMcpError(Invocation invocation, Object error) {
     McpConsentRequired() => (
       WampAppProtocol.errorMcpConsentRequired,
       'Enable public-profile access in WampApp before using this MCP tool.',
+      null,
+    ),
+    McpEndpointUnavailable() => (
+      WampAppProtocol.errorMcpUnavailable,
+      'This server does not expose a WampApp MCP endpoint.',
+      null,
+    ),
+    McpAccessRequestInvalid() => (
+      WampAppProtocol.errorInvalidMcpAccess,
+      'MCP access discovery does not accept arguments.',
       null,
     ),
     _CallerNotAuthorized() || ProfileNotFound() || StateError() => (

--- a/examples/wamp_app/server/test/attachment_store_test.dart
+++ b/examples/wamp_app/server/test/attachment_store_test.dart
@@ -359,6 +359,54 @@ void main() {
     },
   );
 
+  test(
+    'retention retries consumed view-once deletion before staging TTL',
+    () async {
+      final directory = await Directory.systemTemp.createTemp('wampapp-files-');
+      addTearDown(() => directory.delete(recursive: true));
+      final now = DateTime.utc(2026, 8, 24, 12);
+      final attachments = AttachmentStore(
+        '${directory.path}/attachments',
+        stagingTtl: const Duration(days: 1),
+        clock: () => now,
+      );
+      final mailbox = MailboxStore('${directory.path}/messages.json');
+      await attachments.initialize();
+      await mailbox.initialize();
+      final message = _message(
+        messageId: _token(16, 33),
+        attachmentId: _token(16, 34),
+        oneTime: true,
+      );
+      final chunk = _chunk(
+        messageId: message.messageId,
+        attachmentId: message.attachmentIds.single,
+        chunkIndex: 0,
+        chunkCount: 1,
+        fill: 35,
+      );
+      await attachments.put(chunk);
+      await mailbox.append(message, now: now);
+      await mailbox.consumeOneTime(
+        'bob',
+        _token(32, 15),
+        message.messageId,
+        now: now.add(const Duration(minutes: 1)),
+      );
+
+      final removed = await attachments.prune(
+        loadActiveMessages: () => mailbox.activeAttachmentMessages(now: now),
+        loadImmediatelyRemovableMessages: () =>
+            mailbox.consumedOneTimeAttachmentMessages(),
+        now: now,
+      );
+
+      expect(removed.removedAttachments, 1);
+      expect(removed.removedBytes, chunk.encryptedBytes.length);
+      expect(attachments.totalBytes, 0);
+    },
+  );
+
   test('message commit is atomic against attachment pruning', () async {
     final directory = await Directory.systemTemp.createTemp('wampapp-files-');
     addTearDown(() => directory.delete(recursive: true));
@@ -662,6 +710,7 @@ EncryptedChatMessage _message({
   required String messageId,
   required String attachmentId,
   DateTime? expiresAt,
+  bool oneTime = false,
 }) {
   final senderDevice = _token(32, 12);
   return EncryptedChatMessage(
@@ -671,6 +720,7 @@ EncryptedChatMessage _message({
     senderDeviceId: senderDevice,
     recipientUsername: 'bob',
     createdAt: DateTime.utc(2026, 8, 24, 12),
+    oneTime: oneTime,
     expiresAt: expiresAt ?? DateTime.utc(2026, 8, 24, 13),
     encryptedPayload: Uint8List.fromList(List<int>.filled(64, 14)),
     attachmentIds: [attachmentId],

--- a/examples/wamp_app/server/test/mcp_integration_test.dart
+++ b/examples/wamp_app/server/test/mcp_integration_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:connectanum_client/connectanum.dart' as wamp;
@@ -198,6 +199,52 @@ void main() {
     );
     expect(bobDenied['isError'], isTrue);
 
+    final bobEnabled = WampAppMcpConsent.fromWampKeywords(
+      (await bob.session.callSingle(
+        WampAppProtocol.mcpConsentUpdate,
+        argumentsKeywords: WampAppMcpConsentUpdate(
+          expectedRevision: 0,
+          profileReadAllowed: true,
+        ).toWampKeywords(),
+      )).argumentsKeywords,
+    );
+    expect(bobEnabled.profileReadAllowed, isTrue);
+
+    final externalAcceptance = await _runExternalAcceptance(
+      endpoint: endpoint,
+      accounts: const [
+        {
+          'username': 'alice',
+          'password': 'correct horse battery',
+          'display_name': 'Alice Example',
+          'status': '',
+        },
+        {
+          'username': 'bob',
+          'password': 'another correct horse',
+          'display_name': 'Bob Example',
+          'status': '',
+        },
+      ],
+    );
+    expect(externalAcceptance.exitCode, 0, reason: externalAcceptance.stderr);
+    expect(externalAcceptance.stderr, isEmpty);
+    expect(jsonDecode(externalAcceptance.stdout as String), {
+      'status': 'ok',
+      'accounts': 2,
+      'streamable_http': true,
+      'direct_json': true,
+      'access_grants_revoked': true,
+    });
+    for (final secret in const [
+      'correct horse battery',
+      'another correct horse',
+      'Alice Example',
+      'Bob Example',
+    ]) {
+      expect(externalAcceptance.stdout, isNot(contains(secret)));
+    }
+
     final revoked = WampAppMcpConsent.fromWampKeywords(
       (await alice.session.callSingle(
         WampAppProtocol.mcpConsentUpdate,
@@ -245,6 +292,66 @@ void main() {
       ),
     );
   }, timeout: const Timeout(Duration(minutes: 2)));
+
+  test('MCP acceptance input failures are bounded and redacted', () async {
+    final result = await _runExternalAcceptance(
+      rawInput: jsonEncode({
+        'endpoint': 'http://not-loopback.example/mcp',
+        'accounts': const [
+          {
+            'username': 'alice',
+            'password': 'must-never-appear-in-output',
+            'display_name': 'Alice Example',
+            'status': 'Available',
+          },
+        ],
+      }),
+    );
+
+    expect(result.exitCode, 1);
+    expect(result.stdout, isEmpty);
+    expect(
+      result.stderr,
+      'WampApp MCP acceptance failed at endpoint validation.\n',
+    );
+    expect(result.stderr, isNot(contains('must-never-appear-in-output')));
+    expect(result.stderr, isNot(contains('not-loopback.example')));
+
+    final oversized = await _runExternalAcceptance(
+      rawInput: 'must-not-be-echoed-${'x' * (64 * 1024)}',
+    );
+    expect(oversized.exitCode, 1);
+    expect(oversized.stdout, isEmpty);
+    expect(
+      oversized.stderr,
+      'WampApp MCP acceptance failed at bounded input validation.\n',
+    );
+    expect(oversized.stderr, isNot(contains('must-not-be-echoed')));
+  });
+}
+
+Future<ProcessResult> _runExternalAcceptance({
+  Uri? endpoint,
+  List<Map<String, String>>? accounts,
+  String? rawInput,
+}) async {
+  final process = await Process.start(Platform.resolvedExecutable, const [
+    'tool/mcp_profile_acceptance.dart',
+  ], workingDirectory: Directory.current.path);
+  final stdoutFuture = utf8.decoder.bind(process.stdout).join();
+  final stderrFuture = utf8.decoder.bind(process.stderr).join();
+  process.stdin.write(
+    rawInput ??
+        jsonEncode({'endpoint': endpoint.toString(), 'accounts': accounts}),
+  );
+  await process.stdin.close();
+  final exitCode = await process.exitCode.timeout(const Duration(minutes: 2));
+  return ProcessResult(
+    process.pid,
+    exitCode,
+    await stdoutFuture,
+    await stderrFuture,
+  );
 }
 
 void _expectAliceSummary(Map<String, Object?> result) {

--- a/examples/wamp_app/server/test/mcp_integration_test.dart
+++ b/examples/wamp_app/server/test/mcp_integration_test.dart
@@ -22,6 +22,8 @@ void main() {
         backupStorePath: '${directory.path}/backups',
         mcp: WampAppMcpConfig(
           enabled: true,
+          path: '/agent/mcp',
+          authPath: '/agent/mcp/auth',
           consentStorePath: '${directory.path}/mcp-consent.json',
           allowInsecureTransport: true,
         ),
@@ -45,6 +47,36 @@ void main() {
     );
     addTearDown(alice.close);
     addTearDown(bob.close);
+
+    final access = WampAppMcpAccessConfiguration.fromWampKeywords(
+      (await alice.session.callSingle(
+        WampAppProtocol.mcpAccessGet,
+      )).argumentsKeywords,
+    );
+    expect(access.mcpPath, '/agent/mcp');
+    expect(access.authPath, '/agent/mcp/auth');
+    expect(
+      access.mcpUriFor(ServerEndpoint.parse(server.websocketUri.toString())),
+      endpoint,
+    );
+    expect(access.profileFields, WampAppMcpAccessContract.profileFields);
+    expect(
+      access.toWampKeywords().keys,
+      isNot(contains(anyOf('password', 'access_token', 'refresh_token'))),
+    );
+    await expectLater(
+      alice.session.callSingle(
+        WampAppProtocol.mcpAccessGet,
+        argumentsKeywords: const {'include_secrets': true},
+      ),
+      throwsA(
+        isA<wamp.Error>().having(
+          (error) => error.error,
+          'error URI',
+          WampAppProtocol.errorInvalidMcpAccess,
+        ),
+      ),
+    );
 
     final unauthenticated = McpStreamableHttpClient.stateless(
       endpoint,

--- a/examples/wamp_app/server/test/message_service_test.dart
+++ b/examples/wamp_app/server/test/message_service_test.dart
@@ -198,6 +198,71 @@ void main() {
     expect(consumed.receipt.consumedAt, DateTime.utc(2026, 8, 24, 12, 1));
   });
 
+  test(
+    'one-time attachment consumption deletes ciphertext before success',
+    () async {
+      final attachmentId = _token(16, 91);
+      final message = _message(
+        alice,
+        bob,
+        oneTime: true,
+        messageSeed: 90,
+        attachmentIds: [attachmentId],
+      );
+      final bytes = Uint8List.fromList(
+        List<int>.filled(WampAppAttachmentLimits.secretBoxOverheadBytes, 92),
+      );
+      await attachments.put(
+        EncryptedAttachmentChunk(
+          senderUsername: 'alice',
+          messageId: message.messageId,
+          attachmentId: attachmentId,
+          chunkIndex: 0,
+          chunkCount: 1,
+          ciphertextSha256: sha256.convert(bytes).toString(),
+          encryptedBytes: bytes,
+        ),
+      );
+      await service.send('alice', message, now: DateTime.utc(2026, 8, 24, 12));
+      final attachmentService = AttachmentService(
+        store: attachments,
+        mailbox: mailbox,
+      );
+      expect(
+        (await attachmentService.getChunk(
+          'bob',
+          messageId: message.messageId,
+          attachmentId: attachmentId,
+          chunkIndex: 0,
+          now: DateTime.utc(2026, 8, 24, 12),
+        )).encryptedBytes,
+        bytes,
+      );
+
+      final proof = _consumption(bob, 'bob', message.messageId);
+      final consumed = await service.consumeOneTime(
+        'bob',
+        proof,
+        now: DateTime.utc(2026, 8, 24, 12, 1),
+      );
+
+      expect(consumed.receipt.consumedAt, isNotNull);
+      expect(attachments.totalBytes, 0);
+      await expectLater(
+        attachmentService.getChunk(
+          'bob',
+          messageId: message.messageId,
+          attachmentId: attachmentId,
+          chunkIndex: 0,
+        ),
+        throwsA(isA<AttachmentNotFound>()),
+      );
+      final retry = await service.consumeOneTime('bob', proof);
+      expect(retry.receipt.cursor, consumed.receipt.cursor);
+      expect(attachments.totalBytes, 0);
+    },
+  );
+
   test('revoked devices cannot consume one-time messages', () async {
     final message = _message(alice, bob, oneTime: true, messageSeed: 78);
     await service.send('alice', message, now: DateTime.utc(2026, 8, 24, 12));

--- a/examples/wamp_app/server/tool/mcp_profile_acceptance.dart
+++ b/examples/wamp_app/server/tool/mcp_profile_acceptance.dart
@@ -1,0 +1,405 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:connectanum_client/mcp.dart';
+import 'package:wamp_app_protocol/wamp_app_protocol.dart';
+
+const _maxInputBytes = 64 * 1024;
+const _requestTimeout = Duration(seconds: 30);
+const _overallTimeout = Duration(minutes: 2);
+const _clientInfo = <String, Object?>{
+  'name': 'wamp-app-external-acceptance',
+  'version': '0.1.0',
+};
+const _toolNames = <String>{
+  'connectanum.api.describe',
+  'connectanum.api.list',
+  'wampapp_profile_summary',
+};
+const _resourceUris = <String>{
+  'wampapp://privacy/mcp',
+  'wampapp://account/profile-summary',
+};
+const _promptNames = <String>{'review-public-profile'};
+const _profileKeys = <String>{
+  'username',
+  'display_name',
+  'status',
+  'profile_revision',
+  'profile_updated_at',
+  'consent_revision',
+};
+
+Future<void> main() async {
+  var stage = 'input';
+  try {
+    final request = await _readRequest();
+    stage = 'MCP authentication and profile validation';
+    await _runAcceptance(request).timeout(_overallTimeout);
+    stdout.writeln(
+      jsonEncode(<String, Object?>{
+        'status': 'ok',
+        'accounts': request.accounts.length,
+        'streamable_http': true,
+        'direct_json': true,
+        'access_grants_revoked': true,
+      }),
+    );
+  } on _AcceptanceFailure catch (error) {
+    stderr.writeln('WampApp MCP acceptance failed at ${error.stage}.');
+    exitCode = 1;
+  } on TimeoutException {
+    stderr.writeln('WampApp MCP acceptance timed out at $stage.');
+    exitCode = 1;
+  } on Object {
+    stderr.writeln('WampApp MCP acceptance failed at $stage.');
+    exitCode = 1;
+  }
+}
+
+Future<_AcceptanceRequest> _readRequest() async {
+  final bytes = <int>[];
+  try {
+    await for (final chunk in stdin) {
+      if (bytes.length + chunk.length > _maxInputBytes) {
+        throw const _AcceptanceFailure('bounded input validation');
+      }
+      bytes.addAll(chunk);
+    }
+    final decoded = jsonDecode(utf8.decode(bytes));
+    if (decoded is! Map) {
+      throw const _AcceptanceFailure('input validation');
+    }
+    return _AcceptanceRequest.fromJson(decoded.cast<Object?, Object?>());
+  } on _AcceptanceFailure {
+    rethrow;
+  } on Object {
+    throw const _AcceptanceFailure('input validation');
+  } finally {
+    bytes.fillRange(0, bytes.length, 0);
+  }
+}
+
+Future<void> _runAcceptance(_AcceptanceRequest request) async {
+  final unauthenticated = McpStreamableHttpClient.stateless(
+    request.endpoint,
+    clientInfo: _clientInfo,
+    requestTimeout: _requestTimeout,
+  );
+  late final McpBearerChallenge challenge;
+  try {
+    try {
+      await unauthenticated.listToolsDirect(id: 'unauthenticated-tools');
+      throw const _AcceptanceFailure('authentication boundary');
+    } on McpStreamableHttpException catch (error) {
+      if (error.statusCode != HttpStatus.unauthorized ||
+          error.bearerChallenges.length != 1) {
+        throw const _AcceptanceFailure('authentication challenge');
+      }
+      challenge = error.bearerChallenges.single;
+    }
+  } finally {
+    unauthenticated.close(force: true);
+  }
+
+  final authClient = ConnectanumHttpAuthClient.fromMcpBearerChallenge(
+    request.endpoint,
+    challenge,
+    requestTimeout: _requestTimeout,
+  );
+  try {
+    for (var index = 0; index < request.accounts.length; index += 1) {
+      await _validateAccount(
+        request,
+        request.accounts[index],
+        authClient,
+        index,
+      );
+    }
+  } finally {
+    authClient.close(force: true);
+  }
+}
+
+Future<void> _validateAccount(
+  _AcceptanceRequest request,
+  _AcceptanceAccount account,
+  ConnectanumHttpAuthClient authClient,
+  int index,
+) async {
+  ConnectanumHttpAuthGrant? grant;
+  McpStreamableHttpClient? client;
+  try {
+    grant = await authClient.issueScramToken(
+      realm: WampAppProtocol.appRealm,
+      authId: account.username,
+      secret: account.password,
+    );
+    client = McpStreamableHttpClient.withAuthGrant(
+      request.endpoint,
+      grant,
+      clientInfo: _clientInfo,
+      requestTimeout: _requestTimeout,
+    );
+    await client.initialize(id: 'account-$index-initialize');
+    await client.notifyInitialized();
+    if (client.sessionId == null) {
+      throw const _AcceptanceFailure('Streamable HTTP session creation');
+    }
+
+    final tools = await client.listTools(id: 'account-$index-tools');
+    _expectExactStrings(
+      tools.tools.map((tool) => tool['name']),
+      _toolNames,
+      'tool catalog',
+    );
+    final resources = await client.listResources(
+      id: 'account-$index-resources',
+    );
+    _expectExactStrings(
+      resources.resources.map((resource) => resource['uri']),
+      _resourceUris,
+      'resource catalog',
+    );
+    final prompts = await client.listPrompts(id: 'account-$index-prompts');
+    _expectExactStrings(
+      prompts.prompts.map((prompt) => prompt['name']),
+      _promptNames,
+      'prompt catalog',
+    );
+
+    final streamableResult = await client.callTool(
+      'wampapp_profile_summary',
+      id: 'account-$index-streamable-profile',
+    );
+    _expectProfile(streamableResult, account, 'Streamable profile tool');
+    final directResult = await client.callToolDirect(
+      'wampapp_profile_summary',
+      id: 'account-$index-direct-profile',
+    );
+    _expectProfile(directResult, account, 'direct JSON profile tool');
+
+    final profileResource = await client.readResource(
+      'wampapp://account/profile-summary',
+      id: 'account-$index-profile-resource',
+    );
+    if (profileResource.length != 1 ||
+        profileResource.single['text'] is! String ||
+        !(profileResource.single['text'] as String).contains(
+          account.displayName,
+        )) {
+      throw const _AcceptanceFailure('profile resource');
+    }
+    final privacyResource = await client.readResource(
+      'wampapp://privacy/mcp',
+      id: 'account-$index-privacy-resource',
+    );
+    if (privacyResource.length != 1 ||
+        privacyResource.single['text'] is! String ||
+        !(privacyResource.single['text'] as String).contains(
+          'cannot access chats, messages, attachments, backups',
+        )) {
+      throw const _AcceptanceFailure('privacy resource');
+    }
+    final prompt = await client.getPrompt(
+      'review-public-profile',
+      id: 'account-$index-profile-prompt',
+    );
+    if (prompt['messages'] is! List || (prompt['messages'] as List).isEmpty) {
+      throw const _AcceptanceFailure('profile prompt');
+    }
+
+    await authClient.revokeGrant(
+      grant,
+      tokenKind: ConnectanumHttpAuthTokenKind.accessToken,
+    );
+    try {
+      await client.listTools(id: 'account-$index-revoked-access');
+      throw const _AcceptanceFailure('access-token revocation');
+    } on McpStreamableHttpException catch (error) {
+      if (error.statusCode != HttpStatus.unauthorized) {
+        throw const _AcceptanceFailure('access-token revocation');
+      }
+    }
+  } on _AcceptanceFailure {
+    rethrow;
+  } on Object {
+    throw const _AcceptanceFailure('account-scoped MCP access');
+  } finally {
+    if (client != null) {
+      client.close(force: true);
+    }
+    if (grant?.refreshToken != null) {
+      try {
+        await authClient.revokeGrant(
+          grant!,
+          tokenKind: ConnectanumHttpAuthTokenKind.refreshToken,
+        );
+      } on Object {
+        throw const _AcceptanceFailure('grant cleanup');
+      }
+    }
+  }
+}
+
+void _expectExactStrings(
+  Iterable<Object?> values,
+  Set<String> expected,
+  String stage,
+) {
+  final actual = <String>{};
+  for (final value in values) {
+    if (value is! String || !actual.add(value)) {
+      throw _AcceptanceFailure(stage);
+    }
+  }
+  if (actual.length != expected.length || !actual.containsAll(expected)) {
+    throw _AcceptanceFailure(stage);
+  }
+}
+
+void _expectProfile(
+  Map<String, Object?> result,
+  _AcceptanceAccount account,
+  String stage,
+) {
+  if (result['isError'] != false || result['structuredContent'] is! Map) {
+    throw _AcceptanceFailure(stage);
+  }
+  final structured = (result['structuredContent'] as Map)
+      .cast<Object?, Object?>();
+  if (structured['argumentsKeywords'] is! Map) {
+    throw _AcceptanceFailure(stage);
+  }
+  final profile = (structured['argumentsKeywords'] as Map)
+      .cast<Object?, Object?>();
+  if (!_sameKeys(profile.keys, _profileKeys) ||
+      profile['username'] != account.username ||
+      profile['display_name'] != account.displayName ||
+      profile['status'] != account.status ||
+      profile['profile_revision'] is! int ||
+      profile['profile_updated_at'] is! String ||
+      profile['consent_revision'] is! int) {
+    throw _AcceptanceFailure(stage);
+  }
+}
+
+bool _sameKeys(Iterable<Object?> actual, Set<String> expected) {
+  final keys = actual.whereType<String>().toSet();
+  return keys.length == actual.length &&
+      keys.length == expected.length &&
+      keys.containsAll(expected);
+}
+
+final class _AcceptanceRequest {
+  const _AcceptanceRequest({required this.endpoint, required this.accounts});
+
+  factory _AcceptanceRequest.fromJson(Map<Object?, Object?> json) {
+    if (!_sameKeys(json.keys, const {'endpoint', 'accounts'}) ||
+        json['endpoint'] is! String ||
+        json['accounts'] is! List) {
+      throw const _AcceptanceFailure('input validation');
+    }
+    final endpoint = Uri.tryParse(json['endpoint'] as String);
+    if (endpoint == null ||
+        !endpoint.hasAuthority ||
+        endpoint.userInfo.isNotEmpty ||
+        endpoint.query.isNotEmpty ||
+        endpoint.fragment.isNotEmpty ||
+        endpoint.path.isEmpty ||
+        !_endpointTransportAllowed(endpoint)) {
+      throw const _AcceptanceFailure('endpoint validation');
+    }
+    final accountValues = json['accounts'] as List;
+    if (accountValues.isEmpty || accountValues.length > 8) {
+      throw const _AcceptanceFailure('account input validation');
+    }
+    final accounts = <_AcceptanceAccount>[];
+    for (final value in accountValues) {
+      if (value is! Map) {
+        throw const _AcceptanceFailure('account input validation');
+      }
+      accounts.add(_AcceptanceAccount.fromJson(value.cast<Object?, Object?>()));
+    }
+    return _AcceptanceRequest(
+      endpoint: endpoint,
+      accounts: List.unmodifiable(accounts),
+    );
+  }
+
+  final Uri endpoint;
+  final List<_AcceptanceAccount> accounts;
+}
+
+final class _AcceptanceAccount {
+  const _AcceptanceAccount({
+    required this.username,
+    required this.password,
+    required this.displayName,
+    required this.status,
+  });
+
+  factory _AcceptanceAccount.fromJson(Map<Object?, Object?> json) {
+    if (!_sameKeys(json.keys, const {
+          'username',
+          'password',
+          'display_name',
+          'status',
+        }) ||
+        json['username'] is! String ||
+        json['password'] is! String ||
+        json['display_name'] is! String ||
+        json['status'] is! String) {
+      throw const _AcceptanceFailure('account input validation');
+    }
+    final username = json['username'] as String;
+    final password = json['password'] as String;
+    final displayName = json['display_name'] as String;
+    final status = json['status'] as String;
+    if (!_accountInputValid(username, password, displayName) ||
+        displayName.trim() != displayName ||
+        status.trim() != status ||
+        status.length > AccountProfileLimits.maxStatusCharacters) {
+      throw const _AcceptanceFailure('account input validation');
+    }
+    return _AcceptanceAccount(
+      username: username,
+      password: password,
+      displayName: displayName,
+      status: status,
+    );
+  }
+
+  final String username;
+  final String password;
+  final String displayName;
+  final String status;
+}
+
+bool _accountInputValid(String username, String password, String displayName) {
+  try {
+    final registration = AccountRegistration(
+      username: username,
+      password: password,
+      displayName: displayName,
+    )..validate();
+    return registration.username == username &&
+        registration.displayName == displayName;
+  } on FormatException {
+    return false;
+  }
+}
+
+bool _endpointTransportAllowed(Uri endpoint) {
+  if (endpoint.scheme == 'https') return true;
+  if (endpoint.scheme != 'http') return false;
+  final host = endpoint.host.toLowerCase();
+  return host == 'localhost' || host == '127.0.0.1' || host == '::1';
+}
+
+final class _AcceptanceFailure implements Exception {
+  const _AcceptanceFailure(this.stage);
+
+  final String stage;
+}

--- a/examples/wamp_app/shared/lib/src/encrypted_messaging.dart
+++ b/examples/wamp_app/shared/lib/src/encrypted_messaging.dart
@@ -157,9 +157,6 @@ final class EncryptedChatMessage {
           !participantUsernames.contains(recipient)) {
         throw const FormatException('Direct message participants are invalid.');
       }
-      if (oneTime && attachmentIds.isNotEmpty) {
-        throw const FormatException('View-once attachments are not supported.');
-      }
     }
     _validateBase64Url(
       senderDeviceId,

--- a/examples/wamp_app/shared/lib/src/mcp_access.dart
+++ b/examples/wamp_app/shared/lib/src/mcp_access.dart
@@ -1,0 +1,152 @@
+import 'server_endpoint.dart';
+
+abstract final class WampAppMcpAccessContract {
+  static const version = 1;
+  static const keywordNames = <String>{
+    'version',
+    'mcp_path',
+    'auth_path',
+    'streamable_http',
+    'direct_json',
+    'tools',
+    'resources',
+    'prompts',
+    'profile_fields',
+  };
+  static const profileFields = <String>[
+    'username',
+    'display_name',
+    'status',
+    'profile_revision',
+    'profile_updated_at',
+    'consent_revision',
+  ];
+}
+
+final class WampAppMcpAccessConfiguration {
+  WampAppMcpAccessConfiguration({
+    required this.mcpPath,
+    required this.authPath,
+    required this.streamableHttp,
+    required this.directJson,
+    required this.tools,
+    required this.resources,
+    required this.prompts,
+    required Iterable<String> profileFields,
+  }) : profileFields = List.unmodifiable(profileFields) {
+    _validateRoutePath(mcpPath, 'mcp_path');
+    _validateRoutePath(authPath, 'auth_path');
+    if (mcpPath == authPath) {
+      throw const FormatException('MCP and authentication paths must differ.');
+    }
+    if (!streamableHttp || !directJson || !tools || !resources || !prompts) {
+      throw const FormatException(
+        'The MCP access configuration is missing a required capability.',
+      );
+    }
+    final uniqueFields = profileFields.toSet();
+    if (uniqueFields.length != profileFields.length ||
+        uniqueFields.length != WampAppMcpAccessContract.profileFields.length ||
+        !WampAppMcpAccessContract.profileFields.every(uniqueFields.contains)) {
+      throw const FormatException(
+        'The MCP public-profile field boundary is invalid.',
+      );
+    }
+  }
+
+  factory WampAppMcpAccessConfiguration.standard({
+    required String mcpPath,
+    required String authPath,
+  }) => WampAppMcpAccessConfiguration(
+    mcpPath: mcpPath,
+    authPath: authPath,
+    streamableHttp: true,
+    directJson: true,
+    tools: true,
+    resources: true,
+    prompts: true,
+    profileFields: WampAppMcpAccessContract.profileFields,
+  );
+
+  final String mcpPath;
+  final String authPath;
+  final bool streamableHttp;
+  final bool directJson;
+  final bool tools;
+  final bool resources;
+  final bool prompts;
+  final List<String> profileFields;
+
+  Uri mcpUriFor(ServerEndpoint endpoint) => _httpUri(endpoint, mcpPath);
+
+  Uri authUriFor(ServerEndpoint endpoint) => _httpUri(endpoint, authPath);
+
+  Map<String, dynamic> toWampKeywords() => {
+    'version': WampAppMcpAccessContract.version,
+    'mcp_path': mcpPath,
+    'auth_path': authPath,
+    'streamable_http': streamableHttp,
+    'direct_json': directJson,
+    'tools': tools,
+    'resources': resources,
+    'prompts': prompts,
+    'profile_fields': profileFields,
+  };
+
+  factory WampAppMcpAccessConfiguration.fromWampKeywords(
+    Map<String, dynamic>? value,
+  ) {
+    if (value == null ||
+        value.keys.toSet().length !=
+            WampAppMcpAccessContract.keywordNames.length ||
+        !WampAppMcpAccessContract.keywordNames.every(value.containsKey) ||
+        value['version'] != WampAppMcpAccessContract.version ||
+        value['mcp_path'] is! String ||
+        value['auth_path'] is! String ||
+        value['streamable_http'] is! bool ||
+        value['direct_json'] is! bool ||
+        value['tools'] is! bool ||
+        value['resources'] is! bool ||
+        value['prompts'] is! bool ||
+        value['profile_fields'] is! List) {
+      throw const FormatException('MCP access configuration is malformed.');
+    }
+    final fields = (value['profile_fields'] as List);
+    if (fields.any((field) => field is! String)) {
+      throw const FormatException('MCP profile fields are malformed.');
+    }
+    return WampAppMcpAccessConfiguration(
+      mcpPath: value['mcp_path'] as String,
+      authPath: value['auth_path'] as String,
+      streamableHttp: value['streamable_http'] as bool,
+      directJson: value['direct_json'] as bool,
+      tools: value['tools'] as bool,
+      resources: value['resources'] as bool,
+      prompts: value['prompts'] as bool,
+      profileFields: fields.cast<String>(),
+    );
+  }
+}
+
+Uri _httpUri(ServerEndpoint endpoint, String path) =>
+    endpoint.websocketUri.replace(
+      scheme: endpoint.isSecure ? 'https' : 'http',
+      path: path,
+      query: null,
+      fragment: null,
+    );
+
+void _validateRoutePath(String value, String name) {
+  final parsed = Uri.tryParse(value);
+  if (value.isEmpty ||
+      !value.startsWith('/') ||
+      parsed == null ||
+      parsed.scheme.isNotEmpty ||
+      parsed.host.isNotEmpty ||
+      parsed.userInfo.isNotEmpty ||
+      parsed.hasQuery ||
+      parsed.fragment.isNotEmpty ||
+      parsed.path != value) {
+    throw FormatException('$name must be an absolute route path.');
+  }
+}

--- a/examples/wamp_app/shared/lib/src/protocol.dart
+++ b/examples/wamp_app/shared/lib/src/protocol.dart
@@ -8,6 +8,7 @@ abstract final class WampAppProtocol {
   static const profileUpdate = 'com.wampapp.profile.update';
   static const mcpConsentGet = 'com.wampapp.mcp.consent.get';
   static const mcpConsentUpdate = 'com.wampapp.mcp.consent.update';
+  static const mcpAccessGet = 'com.wampapp.mcp.access.get';
   static const mcpProfileSummary = 'com.wampapp.mcp.profile.summary';
   static const deviceEnroll = 'com.wampapp.device.enroll';
   static const deviceList = 'com.wampapp.device.list';
@@ -48,6 +49,7 @@ abstract final class WampAppProtocol {
   static const errorProfileUnavailable =
       'com.wampapp.error.profile_unavailable';
   static const errorInvalidMcpConsent = 'com.wampapp.error.invalid_mcp_consent';
+  static const errorInvalidMcpAccess = 'com.wampapp.error.invalid_mcp_access';
   static const errorMcpConsentConflict =
       'com.wampapp.error.mcp_consent_conflict';
   static const errorMcpConsentRequired =

--- a/examples/wamp_app/shared/lib/wamp_app_protocol.dart
+++ b/examples/wamp_app/shared/lib/wamp_app_protocol.dart
@@ -6,6 +6,7 @@ export 'src/encrypted_attachment.dart';
 export 'src/encrypted_backup.dart';
 export 'src/encrypted_messaging.dart';
 export 'src/mcp_consent.dart';
+export 'src/mcp_access.dart';
 export 'src/platform_push.dart';
 export 'src/protocol.dart';
 export 'src/server_endpoint.dart';

--- a/examples/wamp_app/shared/test/encrypted_messaging_test.dart
+++ b/examples/wamp_app/shared/test/encrypted_messaging_test.dart
@@ -44,9 +44,19 @@ void main() {
       () => _message(attachmentIds: [attachmentIds.first, attachmentIds.first]),
       throwsFormatException,
     );
+    final oneTimeAttachment = _message(
+      oneTime: true,
+      attachmentIds: [attachmentIds.first],
+    );
     expect(
-      () => _message(oneTime: true, attachmentIds: [attachmentIds.first]),
-      throwsFormatException,
+      EncryptedChatMessage.fromWampKeywords(
+        oneTimeAttachment.toWampKeywords(),
+      ).attachmentIds,
+      [attachmentIds.first],
+    );
+    expect(
+      EncryptedChatMessage.fromJson(oneTimeAttachment.toJson()).oneTime,
+      isTrue,
     );
   });
 

--- a/examples/wamp_app/shared/test/mcp_access_test.dart
+++ b/examples/wamp_app/shared/test/mcp_access_test.dart
@@ -1,0 +1,84 @@
+import 'package:test/test.dart';
+import 'package:wamp_app_protocol/wamp_app_protocol.dart';
+
+void main() {
+  test('MCP access configuration round-trips without credentials', () {
+    final configuration = WampAppMcpAccessConfiguration.standard(
+      mcpPath: '/agent/mcp',
+      authPath: '/agent/mcp/auth',
+    );
+
+    final encoded = configuration.toWampKeywords();
+    final decoded = WampAppMcpAccessConfiguration.fromWampKeywords(encoded);
+
+    expect(decoded.mcpPath, '/agent/mcp');
+    expect(decoded.authPath, '/agent/mcp/auth');
+    expect(decoded.streamableHttp, isTrue);
+    expect(decoded.directJson, isTrue);
+    expect(decoded.tools, isTrue);
+    expect(decoded.resources, isTrue);
+    expect(decoded.prompts, isTrue);
+    expect(decoded.profileFields, WampAppMcpAccessContract.profileFields);
+    expect(
+      encoded.keys,
+      isNot(contains(anyOf('password', 'access_token', 'refresh_token'))),
+    );
+  });
+
+  test('MCP routes resolve against the connected WAMP origin', () {
+    final configuration = WampAppMcpAccessConfiguration.standard(
+      mcpPath: '/mcp',
+      authPath: '/mcp/auth',
+    );
+
+    final secure = ServerEndpoint.parse('wss://chat.example:9443/wamp');
+    expect(
+      configuration.mcpUriFor(secure),
+      Uri.parse('https://chat.example:9443/mcp'),
+    );
+    expect(
+      configuration.authUriFor(secure),
+      Uri.parse('https://chat.example:9443/mcp/auth'),
+    );
+
+    final local = ServerEndpoint.parse('ws://localhost:18080/ws');
+    expect(
+      configuration.mcpUriFor(local),
+      Uri.parse('http://localhost:18080/mcp'),
+    );
+  });
+
+  test('MCP access configuration rejects unsafe or misleading metadata', () {
+    final valid = WampAppMcpAccessConfiguration.standard(
+      mcpPath: '/mcp',
+      authPath: '/mcp/auth',
+    ).toWampKeywords();
+
+    for (final invalid in <Map<String, dynamic>>[
+      {...valid, 'mcp_path': 'https://attacker.example/mcp'},
+      {...valid, 'auth_path': '/mcp?token=secret'},
+      {...valid, 'auth_path': '/mcp'},
+      {...valid, 'streamable_http': false},
+      {
+        ...valid,
+        'profile_fields': [...valid['profile_fields'] as List, 'chat'],
+      },
+      {
+        ...valid,
+        'profile_fields': const ['username'],
+      },
+      {
+        ...valid,
+        'profile_fields': const ['username', 'username'],
+      },
+      {...valid, 'version': 2},
+      {...valid, 'access_token': 'must-not-cross-the-boundary'},
+    ]) {
+      expect(
+        () => WampAppMcpAccessConfiguration.fromWampKeywords(invalid),
+        throwsFormatException,
+        reason: '$invalid',
+      );
+    }
+  });
+}

--- a/packages/connectanum_client/lib/src/client.dart
+++ b/packages/connectanum_client/lib/src/client.dart
@@ -127,8 +127,13 @@ class Client {
   ///
   /// After calling the method, this instance of Client can no longer be used.
   Future<void> disconnect() async {
+    if (_state == _ClientState.done) return;
     _logger.fine('Disconnecting');
     _changeState(_ClientState.done);
+    final transportWasOpen = transport.isOpen;
+    if (!transportWasOpen) {
+      await transport.close();
+    }
     await _connectStreamSubscription?.cancel();
     if (!_connectStreamController.isClosed) {
       await _connectStreamController.close();
@@ -136,7 +141,7 @@ class Client {
     if (!_controller.isClosed) {
       await _controller.close();
     }
-    if (transport.isOpen) {
+    if (transportWasOpen) {
       await transport.close();
     }
   }
@@ -195,6 +200,10 @@ class Client {
     final connectionAttempt = ++_connectionAttempt;
     _logger.info('Connecting, attempts remaining: ${options.reconnectCount}');
     await transport.open(pingInterval: options.pingInterval);
+    if (_state == _ClientState.done ||
+        connectionAttempt != _connectionAttempt) {
+      return;
+    }
 
     /// Transport failed opening / initializing
     if (!transport.isOpen || transport.onConnectionLost == null) {

--- a/packages/connectanum_client/lib/src/transport/websocket/websocket_transport_io.dart
+++ b/packages/connectanum_client/lib/src/transport/websocket/websocket_transport_io.dart
@@ -30,6 +30,8 @@ class WebSocketTransport extends AbstractTransport {
   bool _goodbyeSent = false;
   bool _goodbyeReceived = false;
   WebSocket? _socket;
+  HttpClient? _httpClient;
+  int _openAttempt = 0;
   Completer? _onConnectionLost;
   Completer? _onDisconnect;
   late Completer _onReady;
@@ -96,9 +98,14 @@ class WebSocketTransport extends AbstractTransport {
   /// Calling close will close the underlying socket connection
   @override
   Future<void> close({error}) {
-    _socket?.close();
+    _openAttempt += 1;
+    final socket = _socket;
+    final client = _httpClient;
+    _httpClient = null;
+    final closeFuture = socket?.close() ?? Future<void>.value();
+    client?.close(force: socket == null);
     complete(_onDisconnect, error);
-    return Future.value();
+    return closeFuture;
   }
 
   /// on connection lost will only complete if the other end closes unexpectedly
@@ -130,37 +137,48 @@ class WebSocketTransport extends AbstractTransport {
   /// or fail respectively
   @override
   Future<void> open({Duration? pingInterval}) async {
+    final openAttempt = ++_openAttempt;
     _onReady = Completer();
     _onDisconnect = Completer();
     _onConnectionLost = Completer();
     _goodbyeSent = false;
     _goodbyeReceived = false;
+    _socket = null;
+    _httpClient?.close(force: true);
+    final securityContext = _tlsSecurityContext as SecurityContext?;
+    final client = HttpClient(context: securityContext);
+    _httpClient = client;
     try {
-      final securityContext = _tlsSecurityContext as SecurityContext?;
-      final client = securityContext != null || _allowInsecureCertificates
-          ? HttpClient(context: securityContext)
-          : null;
-      if (client != null && _allowInsecureCertificates) {
+      if (_allowInsecureCertificates) {
         client.badCertificateCallback =
             (X509Certificate certificate, String host, int port) => true;
       }
-      _socket = await WebSocket.connect(
+      final socket = await WebSocket.connect(
         _url,
         protocols: [_serializerType],
         headers: _headers,
         customClient: client,
       );
+      if (openAttempt != _openAttempt) {
+        client.close(force: true);
+        await socket.close();
+        return;
+      }
+      _socket = socket;
       _onReady.complete();
       if (pingInterval != null) {
-        Timer.periodic(
-          pingInterval,
-          (timer) => _socket!.pingInterval = Duration(
-            milliseconds: (pingInterval.inMilliseconds * 2 / 3).floor(),
-          ),
+        socket.pingInterval = Duration(
+          milliseconds: (pingInterval.inMilliseconds * 2 / 3).floor(),
         );
       }
-    } on SocketException catch (exception) {
-      _onConnectionLost!.complete(exception);
+    } on IOException catch (exception) {
+      if (identical(_httpClient, client)) {
+        _httpClient = null;
+      }
+      client.close(force: true);
+      if (openAttempt == _openAttempt && !_onConnectionLost!.isCompleted) {
+        _onConnectionLost!.complete(exception);
+      }
     }
   }
 

--- a/packages/connectanum_client/lib/src/transport/websocket/websocket_transport_web.dart
+++ b/packages/connectanum_client/lib/src/transport/websocket/websocket_transport_web.dart
@@ -18,7 +18,7 @@ class WebSocketTransport extends AbstractTransport {
   final String _url;
   final AbstractSerializer _serializer;
   final String _serializerType;
-  late WebSocket _socket;
+  WebSocket? _socket;
   bool _goodbyeSent = false;
   bool _goodbyeReceived = false;
   Completer? _onConnectionLost;
@@ -83,7 +83,7 @@ class WebSocketTransport extends AbstractTransport {
   /// Calling close will close the underlying socket connection
   @override
   Future<void> close({error}) {
-    _socket.close();
+    _socket?.close();
     complete(_onDisconnect, error);
     return Future.value();
   }
@@ -99,7 +99,7 @@ class WebSocketTransport extends AbstractTransport {
   /// This method will return true if the underlying socket has a ready state of open
   @override
   bool get isOpen {
-    return _socket.readyState == WebSocket.OPEN;
+    return _socket?.readyState == WebSocket.OPEN;
   }
 
   /// for this transport this is equal to [isOpen]
@@ -120,14 +120,15 @@ class WebSocketTransport extends AbstractTransport {
     _goodbyeSent = false;
     _goodbyeReceived = false;
     var openCompleter = Completer();
-    _socket = WebSocket(_url, [_serializerType.toJS].toJS);
+    final socket = WebSocket(_url, [_serializerType.toJS].toJS);
+    _socket = socket;
     if (pingInterval != null) {
       _logger.info(
         'The browsers WebSocket API does not support ping interval configuration.',
       );
     }
-    _socket.onOpen.listen((open) => openCompleter.complete(open));
-    _socket.onError.listen((Event error) {
+    socket.onOpen.listen((open) => openCompleter.complete(open));
+    socket.onError.listen((Event error) {
       openCompleter.completeError(error);
       complete(_onConnectionLost, error);
     });
@@ -148,7 +149,7 @@ class WebSocketTransport extends AbstractTransport {
     }
     var serializedMessage = _serializer.serialize(message);
     // toJS only works on casted objects
-    _socket.send(
+    _socket!.send(
       serializedMessage is String
           ? serializedMessage.toJS
           : (serializedMessage as Uint8List).toJS,
@@ -160,6 +161,9 @@ class WebSocketTransport extends AbstractTransport {
   @override
   Stream<AbstractMessage?> receive() {
     final socket = _socket;
+    if (socket == null) {
+      throw StateError('WebSocket transport is not open.');
+    }
     final onDisconnect = _onDisconnect!;
     final onConnectionLost = _onConnectionLost!;
     socket.onClose.listen((closeEvent) {

--- a/packages/connectanum_client/test/client_on_transport_io_events_test.dart
+++ b/packages/connectanum_client/test/client_on_transport_io_events_test.dart
@@ -1,9 +1,9 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:async';
 
 import 'package:connectanum_client/src/client.dart';
 import 'package:connectanum_core/src/message/abort.dart';
@@ -20,7 +20,8 @@ void main() {
   group('Client Events', () {
     // WebSocket transport
     test('test disconnect with web socket transport', () async {
-      final server = await HttpServer.bind('localhost', 9200);
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
       serverListenHandler(HttpRequest req) async {
         if (req.uri.path == '/wamp') {
           var socket = await WebSocketTransformer.upgrade(req);
@@ -39,9 +40,10 @@ void main() {
 
       server.listen(serverListenHandler);
       final transport = WebSocketTransport.withJsonSerializer(
-        'ws://localhost:9200/wamp',
+        'ws://${server.address.address}:${server.port}/wamp',
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       client
           .connect(
@@ -60,7 +62,8 @@ void main() {
     });
 
     test('test on reconnect with web socket transport', () async {
-      final server = await HttpServer.bind('localhost', 9201);
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
       late WebSocket currentSocket;
       serverListenHandler(HttpRequest req) async {
         if (req.uri.path == '/wamp') {
@@ -77,9 +80,10 @@ void main() {
 
       server.listen(serverListenHandler);
       final transport = WebSocketTransport.withJsonSerializer(
-        'ws://localhost:9201/wamp',
+        'ws://${server.address.address}:${server.port}/wamp',
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       var reconnects = 0;
       var hitConnectionLostEvent = false;
@@ -118,7 +122,8 @@ void main() {
     });
 
     test('test on multiple reconnects with web socket transport', () async {
-      final server = await HttpServer.bind('localhost', 9202);
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
       late WebSocket currentSocket;
       serverListenHandler(HttpRequest req) async {
         if (req.uri.path == '/wamp') {
@@ -135,9 +140,10 @@ void main() {
 
       server.listen(serverListenHandler);
       final transport = WebSocketTransport.withJsonSerializer(
-        'ws://localhost:9202/wamp',
+        'ws://${server.address.address}:${server.port}/wamp',
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       var reconnects = 0;
       client
@@ -167,10 +173,12 @@ void main() {
     test(
       'test on connect web socket transport and no server available',
       () async {
+        final port = await _unusedTcpPort();
         final transport = WebSocketTransport.withJsonSerializer(
-          'ws://localhost:9203/wamp',
+          'ws://${InternetAddress.loopbackIPv4.address}:$port/wamp',
         );
         final client = Client(realm: 'com.connectanum', transport: transport);
+        addTearDown(client.disconnect);
         var closeCompleter = Completer();
         client
             .connect(
@@ -198,7 +206,8 @@ void main() {
 
     // Socket transport
     test('test disconnect with socket transport', () async {
-      final server = await ServerSocket.bind('0.0.0.0', 9010);
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
       server.listen((socket) {
         socket.listen((message) {
           if (message.length == 4) {
@@ -244,13 +253,14 @@ void main() {
         });
       });
       final transport = SocketTransport(
-        'localhost',
-        9010,
+        server.address.address,
+        server.port,
         Serializer(),
         SocketHelper.serializationJson,
         messageLengthExponent: SocketHelper.maxMessageLengthConnectanumExponent,
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       client
           .connect(
@@ -269,7 +279,8 @@ void main() {
     });
 
     test('test on reconnect with socket transport', () async {
-      final server = await ServerSocket.bind('0.0.0.0', 9011);
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
       late Socket currentSocket;
       server.listen((socket) {
         currentSocket = socket;
@@ -311,13 +322,14 @@ void main() {
         });
       });
       final transport = SocketTransport(
-        'localhost',
-        9011,
+        server.address.address,
+        server.port,
         Serializer(),
         SocketHelper.serializationJson,
         messageLengthExponent: SocketHelper.maxMessageLengthConnectanumExponent,
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       var reconnects = 0;
       var hitConnectionLostEvent = false;
@@ -355,7 +367,8 @@ void main() {
     });
 
     test('test on multiple reconnects with socket transport', () async {
-      final server = await ServerSocket.bind('0.0.0.0', 9021);
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
       late Socket currentSocket;
       server.listen((socket) {
         currentSocket = socket;
@@ -397,13 +410,14 @@ void main() {
         });
       });
       final transport = SocketTransport(
-        'localhost',
-        9021,
+        server.address.address,
+        server.port,
         Serializer(),
         SocketHelper.serializationJson,
         messageLengthExponent: SocketHelper.maxMessageLengthConnectanumExponent,
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       var reconnects = 0;
       client
@@ -431,14 +445,16 @@ void main() {
     });
 
     test('test on connect socket transport and no server available', () async {
+      final port = await _unusedTcpPort();
       final transport = SocketTransport(
-        'localhost',
-        9019,
+        InternetAddress.loopbackIPv4.address,
+        port,
         Serializer(),
         SocketHelper.serializationJson,
         messageLengthExponent: SocketHelper.maxMessageLengthConnectanumExponent,
       );
       final client = Client(realm: 'com.connectanum', transport: transport);
+      addTearDown(client.disconnect);
       var closeCompleter = Completer();
       client
           .connect(
@@ -567,6 +583,7 @@ void main() {
           return null;
         });
         await suite.open();
+        addTearDown(suite.close);
 
         final options = ClientConnectOptions(
           pingInterval: Duration(seconds: 1),
@@ -602,6 +619,7 @@ void main() {
           return null;
         });
         await suite.open();
+        addTearDown(suite.close);
 
         final options = ClientConnectOptions(
           pingInterval: Duration(seconds: 1),
@@ -628,13 +646,17 @@ void main() {
   });
 }
 
-int webSocketTestSuitePort = 9300;
+Future<int> _unusedTcpPort() async {
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = server.port;
+  await server.close();
+  return port;
+}
 
 class WebSocketTestSuite {
-  late WebSocket socket;
+  final _sockets = <WebSocket>[];
   late HttpServer server;
   late Client client;
-  final port = webSocketTestSuitePort++;
 
   final AbstractMessage? Function(int msgType) onServerMessage;
 
@@ -642,15 +664,16 @@ class WebSocketTestSuite {
 
   Future<void> open() async {
     await openServer();
-    openTransport();
+    await openTransport();
   }
 
   Future<void> openServer() async {
-    server = await HttpServer.bind('localhost', port);
+    server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
 
     serverListenHandler(HttpRequest req) async {
       if (req.uri.path == '/wamp') {
-        socket = await WebSocketTransformer.upgrade(req);
+        final socket = await WebSocketTransformer.upgrade(req);
+        _sockets.add(socket);
         socket.listen((message) {
           final msg = jsonDecode(message);
           final msgType = msg[0];
@@ -668,8 +691,22 @@ class WebSocketTestSuite {
 
   Future<void> openTransport() async {
     final transport = WebSocketTransport.withJsonSerializer(
-      'ws://localhost:$port/wamp',
+      'ws://${server.address.address}:${server.port}/wamp',
     );
     client = Client(realm: 'com.connectanum', transport: transport);
+  }
+
+  Future<void> close() async {
+    try {
+      await client.disconnect();
+    } finally {
+      try {
+        await Future.wait<void>(
+          _sockets.map((socket) => socket.close()),
+        );
+      } finally {
+        await server.close(force: true);
+      }
+    }
   }
 }

--- a/packages/connectanum_client/test/transport/websocket/websocket_transport_io_test.dart
+++ b/packages/connectanum_client/test/transport/websocket/websocket_transport_io_test.dart
@@ -23,7 +23,7 @@ void main() {
     test(
       'Opening a server connection and simple send receive scenario using a serializer',
       () async {
-        var server = await HttpServer.bind('localhost', 9911);
+        var server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
         addTearDown(() => server.close(force: true));
         server.listen((HttpRequest req) async {
           if (req.uri.path == '/wamp') {
@@ -71,21 +71,25 @@ void main() {
         });
 
         var transportJSON = WebSocketTransport.withJsonSerializer(
-          'ws://localhost:9911/wamp',
+          'ws://127.0.0.1:${server.port}/wamp',
         );
+        addTearDown(transportJSON.close);
 
         var transportMsgpack = WebSocketTransport.withMsgpackSerializer(
-          'ws://localhost:9911/wamp',
+          'ws://127.0.0.1:${server.port}/wamp',
         );
+        addTearDown(transportMsgpack.close);
 
         var transportCbor = WebSocketTransport.withCborSerializer(
-          'ws://localhost:9911/wamp',
+          'ws://127.0.0.1:${server.port}/wamp',
         );
+        addTearDown(transportCbor.close);
 
         var transportWithHeaders = WebSocketTransport.withJsonSerializer(
-          'ws://localhost:9911/wamp',
+          'ws://127.0.0.1:${server.port}/wamp',
           {'X_Custom_Header': 'custom_value'},
         );
+        addTearDown(transportWithHeaders.close);
 
         await transportJSON.open();
         transportJSON.send(Hello('my.realm', Details.forHello()));
@@ -110,7 +114,7 @@ void main() {
     );
 
     test('closes connection when inbound WAMP frame is malformed', () async {
-      final server = await HttpServer.bind('localhost', 0);
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => server.close(force: true));
       server.listen((HttpRequest req) async {
         if (req.uri.path == '/wamp') {
@@ -125,7 +129,7 @@ void main() {
       });
 
       final transport = WebSocketTransport.withJsonSerializer(
-        'ws://localhost:${server.port}/wamp',
+        'ws://127.0.0.1:${server.port}/wamp',
       );
       addTearDown(transport.close);
 
@@ -152,7 +156,10 @@ void main() {
         final binary = Uint8List.fromList(
           List<int>.generate(2048, (index) => index & 0xff),
         );
-        final server = await HttpServer.bind('localhost', 0);
+        final server = await HttpServer.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
         addTearDown(() => server.close(force: true));
         server.listen((HttpRequest request) async {
           final socket = await WebSocketTransformer.upgrade(request);
@@ -177,7 +184,7 @@ void main() {
         });
 
         final transport = WebSocketTransport.withJsonSerializer(
-          'ws://localhost:${server.port}/wamp',
+          'ws://127.0.0.1:${server.port}/wamp',
         );
         addTearDown(transport.close);
         await transport.open();
@@ -196,7 +203,7 @@ void main() {
 
     test('sends lazy JSON payload fragments as one text message', () async {
       final received = Completer<Object>();
-      final server = await HttpServer.bind('localhost', 0);
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => server.close(force: true));
       server.listen((HttpRequest request) async {
         final socket = await WebSocketTransformer.upgrade(request);
@@ -208,7 +215,7 @@ void main() {
       });
 
       final transport = WebSocketTransport.withJsonSerializer(
-        'ws://localhost:${server.port}/wamp',
+        'ws://127.0.0.1:${server.port}/wamp',
       );
       addTearDown(transport.close);
       await transport.open();
@@ -235,7 +242,7 @@ void main() {
 
     test('sends MessagePack fragments as one binary message', () async {
       final received = Completer<Object>();
-      final server = await HttpServer.bind('localhost', 0);
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       addTearDown(() => server.close(force: true));
       server.listen((HttpRequest request) async {
         final socket = await WebSocketTransformer.upgrade(request);
@@ -247,7 +254,7 @@ void main() {
       });
 
       final transport = WebSocketTransport.withMsgpackSerializer(
-        'ws://localhost:${server.port}/wamp',
+        'ws://127.0.0.1:${server.port}/wamp',
       );
       addTearDown(transport.close);
       await transport.open();

--- a/packages/connectanum_client/test/transport/websocket/websocket_transport_io_test.dart
+++ b/packages/connectanum_client/test/transport/websocket/websocket_transport_io_test.dart
@@ -13,6 +13,7 @@ import 'package:connectanum_core/src/message/hello.dart';
 import 'package:connectanum_core/src/message/message_types.dart';
 import 'package:connectanum_core/src/message/result.dart';
 import 'package:connectanum_core/src/message/welcome.dart';
+import 'package:connectanum_client/connectanum.dart' show Client;
 import 'package:connectanum_client/src/transport/websocket/websocket_transport_io.dart';
 import 'package:connectanum_client/src/transport/websocket/websocket_transport_serialization.dart';
 import 'package:msgpack_dart/msgpack_dart.dart' as msgpack_dart;
@@ -20,6 +21,42 @@ import 'package:test/test.dart';
 
 void main() {
   group('WebSocket protocol with io communication', () {
+    test('client disconnect cancels a pending websocket upgrade', () async {
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final accepted = Completer<Socket>();
+      final peerClosed = Completer<void>();
+      Socket? acceptedSocket;
+      final subscription = server.listen((socket) {
+        acceptedSocket = socket;
+        socket.listen(
+          (_) {},
+          onError: (_) {
+            if (!peerClosed.isCompleted) peerClosed.complete();
+          },
+          onDone: () {
+            if (!peerClosed.isCompleted) peerClosed.complete();
+          },
+        );
+        accepted.complete(socket);
+      });
+      addTearDown(() async {
+        acceptedSocket?.destroy();
+        await subscription.cancel();
+        await server.close();
+      });
+      final transport = WebSocketTransport.withCborSerializer(
+        'ws://127.0.0.1:${server.port}/wamp',
+      );
+      final client = Client(transport: transport, realm: 'probe.realm');
+      final sessions = client.connect().listen((_) {});
+      addTearDown(sessions.cancel);
+      await accepted.future.timeout(const Duration(seconds: 1));
+
+      await client.disconnect().timeout(const Duration(seconds: 1));
+
+      await peerClosed.future.timeout(const Duration(seconds: 1));
+    });
+
     test(
       'Opening a server connection and simple send receive scenario using a serializer',
       () async {

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -421,6 +421,12 @@ class RunWampAppLabTests(unittest.TestCase):
         self.assertIn("simctl privacy ios-simulator grant microphone", result.stdout)
         self.assertIn("simctl privacy ios-simulator grant camera", result.stdout)
         self.assertEqual(result.stdout.count("--timeout 25m"), 2)
+        self.assertIn(
+            "External MCP acceptance command (bounded credentials on stdin",
+            result.stdout,
+        )
+        self.assertIn("dart run tool/mcp_profile_acceptance.dart", result.stdout)
+        self.assertNotIn("wamp-app-native-smoke-password", result.stdout)
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):
@@ -603,7 +609,7 @@ class RunWampAppLabTests(unittest.TestCase):
         with socket.socket() as released:
             released.bind(("127.0.0.1", port))
 
-    def test_smoke_failure_forces_router_exit_and_removes_reverse(self):
+    def test_smoke_mcp_failure_forces_router_exit_and_removes_reverse(self):
         with socket.socket() as reservation:
             reservation.bind(("127.0.0.1", 0))
             port = reservation.getsockname()[1]
@@ -654,7 +660,6 @@ class RunWampAppLabTests(unittest.TestCase):
                     "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
                     "  printf '%s\\n' '00:00 +0: verifies peer identities and exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls'\n"
-                    "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"
                     "exit 99\n"
@@ -679,6 +684,10 @@ class RunWampAppLabTests(unittest.TestCase):
                     "    while True:\n"
                     "        time.sleep(1)\n"
                     "PY\n"
+                    "fi\n"
+                    "if [[ \"$1\" == run && \"$2\" == tool/mcp_profile_acceptance.dart ]]; then\n"
+                    "  cat >/dev/null\n"
+                    "  exit 7\n"
                     "fi\n"
                     "exit 99\n"
                 ),
@@ -745,7 +754,16 @@ class RunWampAppLabTests(unittest.TestCase):
 
             self.assertLess(time.monotonic() - started, 15)
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("two-device UI smoke failed", result.stderr)
+            self.assertIn(
+                "independent MCP client could not use the UI-granted profile access",
+                result.stderr,
+            )
+            self.assertIn(
+                "Running independent authenticated MCP client",
+                result.stdout,
+            )
+            self.assertNotIn("wamp-app-native-smoke-password", result.stdout)
+            self.assertNotIn("wamp-app-native-smoke-password", result.stderr)
             adb_calls = adb_log.read_text(encoding="utf-8")
             self.assertIn("reverse tcp:", adb_calls)
             self.assertIn("reverse --remove tcp:", adb_calls)

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -66,6 +66,7 @@ class RunWampAppLabTests(unittest.TestCase):
         android_launch_succeeds: bool,
         android_stays_running: bool = True,
         ios_launch_succeeds: bool = True,
+        scrcpy_launch_succeeds: bool = True,
         router_lifetime_seconds: int,
     ) -> tuple[subprocess.CompletedProcess[str], str, str, int, float]:
         with socket.socket() as reservation:
@@ -173,6 +174,18 @@ class RunWampAppLabTests(unittest.TestCase):
                     "printf 'open %s\\n' \"$*\" >>\"$WAMP_APP_TEST_XCRUN_LOG\"\n"
                     "exit 0\n"
                 ),
+                "osascript": (
+                    "#!/usr/bin/env bash\n"
+                    "printf 'osascript %s\\n' \"$*\" >>\"$WAMP_APP_TEST_XCRUN_LOG\"\n"
+                    "exit 0\n"
+                ),
+                "scrcpy": (
+                    "#!/usr/bin/env bash\n"
+                    "printf 'scrcpy %s\\n' \"$*\" >>\"$WAMP_APP_TEST_XCRUN_LOG\"\n"
+                    "[[ \"$WAMP_APP_TEST_SCRCPY_LAUNCH_SUCCEEDS\" == true ]] || exit 1\n"
+                    "trap 'printf %s\\n scrcpy-stopped >>\"$WAMP_APP_TEST_XCRUN_LOG\"; exit 0' TERM INT\n"
+                    "while :; do sleep 1; done\n"
+                ),
             }
             for name, source in commands.items():
                 command = temporary / name
@@ -193,6 +206,9 @@ class RunWampAppLabTests(unittest.TestCase):
             environment["WAMP_APP_TEST_IOS_RUNNING"] = str(ios_running)
             environment["WAMP_APP_TEST_IOS_LAUNCH_SUCCEEDS"] = str(
                 ios_launch_succeeds
+            ).lower()
+            environment["WAMP_APP_TEST_SCRCPY_LAUNCH_SUCCEEDS"] = str(
+                scrcpy_launch_succeeds
             ).lower()
             environment["WAMP_APP_TEST_ROUTER_LIFETIME"] = str(
                 router_lifetime_seconds
@@ -496,6 +512,29 @@ class RunWampAppLabTests(unittest.TestCase):
             "open -a Simulator --args -CurrentDeviceUDID ios-simulator",
             xcrun_calls,
         )
+        self.assertIn(
+            'osascript -e tell application "Simulator" to activate',
+            xcrun_calls,
+        )
+        self.assertIn(
+            "scrcpy --serial emulator-5554 --window-title WampApp Android "
+            "--stay-awake --no-audio --window-x 20 --window-y 40 "
+            "--window-width 540 --window-height 900",
+            xcrun_calls,
+        )
+        self.assertIn("scrcpy-stopped", xcrun_calls)
+        self.assertLess(
+            result.stdout.index("Installing iOS client"),
+            result.stdout.index("Mirroring Android emulator"),
+        )
+        self.assertLess(
+            result.stdout.index("Mirroring Android emulator"),
+            result.stdout.index("Showing iOS simulator"),
+        )
+        self.assertLess(
+            result.stdout.index("Showing iOS simulator"),
+            result.stdout.index("WampApp lab is ready"),
+        )
         self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
         with socket.socket() as released:
             released.bind(("127.0.0.1", port))
@@ -511,6 +550,23 @@ class RunWampAppLabTests(unittest.TestCase):
         self.assertEqual(result.stdout.count("Android WampApp exited; relaunching"), 3)
         self.assertIn("could not be kept running", result.stderr)
         self.assertIn("interactive router or client supervision failed", result.stderr)
+        self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
+        with socket.socket() as released:
+            released.bind(("127.0.0.1", port))
+
+    def test_interactive_lab_survives_failed_optional_android_mirror(self):
+        result, adb_calls, xcrun_calls, port, elapsed = self.run_supervised_script(
+            android_launch_succeeds=True,
+            scrcpy_launch_succeeds=False,
+            router_lifetime_seconds=4,
+        )
+
+        self.assertLess(elapsed, 10)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("scrcpy could not mirror emulator-5554", result.stderr)
+        self.assertIn("Showing iOS simulator ios-simulator", result.stdout)
+        self.assertIn("open -a Simulator", xcrun_calls)
+        self.assertNotIn("scrcpy-stopped", xcrun_calls)
         self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
         with socket.socket() as released:
             released.bind(("127.0.0.1", port))
@@ -556,6 +612,7 @@ class RunWampAppLabTests(unittest.TestCase):
             temporary = pathlib.Path(temporary_directory)
             state = temporary / "state"
             adb_log = temporary / "adb.log"
+            desktop_log = temporary / "desktop.log"
             runtime_tmp_log = temporary / "runtime-tmp.log"
             devices = [
                 {
@@ -642,6 +699,21 @@ class RunWampAppLabTests(unittest.TestCase):
                     "fi\n"
                     "exit 99\n"
                 ),
+                "open": (
+                    "#!/usr/bin/env bash\n"
+                    "printf 'open %s\\n' \"$*\" >>\"$WAMP_APP_TEST_DESKTOP_LOG\"\n"
+                    "exit 98\n"
+                ),
+                "osascript": (
+                    "#!/usr/bin/env bash\n"
+                    "printf 'osascript %s\\n' \"$*\" >>\"$WAMP_APP_TEST_DESKTOP_LOG\"\n"
+                    "exit 98\n"
+                ),
+                "scrcpy": (
+                    "#!/usr/bin/env bash\n"
+                    "printf 'scrcpy %s\\n' \"$*\" >>\"$WAMP_APP_TEST_DESKTOP_LOG\"\n"
+                    "exit 98\n"
+                ),
             }
             for name, source in commands.items():
                 command = temporary / name
@@ -651,6 +723,7 @@ class RunWampAppLabTests(unittest.TestCase):
             environment = os.environ.copy()
             environment["PATH"] = f"{temporary}:{environment['PATH']}"
             environment["WAMP_APP_TEST_ADB_LOG"] = str(adb_log)
+            environment["WAMP_APP_TEST_DESKTOP_LOG"] = str(desktop_log)
             environment["WAMP_APP_TEST_TMPDIR_LOG"] = str(runtime_tmp_log)
             started = time.monotonic()
             result = subprocess.run(
@@ -676,6 +749,12 @@ class RunWampAppLabTests(unittest.TestCase):
             adb_calls = adb_log.read_text(encoding="utf-8")
             self.assertIn("reverse tcp:", adb_calls)
             self.assertIn("reverse --remove tcp:", adb_calls)
+            self.assertFalse(
+                desktop_log.exists(),
+                desktop_log.read_text(encoding="utf-8")
+                if desktop_log.exists()
+                else "",
+            )
             self.assertEqual(
                 runtime_tmp_log.read_text(encoding="utf-8").strip(),
                 str(state / "runtime-tmp"),

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -150,11 +150,27 @@ class RunWampAppLabTests(unittest.TestCase):
             "WAMP_APP_SMOKE_CALL_READY_INBOUND=voice-ready-android-run-id",
             result.stdout,
         )
+        self.assertIn(
+            "WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=video-ready-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_VIDEO_READY_INBOUND=video-ready-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_VIDEO_READY_OUTBOUND=video-ready-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_VIDEO_READY_INBOUND=video-ready-android-run-id",
+            result.stdout,
+        )
         self.assertEqual(result.stdout.count("android.permission.RECORD_AUDIO"), 1)
         self.assertEqual(result.stdout.count("android.permission.CAMERA"), 1)
         self.assertIn("simctl privacy ios-simulator grant microphone", result.stdout)
         self.assertIn("simctl privacy ios-simulator grant camera", result.stdout)
-        self.assertEqual(result.stdout.count("--timeout 11m"), 2)
+        self.assertEqual(result.stdout.count("--timeout 16m"), 2)
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):
@@ -272,7 +288,7 @@ class RunWampAppLabTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
-                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat and completes a WebRTC voice call'\n"
+                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat and completes WebRTC voice and video calls'\n"
                     "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -128,6 +128,13 @@ class RunWampAppLabTests(unittest.TestCase):
             "WAMP_APP_SMOKE_GROUP_INBOUND=group-from-android-run-id",
             result.stdout,
         )
+        self.assertEqual(
+            result.stdout.count(
+                "WAMP_APP_SMOKE_VIEW_ONCE=view-once-from-android-run-id"
+            ),
+            2,
+        )
+        self.assertEqual(result.stdout.count("--timeout 8m"), 2)
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -166,11 +166,51 @@ class RunWampAppLabTests(unittest.TestCase):
             "WAMP_APP_SMOKE_VIDEO_READY_INBOUND=video-ready-android-run-id",
             result.stdout,
         )
+        self.assertIn(
+            "WAMP_APP_SMOKE_PROFILE_STATUS=profile-status-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_PROFILE_STATUS=profile-status-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_PEER_PROFILE_STATUS=profile-status-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_PEER_PROFILE_STATUS=profile-status-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=controls-ready-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CONTROLS_READY_OUTBOUND=controls-ready-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=controls-ready-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CONTROLS_READY_INBOUND=controls-ready-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_BACKUP_PASSPHRASE=backup-passphrase-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_BACKUP_PASSPHRASE=backup-passphrase-ios-run-id",
+            result.stdout,
+        )
         self.assertEqual(result.stdout.count("android.permission.RECORD_AUDIO"), 1)
         self.assertEqual(result.stdout.count("android.permission.CAMERA"), 1)
         self.assertIn("simctl privacy ios-simulator grant microphone", result.stdout)
         self.assertIn("simctl privacy ios-simulator grant camera", result.stdout)
-        self.assertEqual(result.stdout.count("--timeout 16m"), 2)
+        self.assertEqual(result.stdout.count("--timeout 22m"), 2)
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):
@@ -288,7 +328,7 @@ class RunWampAppLabTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
-                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat and completes WebRTC voice and video calls'\n"
+                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat, account controls, backup, and WebRTC calls'\n"
                     "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -106,6 +106,28 @@ class RunWampAppLabTests(unittest.TestCase):
         self.assertIn("WAMP_APP_SMOKE_INBOUND=from-ios-run-id", result.stdout)
         self.assertIn("WAMP_APP_SMOKE_OUTBOUND=from-ios-run-id", result.stdout)
         self.assertIn("WAMP_APP_SMOKE_INBOUND=from-android-run-id", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_ROLE=initiator", result.stdout)
+        self.assertIn("WAMP_APP_SMOKE_ROLE=responder", result.stdout)
+        self.assertEqual(
+            result.stdout.count("WAMP_APP_SMOKE_GROUP_TITLE=native-group-run-id"),
+            2,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_GROUP_OUTBOUND=group-from-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_GROUP_INBOUND=group-from-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_GROUP_OUTBOUND=group-from-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_GROUP_INBOUND=group-from-android-run-id",
+            result.stdout,
+        )
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -60,6 +60,163 @@ class RunWampAppLabTests(unittest.TestCase):
                 check=False,
             )
 
+    def run_supervised_script(
+        self,
+        *,
+        android_launch_succeeds: bool,
+        android_stays_running: bool = True,
+        ios_launch_succeeds: bool = True,
+        router_lifetime_seconds: int,
+    ) -> tuple[subprocess.CompletedProcess[str], str, str, int, float]:
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = reservation.getsockname()[1]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = pathlib.Path(temporary_directory)
+            state = temporary / "state"
+            adb_log = temporary / "adb.log"
+            android_running = temporary / "android-running"
+            xcrun_log = temporary / "xcrun.log"
+            ios_running = temporary / "ios-running"
+            devices = [
+                {
+                    "name": "Android Emulator",
+                    "id": "emulator-5554",
+                    "isSupported": True,
+                    "targetPlatform": "android-arm64",
+                    "emulator": True,
+                },
+                {
+                    "name": "iPhone Simulator",
+                    "id": "ios-simulator",
+                    "isSupported": True,
+                    "targetPlatform": "ios",
+                    "emulator": True,
+                },
+            ]
+            commands = {
+                "uname": (
+                    "#!/usr/bin/env bash\n"
+                    "[[ \"$1\" == -s ]] && printf '%s\\n' Darwin && exit 0\n"
+                    "exit 99\n"
+                ),
+                "flutter": (
+                    "#!/usr/bin/env bash\n"
+                    "if [[ \"$1\" == devices && \"$2\" == --machine ]]; then\n"
+                    f"  printf '%s\\n' '{json.dumps(devices)}'\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$1\" == pub && \"$2\" == get ]]; then exit 0; fi\n"
+                    "if [[ \"$1\" == run ]]; then exit 0; fi\n"
+                    "exit 99\n"
+                ),
+                "dart": (
+                    "#!/usr/bin/env bash\n"
+                    "if [[ \"$1\" == pub && \"$2\" == get ]]; then exit 0; fi\n"
+                    "if [[ \"$1\" == run && \"$2\" == wamp_app_server ]]; then\n"
+                    "  config=\"$4\"\n"
+                    "  port=$(awk '/^  port:/ {print $2; exit}' \"$config\")\n"
+                    "  exec python3 - \"$port\" \"$WAMP_APP_TEST_ROUTER_LIFETIME\" <<'PY'\n"
+                    "import socket\n"
+                    "import sys\n"
+                    "import time\n"
+                    "with socket.socket() as listener:\n"
+                    "    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\n"
+                    "    listener.bind(('127.0.0.1', int(sys.argv[1])))\n"
+                    "    listener.listen()\n"
+                    "    time.sleep(float(sys.argv[2]))\n"
+                    "raise SystemExit(9)\n"
+                    "PY\n"
+                    "fi\n"
+                    "exit 99\n"
+                ),
+                "adb": (
+                    "#!/usr/bin/env bash\n"
+                    "printf '%s\\n' \"$*\" >>\"$WAMP_APP_TEST_ADB_LOG\"\n"
+                    "if [[ \"$3\" == reverse ]]; then exit 0; fi\n"
+                    "if [[ \"$3\" == get-state ]]; then printf '%s\\n' device; exit 0; fi\n"
+                    "if [[ \"$3\" == shell && \"$4\" == pidof ]]; then\n"
+                    "  [[ -f \"$WAMP_APP_TEST_ANDROID_RUNNING\" ]] || exit 1\n"
+                    "  printf '%s\\n' 4242\n"
+                    "  if [[ \"$WAMP_APP_TEST_ANDROID_STAYS_RUNNING\" != true ]]; then\n"
+                    "    rm -f \"$WAMP_APP_TEST_ANDROID_RUNNING\"\n"
+                    "  fi\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$3\" == shell && \"$4\" == am ]]; then\n"
+                    "  [[ \"$WAMP_APP_TEST_ANDROID_LAUNCH_SUCCEEDS\" == true ]] || exit 1\n"
+                    "  : >\"$WAMP_APP_TEST_ANDROID_RUNNING\"\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "exit 99\n"
+                ),
+                "xcrun": (
+                    "#!/usr/bin/env bash\n"
+                    "printf '%s\\n' \"$*\" >>\"$WAMP_APP_TEST_XCRUN_LOG\"\n"
+                    "if [[ \"$1\" == simctl && \"$2\" == spawn ]]; then\n"
+                    "  if [[ -f \"$WAMP_APP_TEST_IOS_RUNNING\" ]]; then\n"
+                    "    printf '%s\\n' '5252 0 UIKitApplication:dev.connectanum.wampApp[test][rb-legacy]'\n"
+                    "  fi\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$1\" == simctl && \"$2\" == launch ]]; then\n"
+                    "  [[ \"$WAMP_APP_TEST_IOS_LAUNCH_SUCCEEDS\" == true ]] || exit 1\n"
+                    "  : >\"$WAMP_APP_TEST_IOS_RUNNING\"\n"
+                    "  printf '%s\\n' 'dev.connectanum.wampApp: 5252'\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "exit 99\n"
+                ),
+            }
+            for name, source in commands.items():
+                command = temporary / name
+                command.write_text(source, encoding="utf-8")
+                command.chmod(command.stat().st_mode | stat.S_IXUSR)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{temporary}:{environment['PATH']}"
+            environment["WAMP_APP_TEST_ADB_LOG"] = str(adb_log)
+            environment["WAMP_APP_TEST_ANDROID_RUNNING"] = str(android_running)
+            environment["WAMP_APP_TEST_ANDROID_LAUNCH_SUCCEEDS"] = str(
+                android_launch_succeeds
+            ).lower()
+            environment["WAMP_APP_TEST_ANDROID_STAYS_RUNNING"] = str(
+                android_stays_running
+            ).lower()
+            environment["WAMP_APP_TEST_XCRUN_LOG"] = str(xcrun_log)
+            environment["WAMP_APP_TEST_IOS_RUNNING"] = str(ios_running)
+            environment["WAMP_APP_TEST_IOS_LAUNCH_SUCCEEDS"] = str(
+                ios_launch_succeeds
+            ).lower()
+            environment["WAMP_APP_TEST_ROUTER_LIFETIME"] = str(
+                router_lifetime_seconds
+            )
+            started = time.monotonic()
+            result = subprocess.run(
+                [
+                    str(SCRIPT),
+                    "--port",
+                    str(port),
+                    "--state-dir",
+                    str(state),
+                ],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=20,
+            )
+            elapsed = time.monotonic() - started
+            return (
+                result,
+                adb_log.read_text(encoding="utf-8"),
+                xcrun_log.read_text(encoding="utf-8"),
+                port,
+                elapsed,
+            )
+
     def test_dry_run_resolves_router_and_both_emulators(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             state = pathlib.Path(temporary_directory) / "does-not-exist"
@@ -307,6 +464,75 @@ class RunWampAppLabTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("mutually exclusive", result.stderr)
+
+    def test_interactive_lab_relaunches_both_clients_and_detects_router_exit(self):
+        result, adb_calls, xcrun_calls, port, _ = self.run_supervised_script(
+            android_launch_succeeds=True,
+            router_lifetime_seconds=6,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Android WampApp exited; relaunching", result.stdout)
+        self.assertIn("iOS WampApp exited; relaunching", result.stdout)
+        self.assertIn("router exited unexpectedly with status 9", result.stderr)
+        self.assertIn(
+            "shell am start -n dev.connectanum.wamp_app/.MainActivity",
+            adb_calls,
+        )
+        self.assertIn(
+            "simctl launch ios-simulator dev.connectanum.wampApp",
+            xcrun_calls,
+        )
+        self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
+        with socket.socket() as released:
+            released.bind(("127.0.0.1", port))
+
+    def test_interactive_lab_bounds_failed_android_relaunches(self):
+        result, adb_calls, _, port, elapsed = self.run_supervised_script(
+            android_launch_succeeds=False,
+            router_lifetime_seconds=30,
+        )
+
+        self.assertLess(elapsed, 15)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.count("Android WampApp exited; relaunching"), 3)
+        self.assertIn("could not be kept running", result.stderr)
+        self.assertIn("interactive router or client supervision failed", result.stderr)
+        self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
+        with socket.socket() as released:
+            released.bind(("127.0.0.1", port))
+
+    def test_interactive_lab_bounds_android_crash_loop(self):
+        result, adb_calls, _, port, elapsed = self.run_supervised_script(
+            android_launch_succeeds=True,
+            android_stays_running=False,
+            router_lifetime_seconds=30,
+        )
+
+        self.assertLess(elapsed, 15)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.count("Android WampApp exited; relaunching"), 3)
+        self.assertIn("Android WampApp exited repeatedly", result.stderr)
+        self.assertIn("interactive router or client supervision failed", result.stderr)
+        self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
+        with socket.socket() as released:
+            released.bind(("127.0.0.1", port))
+
+    def test_interactive_lab_bounds_failed_ios_relaunches(self):
+        result, adb_calls, _, port, elapsed = self.run_supervised_script(
+            android_launch_succeeds=True,
+            ios_launch_succeeds=False,
+            router_lifetime_seconds=30,
+        )
+
+        self.assertLess(elapsed, 15)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.count("iOS WampApp exited; relaunching"), 3)
+        self.assertIn("iOS WampApp could not be kept running", result.stderr)
+        self.assertIn("interactive router or client supervision failed", result.stderr)
+        self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
+        with socket.socket() as released:
+            released.bind(("127.0.0.1", port))
 
     def test_smoke_failure_forces_router_exit_and_removes_reverse(self):
         with socket.socket() as reservation:

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -168,6 +168,11 @@ class RunWampAppLabTests(unittest.TestCase):
                     "fi\n"
                     "exit 99\n"
                 ),
+                "open": (
+                    "#!/usr/bin/env bash\n"
+                    "printf 'open %s\\n' \"$*\" >>\"$WAMP_APP_TEST_XCRUN_LOG\"\n"
+                    "exit 0\n"
+                ),
             }
             for name, source in commands.items():
                 command = temporary / name
@@ -233,6 +238,10 @@ class RunWampAppLabTests(unittest.TestCase):
         self.assertIn("endpoint: ws://localhost:18081/ws", result.stdout)
         self.assertIn("Android emulator: emulator-5554", result.stdout)
         self.assertIn("iOS simulator: ios-simulator", result.stdout)
+        self.assertIn(
+            "open -a Simulator --args -CurrentDeviceUDID ios-simulator",
+            result.stdout,
+        )
         self.assertIn("--no-resident", result.stdout)
         self.assertEqual(result.stdout.count("WAMP_APP_SERVER_ADDRESS="), 2)
 
@@ -483,6 +492,10 @@ class RunWampAppLabTests(unittest.TestCase):
             "simctl launch ios-simulator dev.connectanum.wampApp",
             xcrun_calls,
         )
+        self.assertIn(
+            "open -a Simulator --args -CurrentDeviceUDID ios-simulator",
+            xcrun_calls,
+        )
         self.assertIn(f"reverse --remove tcp:{port}", adb_calls)
         with socket.socket() as released:
             released.bind(("127.0.0.1", port))
@@ -583,7 +596,7 @@ class RunWampAppLabTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
-                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls'\n"
+                    "  printf '%s\\n' '00:00 +0: verifies peer identities and exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls'\n"
                     "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -206,6 +206,18 @@ class RunWampAppLabTests(unittest.TestCase):
             "WAMP_APP_SMOKE_BACKUP_PASSPHRASE=backup-passphrase-ios-run-id",
             result.stdout,
         )
+        self.assertEqual(
+            result.stdout.count(
+                "WAMP_APP_SMOKE_RICH_MEDIA=rich-media-from-android-run-id"
+            ),
+            2,
+        )
+        self.assertEqual(
+            result.stdout.count(
+                "WAMP_APP_SMOKE_RICH_MEDIA_ACK=rich-media-opened-ios-run-id"
+            ),
+            2,
+        )
         self.assertEqual(result.stdout.count("android.permission.RECORD_AUDIO"), 1)
         self.assertEqual(result.stdout.count("android.permission.CAMERA"), 1)
         self.assertIn("simctl privacy ios-simulator grant microphone", result.stdout)
@@ -289,6 +301,7 @@ class RunWampAppLabTests(unittest.TestCase):
             temporary = pathlib.Path(temporary_directory)
             state = temporary / "state"
             adb_log = temporary / "adb.log"
+            runtime_tmp_log = temporary / "runtime-tmp.log"
             devices = [
                 {
                     "name": "Android Emulator",
@@ -328,7 +341,7 @@ class RunWampAppLabTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
-                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat, account controls, backup, and WebRTC calls'\n"
+                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat, rich media, controls, backup, and WebRTC calls'\n"
                     "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"
@@ -338,6 +351,7 @@ class RunWampAppLabTests(unittest.TestCase):
                     "#!/usr/bin/env bash\n"
                     "if [[ \"$1\" == pub && \"$2\" == get ]]; then exit 0; fi\n"
                     "if [[ \"$1\" == run && \"$2\" == wamp_app_server ]]; then\n"
+                    "  printf '%s\\n' \"$TMPDIR\" >\"$WAMP_APP_TEST_TMPDIR_LOG\"\n"
                     "  config=\"$4\"\n"
                     "  port=$(awk '/^  port:/ {print $2; exit}' \"$config\")\n"
                     "  exec python3 - \"$port\" <<'PY'\n"
@@ -382,6 +396,7 @@ class RunWampAppLabTests(unittest.TestCase):
             environment = os.environ.copy()
             environment["PATH"] = f"{temporary}:{environment['PATH']}"
             environment["WAMP_APP_TEST_ADB_LOG"] = str(adb_log)
+            environment["WAMP_APP_TEST_TMPDIR_LOG"] = str(runtime_tmp_log)
             started = time.monotonic()
             result = subprocess.run(
                 [
@@ -406,6 +421,10 @@ class RunWampAppLabTests(unittest.TestCase):
             adb_calls = adb_log.read_text(encoding="utf-8")
             self.assertIn("reverse tcp:", adb_calls)
             self.assertIn("reverse --remove tcp:", adb_calls)
+            self.assertEqual(
+                runtime_tmp_log.read_text(encoding="utf-8").strip(),
+                str(state / "runtime-tmp"),
+            )
             with socket.socket() as released:
                 released.bind(("127.0.0.1", port))
 

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -134,7 +134,27 @@ class RunWampAppLabTests(unittest.TestCase):
             ),
             2,
         )
-        self.assertEqual(result.stdout.count("--timeout 8m"), 2)
+        self.assertIn(
+            "WAMP_APP_SMOKE_CALL_READY_OUTBOUND=voice-ready-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CALL_READY_INBOUND=voice-ready-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CALL_READY_OUTBOUND=voice-ready-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_CALL_READY_INBOUND=voice-ready-android-run-id",
+            result.stdout,
+        )
+        self.assertEqual(result.stdout.count("android.permission.RECORD_AUDIO"), 1)
+        self.assertEqual(result.stdout.count("android.permission.CAMERA"), 1)
+        self.assertIn("simctl privacy ios-simulator grant microphone", result.stdout)
+        self.assertIn("simctl privacy ios-simulator grant camera", result.stdout)
+        self.assertEqual(result.stdout.count("--timeout 11m"), 2)
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):
@@ -242,7 +262,17 @@ class RunWampAppLabTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "if [[ \"$1\" == pub && \"$2\" == get ]]; then exit 0; fi\n"
+                    "if [[ \"$1\" == build && \"$2\" == apk ]]; then\n"
+                    "  mkdir -p build/app/outputs/flutter-apk\n"
+                    "  : >build/app/outputs/flutter-apk/app-debug.apk\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$1\" == build && \"$2\" == ios ]]; then\n"
+                    "  mkdir -p build/ios/iphonesimulator/Runner.app\n"
+                    "  exit 0\n"
+                    "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
+                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat and completes a WebRTC voice call'\n"
                     "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"
@@ -273,6 +303,19 @@ class RunWampAppLabTests(unittest.TestCase):
                 "adb": (
                     "#!/usr/bin/env bash\n"
                     "printf '%s\\n' \"$*\" >>\"$WAMP_APP_TEST_ADB_LOG\"\n"
+                ),
+                "xcrun": (
+                    "#!/usr/bin/env bash\n"
+                    "if [[ \"$1\" == simctl && \"$2\" == get_app_container ]]; then\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$1\" == simctl && \"$2\" == privacy ]]; then\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "if [[ \"$1\" == simctl && \"$2\" == install ]]; then\n"
+                    "  exit 0\n"
+                    "fi\n"
+                    "exit 99\n"
                 ),
             }
             for name, source in commands.items():

--- a/tool/test_run_wamp_app_lab.py
+++ b/tool/test_run_wamp_app_lab.py
@@ -206,6 +206,22 @@ class RunWampAppLabTests(unittest.TestCase):
             "WAMP_APP_SMOKE_BACKUP_PASSPHRASE=backup-passphrase-ios-run-id",
             result.stdout,
         )
+        self.assertIn(
+            "WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND=backup-restored-android-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND=backup-restored-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_BACKUP_RESTORED_OUTBOUND=backup-restored-ios-run-id",
+            result.stdout,
+        )
+        self.assertIn(
+            "WAMP_APP_SMOKE_BACKUP_RESTORED_INBOUND=backup-restored-android-run-id",
+            result.stdout,
+        )
         self.assertEqual(
             result.stdout.count(
                 "WAMP_APP_SMOKE_RICH_MEDIA=rich-media-from-android-run-id"
@@ -222,7 +238,7 @@ class RunWampAppLabTests(unittest.TestCase):
         self.assertEqual(result.stdout.count("android.permission.CAMERA"), 1)
         self.assertIn("simctl privacy ios-simulator grant microphone", result.stdout)
         self.assertIn("simctl privacy ios-simulator grant camera", result.stdout)
-        self.assertEqual(result.stdout.count("--timeout 22m"), 2)
+        self.assertEqual(result.stdout.count("--timeout 25m"), 2)
         self.assertNotIn("--no-resident", result.stdout)
 
     def test_dry_run_rejects_physical_devices(self):
@@ -341,7 +357,7 @@ class RunWampAppLabTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "if [[ \"$1\" == test ]]; then\n"
-                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat, rich media, controls, backup, and WebRTC calls'\n"
+                    "  printf '%s\\n' '00:00 +0: exchanges encrypted chat, rich media, controls, backup recovery, and WebRTC calls'\n"
                     "  [[ \" $* \" == *\" -d emulator-5554 \"* ]] && exit 7\n"
                     "  exit 0\n"
                     "fi\n"


### PR DESCRIPTION
## Summary
- extend the paired Android/iOS smoke through encrypted group stickers, view-once messages, video calls, account controls, rich media, profile/contact flows, and destructive encrypted cloud/local recovery
- harden native WebRTC state, asynchronous picker handling, compact layouts, WebSocket teardown, and the persistent interactive lab supervisor
- add local-only Standard, Ocean, and Sunset message-bubble designs selected independently per conversation and stored in the encrypted device vault/backups
- keep router evidence free of plaintext message bodies, raw media payloads, and local preference values

## Verification
- `bin/test-wamp-app`
- `bin/verify`
- paired Android API 35 and iOS 26.4 smoke evidence for the native flows; the new appearance recovery assertion is intentionally pending while the interactive tester lab remains active
- exact-head package dry run `33240068792`
- exact-head PR CI `33240068807` and push CI `33240067540`
- exact-head WampApp artifacts/benchmark run `33240067539`, including all seven bundles
- comprehensive feature-head deployment audit and protected-`master` strict audit
