### PR TITLE
fix(router): authorize WAMP Meta discovery per target action

### DIFF
--- a/docs/exec-plans/2026-08-24-wamp-app.md
+++ b/docs/exec-plans/2026-08-24-wamp-app.md
@@ -1,7 +1,7 @@
 # WampApp Consumer Application
 
-Status: active; consumer UX hardening is being promoted to master and packaged
-for beta testers on the hosted beta.5 graph
+Status: active; consumer UX hardening is published on master with all seven
+beta bundles, green hosted CI, and strict deployment audit on the beta.5 graph
 Started: 2026-08-24
 
 ## Goal
@@ -1141,3 +1141,19 @@ integration without private project assumptions.
   Revisit this temporary compatibility define when upstream adopts standard
   coroutines. All six other bundles and all 28 benchmark checks pass at
   `1db5edb6`, as does refreshed local `bin/verify`.
+- 2026-09-07: Promotion and beta packaging are complete at `a5613d17` on
+  both master remotes. CI `34102845220` passes all four jobs; WampApp Artifacts
+  `34102845216` passes every client/server build and all 28 production
+  benchmark checks. Windows job `101681015702` successfully builds the app
+  with current MSVC and the scoped compatibility shim. Web and Windows
+  artifact checksums and clean-tree manifests match the final head. Local
+  `bin/test-fast`, `bin/test-wamp-app`, and refreshed `bin/verify` pass, with
+  ten packaging regressions. The strict audit passes with
+  `--require-clean-latest-ci --require-clean-latest-ci-logs
+  --require-workflows-visible --require-router-package` and unchanged branch
+  protections. Packages remain at hosted `3.0.0-beta.5`; artifacts are beta
+  testing bundles, not app-store/live-service deployment. Windows Hello
+  hardware validation remains distinct from successful hosted compilation.
+  Post-deployment evidence notes were held for the next implementation commit
+  and are bundled with the Meta discovery authorization fix, per the
+  no-docs-only-bookkeeping-commit policy.

--- a/docs/exec-plans/2026-09-09-meta-discovery-authorization.md
+++ b/docs/exec-plans/2026-09-09-meta-discovery-authorization.md
@@ -1,0 +1,72 @@
+# Meta Discovery Authorization
+
+Status: implementation verified; branch publication requested, master integration and package release pending
+Started: 2026-09-09
+Completed: 2026-09-09
+
+## Contract
+
+The user requires registration Meta discovery to disclose only callable
+procedures and subscription Meta discovery to disclose only subscribable
+topics. Permission to invoke a Meta procedure is not a grant to discover all
+realm entities. Publishing alone must not expose subscription metadata.
+
+The [WAMP Meta API specification](https://wamp-proto.org/wamp_latest_ietf.html)
+defines list/lookup/match/get and participant/count procedures. It describes
+publisher use cases for subscription introspection; subscribe-only visibility
+is this router's explicitly requested stricter policy, not a universal
+WAMP protocol requirement. Preserve existing response shapes and make hidden
+IDs indistinguishable from missing IDs through the related Meta endpoints.
+
+## Work
+
+1. Reproduce publish-only subscription visibility on real WebSocket,
+   RawSocket, router-hosted MCP direct JSON, and Streamable HTTP connections.
+2. Require subscribe permission for live and configured subscription Meta
+   snapshots, including the correct match policy for dynamic authorization.
+3. Remove the configured documentation-only registration authorization bypass
+   in MCP Meta snapshots. Leave explicitly configured general API documentation
+   catalogs outside this change; those are not WAMP registration Meta results.
+4. Exercise static grants/denies, dynamic denials, pattern subscriptions,
+   related Meta lookup/detail/count methods, and authorized positive controls.
+5. Run focused tests and analysis, local review, and `bin/verify` sequentially
+   after the baseline `bin/test-fast`. Do not overlap native runtime test gates.
+
+## Progress
+
+- Initial inspection: live registration snapshots already check `call`.
+  WAMP and MCP subscription snapshots use `publish OR subscribe`. Configured
+  MCP registration snapshots skip authorization when `allow_call` is false.
+  Subscription visibility also omits match-policy context for dynamic checks.
+- Baseline `bin/test-fast` passed before implementation. All eight live-router
+  regressions then failed on unauthorized subscription IDs across WebSocket,
+  RawSocket, MCP direct JSON, and MCP Streamable HTTP, under both static and
+  dynamic policies. The initial standalone run skipped without a resolved
+  native library; the red and green runs explicitly loaded the ffi-test library.
+- Implemented subscribe-only visibility and dynamic match-policy context on
+  both paths, plus call authorization for configured MCP registration entries.
+  All eight regressions now pass, including authorized positive controls,
+  publish-only and register-only callers, explicit and dynamic denials,
+  exact/prefix/wildcard subscriptions, configured entries, and hidden-ID parity.
+- Router analysis and the combined 122-test Meta/session/auth suite pass.
+  Local semantic review completed; source checks confirmed catalog separation,
+  exhaustive match-policy conversion, and existing static/dynamic precedence
+  coverage. No actionable production-code finding remained.
+- The first full `bin/verify` run exposed a legacy MCP smoke expectation that
+  anonymously disclosed a configured registration without call permission.
+  That smoke now requires the ID to stay hidden publicly, while an authorized
+  member retains synthetic ID/list/get/callee coverage. An ID learned by the
+  member must also remain hidden when used on the public endpoint. The separate
+  explicitly configured documentation catalog remains visible as before.
+  The updated smoke passes independently and in the complete verification gate.
+- Final `bin/verify` passes: 482 router tests (including all eight new discovery
+  cases), six isolated remote-auth tests, 13 zero-copy tests, 124 benchmark tests,
+  isolated package/live MCP consumer smokes, and Chrome/Dart2Wasm SCRAM and
+  WebSocket coverage. Router analysis and `git diff --check` are clean. The
+  test-only follow-up review was checked against the intentional nondisclosure
+  contract and existing helper behavior; no actionable issue remained.
+- The user requested a commit and push of the verified security branch.
+  Published beta.5 consumers still require master integration and a synchronized
+  release to receive this fix; pushing this branch does not publish packages.
+  Resume the broader WampApp plan without treating this source verification as
+  evidence of a package publication or deployment.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,8 +1,31 @@
 # Project State
 
-Last updated: 2026-09-07
-Current branch: `master`
-Current milestone: harden the standalone WampApp as a consumer-facing
+Last updated: 2026-09-09
+Current branch: `codex/meta-discovery-authorization`
+Current milestone: the WAMP Meta discovery authorization fix is implemented
+and locally verified. Its completed plan is
+`docs/exec-plans/2026-09-09-meta-discovery-authorization.md`; the broader active
+consumer plan remains `docs/exec-plans/2026-08-24-wamp-app.md`.
+Live WebSocket, RawSocket, MCP direct JSON, and
+MCP Streamable HTTP regressions reproduced subscription disclosure to callers
+with publish permission but no subscribe permission. Subscription snapshots now
+require subscribe permission, with exact/prefix/wildcard match context forwarded
+to dynamic authorization. Configured MCP registration snapshots no longer skip
+call authorization for documentation-only entries. Related lookup, match, get,
+participant, and count methods retain the same filtered view and existing wire
+shapes. General explicitly configured API documentation catalogs are unchanged.
+Baseline `bin/test-fast`, router analysis, and 122 focused live Meta/session/auth
+tests pass. Local semantic review is complete. The first `bin/verify` run found
+one obsolete MCP smoke expectation for the configured-registration bypass;
+it now checks public nondisclosure and authorized-member visibility. The final
+`bin/verify` rerun passes, including all 482 router tests, six isolated remote-auth
+tests, 13 zero-copy tests, package-consumer and live MCP smokes, 124 benchmark
+tests, and Chrome/Dart2Wasm coverage. This source fix is isolated on the security
+branch; integration into master and the next synchronized beta release are
+still required before published-package consumers receive it. Branch publication
+does not publish packages. The beta.5 packages are unchanged.
+
+Previous milestone: harden the standalone WampApp as a consumer-facing
 application on top of the merged and published `3.0.0-beta.5` graph. The main
 shell now keeps protocol and endpoint details out of the conversation flow and
 offers dedicated Settings and technical-information screens. Account-encrypted
@@ -25,21 +48,29 @@ router/MCP consumer smokes, benchmark integration, package smokes, and Chrome
 Dart2Wasm SCRAM worker coverage.
 
 The consumer settings, biometric sign-in, localization, and accessible accent
-work are merged into both `master` remotes at `f63dbe3d`. Fresh local
-`bin/test-fast`, `bin/test-wamp-app`, and `bin/verify` gates pass. Hosted
-WampApp run `34099558143` passes all 28 production benchmark checks and six
-bundles, including the repaired Linux secure-storage build. Windows exposed
-the biometric plugin's obsolete `/await` flag under current MSVC; the
-first flag-only correction at `1db5edb6` exposed an upstream nonstandard
-coroutine return (C3773). The application now preserves the plugin's legacy
-coroutine behavior and applies Microsoft's deprecation compatibility define
-only to that target while it still uses `/await`, with an isolation and
-idempotence regression. Final hosted Windows, CI, and strict audit evidence
-remain required before declaring all seven beta bundles published.
-The public Connectanum package graph
-remains at `3.0.0-beta.5`; this application-only update does not change library
-release inputs. Fresh local verification, hosted CI, production benchmark
-gates, and the strict deployment audit are required for the promotion handoff.
+work and platform packaging fixes are merged into both `master` remotes at
+`a5613d17`. Local `bin/test-fast`, `bin/test-wamp-app`, and final `bin/verify`
+gates pass, including all ten packaging regressions. Hosted
+[CI run 34102845220](https://github.com/konsultaner/connectanum-dart/actions/runs/34102845220)
+passes all four jobs, including Full Verify and Dart VM Coverage. Hosted
+[WampApp run 34102845216](https://github.com/konsultaner/connectanum-dart/actions/runs/34102845216)
+publishes all six client bundles and the Linux server, with all 28 production
+benchmark checks passing. Downloaded web and Windows archives have verified
+SHA-256 checksums and clean-tree manifests matching the release head. Windows
+includes the app, Connectanum native, biometric, and secure-storage DLLs.
+The strict deployment audit passes baseline protection, workflow visibility,
+router package visibility, exact-head CI, and clean CI logs. These are beta
+testing artifacts retained for 14 days, not app-store or live-service releases.
+The public Connectanum package graph remains at `3.0.0-beta.5`; this
+application-only update does not change library release inputs.
+
+Linux packaging now installs libsecret development headers. Windows preserves
+the upstream biometric plugin's legacy coroutine behavior using Microsoft's
+deprecation compatibility define only on the affected MSVC target while it
+still uses `/await`. The initially attempted flag removal exposed an upstream
+nonstandard coroutine return (C3773), so retain the scoped compatibility shim
+until upstream adopts standard coroutines. Hosted compilation is proven;
+Windows Hello hardware interaction was not exercised on the macOS host.
 
 All seven Dart packages and three Rust crates now advance together to beta.5.
 Client and router hooks stage and atomically rename every configured, built, or
@@ -445,7 +476,7 @@ dedicated Web Worker, while existing XSalsa20-Poly1305 v1 attachments remain
 readable. Server attachment storage is now
 bounded by configurable global and per-sender ciphertext quotas, reconciled on
 startup, and pruned by staged TTL without racing mailbox commits.
-The active plan is `docs/exec-plans/2026-08-24-wamp-app.md`.
+The active consumer UX plan is `docs/exec-plans/2026-08-24-wamp-app.md`.
 
 WampApp lives under `examples/wamp_app` as standalone client, server, and shared
 protocol packages. The server and Flutter client resolve the public
@@ -27298,7 +27329,8 @@ at the older `47bbf9c` commit.
 
 ## Active Plan
 
-- There is no active execution plan. The most recently completed MCP
+- See the current milestone at the top of this file for the active plan.
+  The following entries retain historical verification evidence. The completed MCP
   downstream-readiness plan is
   `docs/exec-plans/2026-08-17-mcp-grant-runtime-expiry-enforcement.md`. It closes
   the post-construction lifetime gap for router HTTP-auth and OAuth grant-aware

--- a/packages/connectanum_router/lib/src/router/router_instance/router_mcp.dart
+++ b/packages/connectanum_router/lib/src/router/router_instance/router_mcp.dart
@@ -5410,7 +5410,12 @@ class _RouterMcpEndpoint {
     );
   }
 
-  Future<bool> _isAuthorized(AuthorizationAction action, String uri) async {
+  Future<bool> _isAuthorized(
+    AuthorizationAction action,
+    String uri, {
+    PermissionMatchPolicy? targetMatchPolicy,
+    Map<String, Object?> options = const {},
+  }) async {
     if (isDisposed) {
       return false;
     }
@@ -5439,6 +5444,8 @@ class _RouterMcpEndpoint {
           authMethod: session.authMethod,
           authProvider: session.authProvider,
           isInternal: session.authorizationIsInternal,
+          targetMatchPolicy: targetMatchPolicy,
+          options: options,
         ),
       );
       return !isDisposed && decision.allowed;
@@ -5674,8 +5681,7 @@ class _RouterMcpEndpoint {
       if (visibleExactProcedures.contains(procedure.procedure)) {
         continue;
       }
-      if (procedure.allowCall &&
-          !await _isAuthorized(AuthorizationAction.call, procedure.procedure)) {
+      if (!await _isAuthorized(AuthorizationAction.call, procedure.procedure)) {
         continue;
       }
       visible.add(
@@ -5696,15 +5702,15 @@ class _RouterMcpEndpoint {
   ) async {
     final visible = <SubscriptionSnapshot>[];
     for (final subscription in subscriptions) {
-      final canPublish = await _isAuthorized(
-        AuthorizationAction.publish,
-        subscription.topic,
-      );
       final canSubscribe = await _isAuthorized(
         AuthorizationAction.subscribe,
         subscription.topic,
+        targetMatchPolicy: _permissionMatchPolicyFromTopic(
+          subscription.matchPolicy,
+        ),
+        options: {'match': _topicMatchPolicyName(subscription.matchPolicy)},
       );
-      if (canPublish || canSubscribe) {
+      if (canSubscribe) {
         visible.add(subscription);
       }
     }
@@ -5731,13 +5737,15 @@ class _RouterMcpEndpoint {
       if (visibleExactTopics.contains(topic.topic)) {
         continue;
       }
-      final canPublish =
-          topic.allowPublish &&
-          await _isAuthorized(AuthorizationAction.publish, topic.topic);
       final canSubscribe =
           topic.allowSubscribe &&
-          await _isAuthorized(AuthorizationAction.subscribe, topic.topic);
-      if (!canPublish && !canSubscribe) {
+          await _isAuthorized(
+            AuthorizationAction.subscribe,
+            topic.topic,
+            targetMatchPolicy: PermissionMatchPolicy.exact,
+            options: const {'match': 'exact'},
+          );
+      if (!canSubscribe) {
         continue;
       }
       visible.add(

--- a/packages/connectanum_router/lib/src/router/router_instance/router_worker_session.dart
+++ b/packages/connectanum_router/lib/src/router/router_instance/router_worker_session.dart
@@ -1337,19 +1337,17 @@ Future<List<SubscriptionSnapshot>> _visibleMetaSubscriptionsForState(
 }) async {
   final visible = <SubscriptionSnapshot>[];
   for (final subscription in subscriptions) {
-    final canPublish = await _stateActionAuthorized(
-      state: state,
-      connectionId: connectionId,
-      action: AuthorizationAction.publish,
-      uri: subscription.topic,
-    );
     final canSubscribe = await _stateActionAuthorized(
       state: state,
       connectionId: connectionId,
       action: AuthorizationAction.subscribe,
       uri: subscription.topic,
+      targetMatchPolicy: _permissionMatchPolicyFromTopic(
+        subscription.matchPolicy,
+      ),
+      options: {'match': _topicMatchPolicyName(subscription.matchPolicy)},
     );
-    if (canPublish || canSubscribe) {
+    if (canSubscribe) {
       visible.add(subscription);
     }
   }
@@ -1361,6 +1359,8 @@ Future<bool> _stateActionAuthorized({
   required int connectionId,
   required AuthorizationAction action,
   required String uri,
+  PermissionMatchPolicy? targetMatchPolicy,
+  Map<String, Object?> options = const {},
 }) async {
   final realmSettings = state.realmSettings;
   final realmUri = state.realmUri;
@@ -1381,6 +1381,8 @@ Future<bool> _stateActionAuthorized({
     authMethod: welcomeDetails?.authmethod ?? state.authMethod,
     authProvider: welcomeDetails?.authprovider,
     protocol: state.protocol ?? state.listenerSettings.primaryProtocol,
+    targetMatchPolicy: targetMatchPolicy,
+    options: options,
     isInternal: false,
   );
   return decision.allowed;

--- a/packages/connectanum_router/test/meta_discovery_authorization_test.dart
+++ b/packages/connectanum_router/test/meta_discovery_authorization_test.dart
@@ -1,0 +1,414 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+
+import 'package:connectanum_client/connectanum.dart' as client;
+import 'package:connectanum_client/mcp.dart' as mcp;
+import 'package:connectanum_client/src/transport/socket/socket_helper.dart';
+import 'package:connectanum_client/src/transport/socket/socket_transport.dart'
+    as socket_transport;
+import 'package:connectanum_core/connectanum_core.dart' as core;
+import 'package:connectanum_core/src/serializer/json/serializer.dart'
+    as json_serializer;
+import 'package:connectanum_router/connectanum_router.dart';
+import 'package:test/test.dart';
+
+import 'support/native_lib.dart';
+
+typedef _MetaResult = ({List<Object?> args, Map<String, Object?> details});
+typedef _MetaCall =
+    Future<_MetaResult> Function(String procedure, List<Object?> arguments);
+
+void main() {
+  setUpAll(
+    () => AuthorizationProviderFactoryRegistry.registerFactory(
+      const _MetaPolicyFactory(),
+    ),
+  );
+  tearDownAll(
+    () => AuthorizationProviderFactoryRegistry.unregisterFactory('meta-policy'),
+  );
+  final nativeLib = resolveOrBuildNativeLib();
+  for (final dynamicPolicy in [false, true]) {
+    for (final transport in [
+      'websocket',
+      'rawsocket',
+      'mcp-json',
+      'mcp-stream',
+    ]) {
+      test(
+        '$transport Meta discovery enforces ${dynamicPolicy ? 'dynamic' : 'static'} action permissions',
+        () async {
+          final runtime = NativeTransportRuntime(libraryPath: nativeLib)
+            ..start();
+          addTearDown(() {
+            runtime.shutdown();
+            runtime.dispose();
+          });
+          final binding = Router(
+            RouterConfig(
+              endpoints: [
+                Endpoint(
+                  host: '127.0.0.1',
+                  port: 0,
+                  tlsMode: TlsMode.disabled,
+                  maxRawSocketSizeExponent: 16,
+                  webSocketPath: '/ws',
+                ),
+              ],
+            ),
+            settings: _settings(dynamicPolicy),
+          ).start(runtime, workerEntryPoint: _workerEntryPoint);
+          addTearDown(binding.dispose);
+          final service = await binding.createInternalSession(
+            realmUri: 'realm1',
+            authId: 'service',
+            authRole: 'service',
+          );
+          addTearDown(service.close);
+
+          final registrations = <String, int>{};
+          final subscriptions = <String, int>{};
+          for (final scope in ['allowed', 'blocked', 'write', 'dynamic']) {
+            final registered = await service.register('app.$scope.procedure');
+            registrations[scope] = registered.registrationId;
+            registered.onInvoke(
+              (invocation) => invocation.respondWith(arguments: ['ok']),
+            );
+            final subscribed = await service.subscribe('app.$scope.topic');
+            subscriptions[scope] = subscribed.subscriptionId;
+          }
+          final patterns = <String, int>{};
+          for (final match in ['exact', 'prefix', 'wildcard']) {
+            final subscription = await service.subscribe(
+              match == 'wildcard' ? 'app.pattern.' : 'app.pattern',
+              options: core.SubscribeOptions(match: match),
+            );
+            patterns[match] = subscription.subscriptionId;
+          }
+
+          final port = binding.listeners.single.port;
+          late final _MetaCall call;
+          if (transport.startsWith('mcp')) {
+            final http = mcp.McpStreamableHttpClient(
+              Uri.parse('http://127.0.0.1:$port/mcp'),
+            );
+            addTearDown(() => http.close(force: true));
+            final direct = transport == 'mcp-json';
+            if (!direct) await http.initialize();
+            call = (procedure, arguments) async {
+              final result = await http.callWampMetaProcedure(
+                procedure,
+                arguments: arguments,
+                directJson: direct,
+              );
+              return (
+                args: result.arguments,
+                details: result.argumentsKeywords,
+              );
+            };
+          } else {
+            final peer = client.Client(
+              realm: 'realm1',
+              transport: transport == 'websocket'
+                  ? client.WebSocketTransport.withJsonSerializer(
+                      'ws://127.0.0.1:$port/ws',
+                    )
+                  : socket_transport.SocketTransport(
+                      '127.0.0.1',
+                      port,
+                      json_serializer.Serializer(),
+                      SocketHelper.serializationJson,
+                    ),
+            );
+            final session = await peer.connect().first.timeout(
+              const Duration(seconds: 10),
+            );
+            addTearDown(session.close);
+            // Meta-call permission is not permission to use the discovered URI.
+            await expectLater(
+              session.subscribe('app.write.topic'),
+              throwsA(
+                isA<core.Error>().having(
+                  (e) => e.error,
+                  'error',
+                  core.Error.notAuthorized,
+                ),
+              ),
+            );
+            await session.publish(
+              'app.write.topic',
+              options: core.PublishOptions(acknowledge: true),
+            );
+            await expectLater(
+              session.call('app.write.procedure').first,
+              throwsA(
+                isA<core.Error>().having(
+                  (e) => e.error,
+                  'error',
+                  core.Error.notAuthorized,
+                ),
+              ),
+            );
+            expect(
+              (await session.call('app.allowed.procedure').first).arguments,
+              ['ok'],
+            );
+            await session.subscribe('app.allowed.topic');
+            call = (procedure, arguments) async {
+              try {
+                final result = await session
+                    .call(procedure, arguments: arguments)
+                    .first;
+                final args = List<Object?>.from(result.arguments ?? const []);
+                if (args.length == 1 && args.single is Map) {
+                  return (
+                    args: const [],
+                    details: Map<String, Object?>.from(args.single as Map),
+                  );
+                }
+                return (args: args, details: <String, Object?>{});
+              } on core.Error catch (error) {
+                return (args: [error.error], details: <String, Object?>{});
+              }
+            };
+          }
+
+          for (final kind in ['registration', 'subscription']) {
+            final ids = kind == 'registration' ? registrations : subscriptions;
+            final uriSuffix = kind == 'registration' ? 'procedure' : 'topic';
+            final listing = await call('wamp.$kind.list', []);
+            final exact = (listing.details['exact'] as List).cast<int>();
+            expect(exact, contains(ids['allowed']));
+            expect(exact, isNot(contains(ids['blocked'])));
+            expect(exact, isNot(contains(ids['write'])));
+            expect(exact.contains(ids['dynamic']), !dynamicPolicy);
+            final allowedDetails = await call('wamp.$kind.get', [
+              ids['allowed'],
+            ]);
+            expect(allowedDetails.details['uri'], 'app.allowed.$uriSuffix');
+            for (final method in ['lookup', 'match']) {
+              final allowed = await call('wamp.$kind.$method', [
+                'app.allowed.$uriSuffix',
+              ]);
+              expect(
+                allowed.args.expand(
+                  (value) => value is List ? value : [value],
+                ),
+                contains(ids['allowed']),
+              );
+            }
+            for (final scope in [
+              'blocked',
+              'write',
+              if (dynamicPolicy) 'dynamic',
+            ]) {
+              for (final method in ['lookup', 'match']) {
+                final result = await call('wamp.$kind.$method', [
+                  'app.$scope.$uriSuffix',
+                ]);
+                expect(result.args.where((value) => value != null), isEmpty);
+              }
+              // Guessing an ID must not distinguish a denied entry from absence.
+              for (final method in [
+                'get',
+                kind == 'registration' ? 'list_callees' : 'list_subscribers',
+                kind == 'registration' ? 'count_callees' : 'count_subscribers',
+              ]) {
+                final denied = await call('wamp.$kind.$method', [ids[scope]]);
+                final missing = await call('wamp.$kind.$method', [
+                  9007199254740990,
+                ]);
+                expect(denied.args, equals(missing.args));
+                expect(denied.details, equals(missing.details));
+              }
+            }
+          }
+          final subscriptionList = await call('wamp.subscription.list', []);
+          expect(
+            subscriptionList.details['exact'],
+            contains(patterns['exact']),
+          );
+          for (final match in ['prefix', 'wildcard']) {
+            expect(
+              (subscriptionList.details[match] as List).contains(
+                patterns[match],
+              ),
+              !dynamicPolicy,
+            );
+          }
+          if (transport.startsWith('mcp')) {
+            for (final entry in [
+              ('registration', 'app.blocked.documented'),
+              ('subscription', 'app.write.configured'),
+              ('subscription', 'app.allowed.disabled'),
+            ]) {
+              final result = await call('wamp.${entry.$1}.lookup', [entry.$2]);
+              expect(result.args, isEmpty);
+            }
+            final allowed = await call('wamp.subscription.lookup', [
+              'app.allowed.configured',
+            ]);
+            expect(allowed.args, hasLength(1));
+          }
+        },
+        skip: nativeLib == null ? 'Native transport library unavailable' : null,
+        timeout: const Timeout(Duration(seconds: 60)),
+      );
+    }
+  }
+}
+
+RouterSettings _settings(bool dynamicPolicy) {
+  final realm = RealmSettingsBuilder('realm1')
+    ..addAuthMethod('anonymous')
+    ..addRoleFromBuilder(
+      RoleSettingsBuilder('service')..addPermissionFromBuilder(
+        PermissionSettingsBuilder('')
+          ..setMatchPolicy(PermissionMatchPolicy.prefix)
+          ..allowOperations([
+            'call',
+            'register',
+            'unregister',
+            'subscribe',
+            'unsubscribe',
+            'publish',
+          ]),
+      ),
+    )
+    ..addRoleFromBuilder(
+      RoleSettingsBuilder('anonymous')
+        ..addPermissionFromBuilder(
+          PermissionSettingsBuilder('wamp.')
+            ..setMatchPolicy(PermissionMatchPolicy.prefix)
+            ..allowOperations(['call']),
+        )
+        ..addPermissionFromBuilder(
+          PermissionSettingsBuilder('app.')
+            ..setMatchPolicy(PermissionMatchPolicy.prefix)
+            ..allowOperations(['publish', 'register']),
+        )
+        ..addPermissionFromBuilder(
+          PermissionSettingsBuilder('app.blocked.')
+            ..setMatchPolicy(PermissionMatchPolicy.prefix)
+            ..denyOperations(['call', 'subscribe']),
+        )
+        ..addPermissionFromBuilder(
+          PermissionSettingsBuilder('app.allowed.')
+            ..setMatchPolicy(PermissionMatchPolicy.prefix)
+            ..allowOperations(['call', 'subscribe']),
+        )
+        ..addPermissionFromBuilder(
+          PermissionSettingsBuilder('app.dynamic.')
+            ..setMatchPolicy(PermissionMatchPolicy.prefix)
+            ..allowOperations(['call', 'subscribe']),
+        )
+        ..addPermissionFromBuilder(
+          PermissionSettingsBuilder('app.pattern')
+            ..setMatchPolicy(PermissionMatchPolicy.prefix)
+            ..allowOperations(['subscribe']),
+        ),
+    );
+  if (dynamicPolicy) realm.setAuthorizationProvider('meta-policy');
+  return (RouterSettingsBuilder()
+        ..addRealmFromBuilder(realm)
+        ..addAuthorizationProvider(
+          'meta-policy',
+          const AuthorizationProviderDefinition(type: 'meta-policy'),
+        )
+        ..addSessionProfileFromBuilder(
+          SessionProfileSettingsBuilder('mcp')
+            ..setRealm('realm1')
+            ..addAuthMethod('anonymous'),
+        )
+        ..addListenerFromBuilder(
+          ListenerSettingsBuilder('mixed', '127.0.0.1:0')
+            ..addAuthMethod('anonymous')
+            ..setPath('/ws')
+            ..addProtocol(ListenerProtocol.websocket)
+            ..addProtocol(ListenerProtocol.rawsocket)
+            ..addProtocol(ListenerProtocol.http)
+            ..setWebSocketOptions(
+              const WebSocketListenerSettings(subprotocols: ['wamp.2.json']),
+            )
+            ..setHttpOptions(
+              HttpListenerSettings(
+                routes: [
+                  HttpRouteSettings(
+                    match: const HttpRouteMatch(path: '/mcp'),
+                    action: const HttpRouteAction(
+                      type: HttpRouteActionType.mcp,
+                      realm: 'realm1',
+                      sessionProfile: 'mcp',
+                      options: {
+                        'procedures': [
+                          {
+                            'procedure': 'app.blocked.documented',
+                            'allow_call': false,
+                          },
+                        ],
+                        'topics': [
+                          {
+                            'topic': 'app.write.configured',
+                            'allowPublish': true,
+                            'allowSubscribe': false,
+                          },
+                          {
+                            'topic': 'app.allowed.disabled',
+                            'allowSubscribe': false,
+                          },
+                          {
+                            'topic': 'app.allowed.configured',
+                            'allowSubscribe': true,
+                          },
+                        ],
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        )
+        ..addAuthenticator(
+          'anonymous',
+          const AuthenticatorDefinition(type: 'anonymous'),
+        )
+        ..setWorkerPool(const WorkerPoolSettings(minWorkers: 1)))
+      .build();
+}
+
+void _workerEntryPoint(Map<String, Object?> init) {
+  AuthorizationProviderFactoryRegistry.registerFactory(
+    const _MetaPolicyFactory(),
+  );
+  defaultRouterWorkerEntryPoint(init);
+}
+
+class _MetaPolicyFactory extends AuthorizationProviderFactory {
+  const _MetaPolicyFactory();
+  @override
+  String get type => 'meta-policy';
+  @override
+  Future<AuthorizationProvider> create(Map<String, Object?> options) async =>
+      _MetaPolicy();
+}
+
+class _MetaPolicy implements AuthorizationProvider {
+  @override
+  AuthorizationDecision? authorize(AuthorizationRequest request) {
+    if (request.authRole != 'anonymous') return null;
+    if (request.uri.startsWith('app.dynamic.') &&
+        (request.action == AuthorizationAction.call ||
+            request.action == AuthorizationAction.subscribe)) {
+      return const AuthorizationDecision.deny();
+    }
+    if (request.action == AuthorizationAction.subscribe &&
+        request.uri.startsWith('app.pattern') &&
+        request.targetMatchPolicy != null &&
+        request.targetMatchPolicy != PermissionMatchPolicy.exact) {
+      return const AuthorizationDecision.deny();
+    }
+    return null;
+  }
+}

--- a/packages/connectanum_router/test/router_integration_native_test.dart
+++ b/packages/connectanum_router/test/router_integration_native_test.dart
@@ -14051,16 +14051,10 @@ void main() {
           (documentedRegistrationLookup['structuredContent']
                   as Map<String, Object?>)['arguments']
               as List;
-      expect(documentedRegistrationIds, hasLength(1));
-      final documentedRegistrationId = (documentedRegistrationIds.single as num)
-          .toInt();
-      expect(documentedRegistrationId, greaterThan(0));
+      // Explicit API documentation is not permission to discover a registration.
+      expect(documentedRegistrationIds, isEmpty);
       final lateLiveRegistration = await serviceSession.register(
         'app.late.live',
-      );
-      expect(
-        lateLiveRegistration.registrationId,
-        isNot(equals(documentedRegistrationId)),
       );
 
       final documentedRegistrationList = await _callRouterJsonMethod(
@@ -14075,52 +14069,6 @@ void main() {
                       as Map<String, Object?>)['argumentsKeywords']
                   as Map<String, Object?>)['exact']
               as List;
-      expect(
-        documentedRegistrationExactIds,
-        contains(documentedRegistrationId),
-      );
-
-      final documentedRegistrationGet = await _callRouterJsonMethod(
-        client,
-        listener.port,
-        '/mcp/public',
-        'wamp.registration.get',
-        {'id': documentedRegistrationId},
-      );
-      final documentedRegistrationDetails =
-          (documentedRegistrationGet['structuredContent']
-                  as Map<String, Object?>)['argumentsKeywords']
-              as Map<String, Object?>;
-      expect(
-        documentedRegistrationDetails,
-        containsPair('uri', 'app.documented.only'),
-      );
-
-      final documentedRegistrationCallees = await _callRouterJsonMethod(
-        client,
-        listener.port,
-        '/mcp/public',
-        'wamp.registration.list_callees',
-        {'id': documentedRegistrationId},
-      );
-      expect(
-        (documentedRegistrationCallees['structuredContent']
-            as Map<String, Object?>)['arguments'],
-        isEmpty,
-      );
-
-      final documentedRegistrationCalleeCount = await _callRouterJsonMethod(
-        client,
-        listener.port,
-        '/mcp/public',
-        'wamp.registration.count_callees',
-        {'id': documentedRegistrationId},
-      );
-      expect(
-        (documentedRegistrationCalleeCount['structuredContent']
-            as Map<String, Object?>)['arguments'],
-        equals([0]),
-      );
 
       final subscribeResult = await _callMcpTool(
         client,
@@ -14940,6 +14888,14 @@ void main() {
           (secureJsonDirectDocumentedRegistration.arguments.single as num)
               .toInt();
       expect(secureJsonDirectDocumentedRegistrationId, greaterThan(0));
+      expect(
+        lateLiveRegistration.registrationId,
+        isNot(equals(secureJsonDirectDocumentedRegistrationId)),
+      );
+      expect(
+        documentedRegistrationExactIds,
+        isNot(contains(secureJsonDirectDocumentedRegistrationId)),
+      );
       final secureJsonDirectDocumentedRegistrationDetails =
           await secureJsonPostClient.getWampRegistration(
             secureJsonDirectDocumentedRegistrationId,
@@ -14950,6 +14906,43 @@ void main() {
         secureJsonDirectDocumentedRegistrationDetails.argumentsKeywords,
         containsPair('uri', 'app.documented.only'),
       );
+      final authorizedRegistrations = await secureJsonPostClient
+          .callWampMetaProcedure('wamp.registration.list', directJson: true);
+      expect(
+        authorizedRegistrations.argumentsKeywords['exact'],
+        contains(secureJsonDirectDocumentedRegistrationId),
+      );
+      for (final method in ['get', 'list_callees', 'count_callees']) {
+        final hidden = await _callRouterJsonMethod(
+          client,
+          listener.port,
+          '/mcp/public',
+          'wamp.registration.$method',
+          {'id': secureJsonDirectDocumentedRegistrationId},
+        );
+        final missing = await _callRouterJsonMethod(
+          client,
+          listener.port,
+          '/mcp/public',
+          'wamp.registration.$method',
+          {'id': 9007199254740990},
+        );
+        expect(
+          hidden['structuredContent'],
+          equals(missing['structuredContent']),
+        );
+        if (method != 'get') {
+          final authorized = await secureJsonPostClient.callWampMetaProcedure(
+            'wamp.registration.$method',
+            arguments: [secureJsonDirectDocumentedRegistrationId],
+            directJson: true,
+          );
+          expect(
+            authorized.arguments,
+            method == 'list_callees' ? isEmpty : equals([0]),
+          );
+        }
+      }
 
       final secureJsonDirectResources = await secureJsonPostClient
           .listResources(


### PR DESCRIPTION
## Summary
- Require subscribe authorization for WAMP and MCP subscription Meta discovery instead of accepting publish-only permission.
- Close the configured MCP registration call-authorization bypass and pass subscription match-policy context to dynamic authorization.
- Cover WebSocket, RawSocket, direct JSON, Streamable HTTP, hidden-ID lookups/details/counts, and authorized positive cases.

## Verification
- Clean-tree bin/verify passed, including 482 router tests and Chrome/Dart2Wasm coverage.
- CI: https://github.com/konsultaner/connectanum-dart/actions/runs/34331583523 (all four jobs passed).
- Package publish dry run: https://github.com/konsultaner/connectanum-dart/actions/runs/34331583640 (passed).
- Strict master baseline and exact-head branch CI/log/package-readiness audits passed.

This merges the verified source fix only. It does not change package versions, create release tags, or publish to pub.dev.