### PR TITLE
Verify WampApp against hosted 3.0.0-beta.5 packages

### DIFF
--- a/bin/run-wamp-app-lab
+++ b/bin/run-wamp-app-lab
@@ -434,11 +434,12 @@ stop_process() {
 
   if owned_process_is_live "$pid"; then
     kill "$pid" 2>/dev/null || true
-    for attempt in 1 2 3 4 5; do
+    # Preserve the five-second TERM grace while noticing prompt exits quickly.
+    for attempt in {1..50}; do
       if ! owned_process_is_live "$pid"; then
         break
       fi
-      sleep 1
+      sleep 0.1
     done
     if owned_process_is_live "$pid"; then
       kill -9 "$pid" 2>/dev/null || true

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -1,6 +1,6 @@
 # WampApp Consumer Application
 
-Status: active; hosted beta.4 graph verified, beta.5 repair pending release
+Status: active; hosted beta.5 graph verified locally, hosted CI pending
 Started: 2026-08-24
 
 ## Goal
@@ -1059,3 +1059,9 @@ integration without private project assumptions.
   3-pass/64 MiB Argon2, encrypted reconnect/message delivery, and five 64 MiB
   memory/disk attachment iterations. This correction advances with the atomic
   hook and package-score repairs in synchronized beta.5.
+- 2026-08-31: The standalone client and server now resolve the exact hosted
+  beta.5 core, client, MCP, and router graph through committed lockfiles.
+  `bin/test-wamp-app` passes with the complete shared, server, Flutter, Chrome,
+  and release-web gates. The production validator passes all 28 application and
+  64 MiB attachment metrics, and repository-wide `bin/verify` passes. Hosted
+  branch evidence is next.

--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -1,6 +1,7 @@
 # WampApp Consumer Application
 
-Status: active; hosted beta.5 graph verified locally, hosted CI pending
+Status: active; hosted beta.5 graph verified locally and by exact-head CI,
+protected-master review pending
 Started: 2026-08-24
 
 ## Goal
@@ -1065,3 +1066,14 @@ integration without private project assumptions.
   and release-web gates. The production validator passes all 28 application and
   64 MiB attachment metrics, and repository-wide `bin/verify` passes. Hosted
   branch evidence is next.
+- 2026-08-31: Exact-head CI and packaging evidence is complete at `6c78f585`.
+  Both CI runs pass Fast Checks, WampApp Consumer, Full Verify, Dart VM Coverage,
+  and Codecov; WampApp Artifacts passes the production benchmark gate and builds
+  web, Android, unsigned iOS, macOS, Linux, Windows, and Linux-server bundles.
+  The hosted 28-metric benchmark reports 4.508 s onboarding p95, 2.524 s
+  reconnect p95, 93.741 ms accepted-message p95, 173.211 ms delivered-message
+  p95, 6.646 messages/s, and passing five-iteration 64 MiB memory/disk encrypted
+  attachment gates. PR #88 is clean and awaits the required independent review
+  before protected-master promotion; the release-candidate readiness audit is
+  intentionally scoped to the default branch and is not applicable to this
+  feature branch.

--- a/docs/exec-plans/2026-08-30-3.0.0-beta.5-release.md
+++ b/docs/exec-plans/2026-08-30-3.0.0-beta.5-release.md
@@ -67,10 +67,13 @@ visible on the `connectanum_bench` package page.
   `dart.konsultaner.de` in dependency order.
 - 2026-08-31: The beta.5 benchmark page renders the 78-workload Gbit/s matrix,
   its hosted archive contains the canonical example, and completed Pana analysis
-  awards `160/160`. The compatibility facade publish fails closed because its
-  pub.dev rule expects `v{{version}}` instead of the checked-in monorepo
-  convention `connectanum-v{{version}}`; its archive validates with zero
-  warnings.
+  awards `160/160`. After correcting its pub.dev tag rule to the checked-in
+  `connectanum-v{{version}}` convention, the compatibility facade publish passes
+  with zero warnings and `connectanum 3.0.0-beta.5` is indexed with the beta.5
+  client dependency.
 - 2026-08-31: WampApp now resolves the exact hosted beta.5 graph. Its complete
   app gate, 28-metric production validator, and repository-wide `bin/verify`
-  pass locally; hosted evidence remains.
+  pass locally. Exact-head CI, Codecov, the hosted production benchmark gate,
+  and all seven WampApp beta bundles pass at `6c78f585`; PR #88 now awaits the
+  required independent review before protected-master promotion and the
+  master-only release audit.

--- a/docs/exec-plans/2026-08-30-3.0.0-beta.5-release.md
+++ b/docs/exec-plans/2026-08-30-3.0.0-beta.5-release.md
@@ -60,3 +60,17 @@ visible on the `connectanum_bench` package page.
   FFI tests, 416 Dart core tests, 118 MCP tests, 474 router tests, isolated
   package consumers, live router-hosted MCP and remote-authentication smokes,
   zero-copy transfer coverage, and Chrome/Dart2Wasm SCRAM and WebSocket tests.
+- 2026-08-31: Protected master merge `4eb8a466` is green. The signed beta.5
+  native prerelease, fresh native install validation, and multi-architecture
+  router image with router-hosted MCP smoke pass. Core, client, MCP, router,
+  auth server, and benchmark beta.5 packages are published and indexed under
+  `dart.konsultaner.de` in dependency order.
+- 2026-08-31: The beta.5 benchmark page renders the 78-workload Gbit/s matrix,
+  its hosted archive contains the canonical example, and completed Pana analysis
+  awards `160/160`. The compatibility facade publish fails closed because its
+  pub.dev rule expects `v{{version}}` instead of the checked-in monorepo
+  convention `connectanum-v{{version}}`; its archive validates with zero
+  warnings.
+- 2026-08-31: WampApp now resolves the exact hosted beta.5 graph. Its complete
+  app gate, 28-metric production validator, and repository-wide `bin/verify`
+  pass locally; hosted evidence remains.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,16 +1,18 @@
 # Project State
 
-Last updated: 2026-08-30
-Current branch: `codex/wamp-app-beta4-hosted-graph`
+Last updated: 2026-08-31
+Current branch: `codex/wamp-app-beta5-hosted-graph`
 Current milestone: promote and publish the synchronized `3.0.0-beta.5` repair
-release. Native beta.4 artifacts and six modular packages are published, and
-all seven package pages are verified under `dart.konsultaner.de`. Publication
-of the compatibility facade remains blocked by its pub.dev automated tag rule,
-which must accept the monorepo tag `connectanum-v{{version}}`. The standalone
-consumer application resolves an exact hosted beta.4 graph from committed
-lockfiles and passes `bin/test-wamp-app`, including 56 shared tests, 145 server
-tests, 217 Flutter tests, Chrome worker coverage, endpoint smoke, and the
-release web build.
+release. Signed native beta.5 artifacts, the multi-architecture router image,
+and six modular beta.5 packages are published, and their package pages are
+verified under `dart.konsultaner.de`. Publication of the compatibility facade
+remains blocked by its pub.dev automated tag rule, which still expects
+`v{{version}}` and must accept the monorepo tag
+`connectanum-v{{version}}`. The standalone consumer application resolves the
+exact hosted beta.5 core, client, MCP, and router graph from committed lockfiles.
+`bin/test-wamp-app` passes with 56 shared tests, 145 server tests, 217 Flutter
+tests, Chrome worker coverage, endpoint smoke, and the release web build; the
+production validator also passes all 28 metrics.
 
 All seven Dart packages and three Rust crates now advance together to beta.5.
 Client and router hooks stage and atomically rename every configured, built, or
@@ -32,13 +34,17 @@ across production Argon2 onboarding/reconnect, encrypted delivery, and five
 at beta.5 with 138 native core tests, 90 FFI tests, 416 Dart core tests, 118 MCP
 tests, 474 router tests, isolated consumers, live router/MCP integration, remote
 authentication, zero-copy forwarding, and Chrome/Dart2Wasm coverage. Protected
-branch promotion, clean-tree package archives, native artifacts, dependency-
-ordered publication, and exact hosted beta.5 consumer verification remain.
+master promotion, clean-tree package archives, native artifacts, router-image
+publication, dependency-ordered publication of the six modular packages, and
+exact hosted beta.5 consumer verification are complete. The facade tag-rule
+correction, hosted repin evidence, and final deployment audit remain. The exact
+hosted-graph branch also passes the complete repository-wide `bin/verify` gate
+with formatting unchanged.
 
-The live pub.dev score API still reports client and router at 160/160 and the
-facade, core, MCP, auth server, and benchmarks at 150/160 because beta.4
-archives are immutable. The beta.5 archives contain the canonical entrypoints;
-updated scores can appear only after publication and Pana reanalysis.
+The beta.5 benchmark package page is live and renders the complete 78-workload
+Gbit/s matrix. Its published archive contains `README.md`,
+`analysis_options.yaml`, and `example/main.dart`; completed pub.dev Pana analysis
+awards `160/160`. Beta.4 remains immutable at 150/160.
 Onboarding now probes the configured router with a bounded anonymous WAMP
 handshake and presents debounced checking, ready, unreachable, and retry states
 without weakening registration validation. Stale and post-disposal probe

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -4,12 +4,10 @@ Last updated: 2026-08-31
 Current branch: `codex/wamp-app-beta5-hosted-graph`
 Current milestone: promote and publish the synchronized `3.0.0-beta.5` repair
 release. Signed native beta.5 artifacts, the multi-architecture router image,
-and six modular beta.5 packages are published, and their package pages are
-verified under `dart.konsultaner.de`. Publication of the compatibility facade
-remains blocked by its pub.dev automated tag rule, which still expects
-`v{{version}}` and must accept the monorepo tag
-`connectanum-v{{version}}`. The standalone consumer application resolves the
-exact hosted beta.5 core, client, MCP, and router graph from committed lockfiles.
+and all seven beta.5 packages are published, and their package pages are
+verified under `dart.konsultaner.de`. The standalone consumer application
+resolves the exact hosted beta.5 core, client, MCP, and router graph from
+committed lockfiles.
 `bin/test-wamp-app` passes with 56 shared tests, 145 server tests, 217 Flutter
 tests, Chrome worker coverage, endpoint smoke, and the release web build; the
 production validator also passes all 28 metrics.
@@ -37,9 +35,14 @@ authentication, zero-copy forwarding, and Chrome/Dart2Wasm coverage. Protected
 master promotion, clean-tree package archives, native artifacts, router-image
 publication, dependency-ordered publication of the six modular packages, and
 exact hosted beta.5 consumer verification are complete. The facade tag-rule
-correction, hosted repin evidence, and final deployment audit remain. The exact
-hosted-graph branch also passes the complete repository-wide `bin/verify` gate
-with formatting unchanged.
+correction and compatibility-facade publication are also complete. Exact-head
+hosted repin evidence is complete at `6c78f585`: both CI runs are fully green,
+the production benchmark gate passes all 28 checks, and all seven WampApp beta
+bundles build successfully. The branch-scoped strict deployment checks pass;
+release-candidate readiness correctly remains unavailable until PR #88 receives
+the required independent review, lands on protected `master`, and the
+master-only release workflows and audit run. The exact hosted-graph branch also
+passes the complete repository-wide `bin/verify` gate with formatting unchanged.
 
 The beta.5 benchmark package page is live and renders the complete 78-workload
 Gbit/s matrix. Its published archive contains `README.md`,

--- a/examples/wamp_app/README.md
+++ b/examples/wamp_app/README.md
@@ -65,7 +65,7 @@ The implemented slices provide:
   exact allowlist and no chat, key, backup, or attachment disclosure;
 - bounded anonymous registration, control-operation, and binary-transfer abuse
   guards, plus six-device live conflict stress;
-- hosted `3.0.0-beta.2` dependencies for both client and server; and
+- hosted `3.0.0-beta.5` dependencies for both client and server; and
 - end-to-end tests covering registration, device trust, encrypted two-account
   and group delivery, attachment authorization/resume, receipt propagation,
   reconnect deduplication, server-signature verification, and plaintext

--- a/examples/wamp_app/client/pubspec.lock
+++ b/examples/wamp_app/client/pubspec.lock
@@ -133,34 +133,34 @@ packages:
     dependency: "direct main"
     description:
       name: connectanum_client
-      sha256: "26f316929d846903829fe7340c08ea431e3ea2ed2c25353b394145b65f6bed4d"
+      sha256: db4f8b43bc4e15bf38215f22e4c461dc14a474c57f6016e22551bd1780e2d780
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   connectanum_core:
     dependency: "direct main"
     description:
       name: connectanum_core
-      sha256: "835b203692f10a238c2abbdc592554c914966e34513a15def91157c199752fbf"
+      sha256: "57c0aa7d0c19e9a4592d603ec3c409154f7efd9abae1a1eb90cfbcb1eb113c91"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   connectanum_mcp:
     dependency: transitive
     description:
       name: connectanum_mcp
-      sha256: "9cc9cc549277ca25aed08888ac846e3b3a6405ce953cf8ab5cbd707a69392602"
+      sha256: "537246c118d105dc6614aee2443c2fb5b55c901981869c81cffa49e17e4cf729"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   connectanum_router:
     dependency: transitive
     description:
       name: connectanum_router
-      sha256: "332b614a5634e9ed85a585c7be780afef911013a2ff5ec4601d1b2a6e331b8c0"
+      sha256: a658949e1984d773363136265113a7749cbfb3fac55d16cc846c607d076921e6
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   convert:
     dependency: transitive
     description:

--- a/examples/wamp_app/client/pubspec.yaml
+++ b/examples/wamp_app/client/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 
 dependencies:
   audioplayers: ^6.8.1
-  connectanum_client: 3.0.0-beta.4
-  connectanum_core: 3.0.0-beta.4
+  connectanum_client: 3.0.0-beta.5
+  connectanum_core: 3.0.0-beta.5
   crypto: ^3.0.7
   cryptography: ^2.9.0
   cryptography_flutter: ^2.3.4

--- a/examples/wamp_app/server/pubspec.lock
+++ b/examples/wamp_app/server/pubspec.lock
@@ -85,34 +85,34 @@ packages:
     dependency: "direct main"
     description:
       name: connectanum_client
-      sha256: "26f316929d846903829fe7340c08ea431e3ea2ed2c25353b394145b65f6bed4d"
+      sha256: db4f8b43bc4e15bf38215f22e4c461dc14a474c57f6016e22551bd1780e2d780
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   connectanum_core:
     dependency: "direct main"
     description:
       name: connectanum_core
-      sha256: "835b203692f10a238c2abbdc592554c914966e34513a15def91157c199752fbf"
+      sha256: "57c0aa7d0c19e9a4592d603ec3c409154f7efd9abae1a1eb90cfbcb1eb113c91"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   connectanum_mcp:
     dependency: transitive
     description:
       name: connectanum_mcp
-      sha256: "9cc9cc549277ca25aed08888ac846e3b3a6405ce953cf8ab5cbd707a69392602"
+      sha256: "537246c118d105dc6614aee2443c2fb5b55c901981869c81cffa49e17e4cf729"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   connectanum_router:
     dependency: "direct main"
     description:
       name: connectanum_router
-      sha256: "332b614a5634e9ed85a585c7be780afef911013a2ff5ec4601d1b2a6e331b8c0"
+      sha256: a658949e1984d773363136265113a7749cbfb3fac55d16cc846c607d076921e6
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-beta.4"
+    version: "3.0.0-beta.5"
   convert:
     dependency: transitive
     description:

--- a/examples/wamp_app/server/pubspec.yaml
+++ b/examples/wamp_app/server/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   args: ^2.7.0
-  connectanum_client: 3.0.0-beta.4
-  connectanum_core: 3.0.0-beta.4
-  connectanum_router: 3.0.0-beta.4
+  connectanum_client: 3.0.0-beta.5
+  connectanum_core: 3.0.0-beta.5
+  connectanum_router: 3.0.0-beta.5
   crypto: ^3.0.7
   googleapis_auth: ^2.3.3
   http: ^1.6.0


### PR DESCRIPTION
## Summary
- pin the standalone WampApp client and server to exact hosted `3.0.0-beta.5` packages
- commit the pub.dev integrity hashes for core, client, MCP, and router
- record the live `connectanum_bench` 160/160 score and published 78-workload Gbit/s README

## Verification
- `bin/test-wamp-app`
- `bin/wamp-app-production-validate` (28/28 metrics)
- `bin/verify`
- `git diff --check`