### PR TITLE
fix(ci): isolate coverage downloads from pub publishing auth

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -103,6 +103,13 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1
 
+      # Codecov needs OIDC, but public dependency downloads do not need pub auth.
+      - name: Use anonymous pub.dev downloads
+        run: |
+          if dart pub token list | grep -Fxq 'https://pub.dev'; then
+            dart pub token remove https://pub.dev
+          fi
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Bootstrap workspace

--- a/docs/exec-plans/2026-09-09-meta-discovery-authorization.md
+++ b/docs/exec-plans/2026-09-09-meta-discovery-authorization.md
@@ -1,6 +1,6 @@
 # Meta Discovery Authorization
 
-Status: implementation verified; branch publication requested, master integration and package release pending
+Status: source fix merged; coverage bootstrap repair in progress; package release pending
 Started: 2026-09-09
 Completed: 2026-09-09
 
@@ -70,3 +70,49 @@ IDs indistinguishable from missing IDs through the related Meta endpoints.
   release to receive this fix; pushing this branch does not publish packages.
   Resume the broader WampApp plan without treating this source verification as
   evidence of a package publication or deployment.
+- Commit `16d0efa5` is pushed to both GitLab and GitHub on
+  `codex/meta-discovery-authorization`. Fresh clean-tree `bin/verify` passes.
+  CI `34331583523` passes all four jobs and package publish dry run `34331583640`
+  passes, both at the exact commit. The strict master deployment baseline and
+  branch exact-head clean-CI/log, relevant package dry-run, visible-workflow,
+  and router-package audits pass. No merge, release tag, or package publication
+  was performed. Post-push evidence notes are held for the next implementation
+  commit rather than creating a docs-only bookkeeping commit.
+- The user requested master integration. Opened
+  [PR #89](https://github.com/konsultaner/connectanum-dart/pull/89) from the
+  verified security branch. GitHub reports no merge conflicts but requires one
+  approving review; the normal merge command was rejected by branch policy.
+  PR-triggered CI is running. Neither master remote has moved from `a5613d17`,
+  and no branch-protection bypass or release publication was performed.
+- On 2026-09-10, the user merged PR #89 at `04123953`. Its source tree matches
+  the verified `16d0efa5` tree exactly. Fast-forwarded local and GitLab master
+  to the GitHub merge commit while preserving uncommitted evidence notes.
+  Post-merge package publish dry run `34472422572` passes; CI `34472422608`,
+  WAMP Profile Benchmarks `34472422573`, and fresh local `bin/verify` are running.
+  This source integration does not publish a new package version.
+
+## Post-Merge CI Repair
+
+- Master `04123953` passes fresh local `bin/verify`, hosted package publish
+  dry run `34472422572`, WAMP Profile Benchmarks `34472422573`, and strict
+  baseline/package/benchmark audits. CI `34472422608` passes Fast Checks,
+  WampApp Consumer, and Full Verify. Coverage fails before collection with
+  pub.dev authorization errors on both the initial job and a targeted rerun.
+- Coverage grants `id-token: write` for Codecov. Its setup-dart step registers
+  a pub.dev token automatically; other test jobs resolve public dependencies
+  without that token. Keep Codecov OIDC, artifact strictness, and publishing
+  workflows unchanged. Remove only the coverage runner's pub.dev token before
+  bootstrap, guarded by token-list presence because absent removal exits 65.
+- Regression tests execute the exact workflow shell block against dummy
+  env-var tokens, preserving another registry and proving repeated cleanup.
+  Both tests failed before the fix and pass afterward. All 22 verification
+  script tests and baseline `bin/test-fast` pass; fresh `bin/verify` is running.
+- Dart's [token store](https://github.com/dart-lang/pub/blob/master/lib/src/authentication/token_store.dart)
+  uses the [platform configuration directory](https://github.com/dart-lang/pub/blob/master/lib/src/io.dart),
+  not `PUB_CACHE`. The fixture now isolates HOME, APPDATA, XDG_CONFIG_HOME,
+  and PUB_CACHE, clears inherited test config overrides, and refuses writes
+  unless CLI help confirms its temporary token location. The initial fixture
+  mistakenly created a local dummy-token file; test entries were removed and
+  the generated file deleted. The pre-existing OAuth login file was unchanged.
+- Follow-up branch: `codex/coverage-pub-auth-isolation`. Master remains red
+  until the workflow fix has hosted evidence and protected-branch integration.

--- a/docs/project_state.md
+++ b/docs/project_state.md
@@ -1,9 +1,10 @@
 # Project State
 
-Last updated: 2026-09-09
-Current branch: `codex/meta-discovery-authorization`
+Last updated: 2026-09-10
+Current branch: `codex/coverage-pub-auth-isolation`
 Current milestone: the WAMP Meta discovery authorization fix is implemented
-and locally verified. Its completed plan is
+and merged into both master remotes; repair the post-merge coverage bootstrap
+authentication failure before further release work. Its implementation plan is
 `docs/exec-plans/2026-09-09-meta-discovery-authorization.md`; the broader active
 consumer plan remains `docs/exec-plans/2026-08-24-wamp-app.md`.
 Live WebSocket, RawSocket, MCP direct JSON, and
@@ -20,10 +21,39 @@ one obsolete MCP smoke expectation for the configured-registration bypass;
 it now checks public nondisclosure and authorized-member visibility. The final
 `bin/verify` rerun passes, including all 482 router tests, six isolated remote-auth
 tests, 13 zero-copy tests, package-consumer and live MCP smokes, 124 benchmark
-tests, and Chrome/Dart2Wasm coverage. This source fix is isolated on the security
-branch; integration into master and the next synchronized beta release are
-still required before published-package consumers receive it. Branch publication
-does not publish packages. The beta.5 packages are unchanged.
+tests, and Chrome/Dart2Wasm coverage. This source fix is now on master; the next
+synchronized beta release is still required before published-package consumers
+receive it. Master integration does not publish packages. The beta.5 packages
+are unchanged.
+
+Commit `16d0efa5` is pushed to both maintained security-branch remotes. A fresh
+clean-tree `bin/verify` passes. Hosted CI `34331583523` passes all four jobs and
+package publish dry run `34331583640` passes at that exact head. The strict
+master deployment baseline and branch-scoped exact-head CI/log, package dry-run,
+workflow-visibility, and router-package audits pass. These post-push evidence
+notes remain uncommitted until the next implementation commit, per policy.
+
+[PR #89](https://github.com/konsultaner/connectanum-dart/pull/89) was merged by
+the user on 2026-09-10 at `04123953`. Local master and both maintained remotes
+now match that merge commit, whose source tree is identical to `16d0efa5`.
+Fresh master `bin/verify`, package publish dry run `34472422572`, and WAMP
+Profile Benchmarks `34472422573` pass. Strict baseline, package dry-run, and
+benchmark artifact audits pass at the merge commit. CI `34472422608` passes
+Fast Checks, WampApp Consumer, and Full Verify, but coverage bootstrap fails
+twice with pub.dev authorization errors, including a targeted rerun. The
+missing coverage artifact is secondary; coverage never ran.
+No release tag or package publication was requested or performed.
+
+The follow-up branch removes only the automatically registered pub.dev token
+from the ephemeral coverage runner before bootstrap, retaining Codecov OIDC and
+all publishing workflows. A guarded token-list check handles absent tokens.
+Two fail-first regressions verify step ordering, unchanged Codecov/strict
+artifact settings, real Dart token removal, another registry's preservation,
+and repeated cleanup. The fixture isolates both cache and platform configuration
+directories and confirms the temporary token path before writes. Baseline
+`bin/test-fast` and all 22 verification-script tests pass; fresh `bin/verify`
+for the workflow follow-up is running. Master CI remains red until this fix is
+independently reviewed and merged.
 
 Previous milestone: harden the standalone WampApp as a consumer-facing
 application on top of the merged and published `3.0.0-beta.5` graph. The main

--- a/tool/test_verification_scripts.py
+++ b/tool/test_verification_scripts.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import tempfile
 import textwrap
@@ -55,6 +56,91 @@ VERIFY = REPO_ROOT / "bin" / "verify"
 
 
 class VerificationScriptsTest(unittest.TestCase):
+    def test_coverage_isolates_pub_download_auth_from_codecov_oidc(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/dart.yml").read_text()
+        coverage = workflow.split("\n  coverage:\n", 1)[1]
+        cleanup = "dart pub token remove https://pub.dev"
+
+        self.assertIn(cleanup, coverage)
+        self.assertLess(
+            coverage.index("uses: dart-lang/setup-dart@"), coverage.index(cleanup)
+        )
+        self.assertLess(coverage.index(cleanup), coverage.index("run: bin/bootstrap"))
+        self.assertLess(
+            coverage.index(cleanup),
+            coverage.index("run: dart pub global activate coverage"),
+        )
+        self.assertIn("id-token: write", coverage)
+        self.assertIn("uses: codecov/codecov-action@", coverage)
+        self.assertIn("use_oidc: true", coverage)
+        self.assertIn("fail_ci_if_error: true", coverage)
+        self.assertIn("if-no-files-found: error", coverage)
+
+    def test_coverage_pub_token_cleanup_preserves_other_registries(self) -> None:
+        workflow = (REPO_ROOT / ".github/workflows/dart.yml").read_text()
+        coverage = workflow.split("\n  coverage:\n", 1)[1]
+        marker = "      - name: Use anonymous pub.dev downloads\n"
+        self.assertIn(marker, coverage)
+        step = coverage.split(marker, 1)[1].split("\n      - ", 1)[0]
+        command = textwrap.dedent(step.split("        run: |\n", 1)[1])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            env = dict(
+                os.environ,
+                PUB_CACHE=tmp_dir,
+                HOME=tmp_dir,
+                APPDATA=tmp_dir,
+                XDG_CONFIG_HOME=tmp_dir,
+                CONNECTANUM_TEST_PUB_TOKEN="not-a-real-token",
+                DART_SUPPRESS_ANALYTICS="true",
+            )
+            env.pop("_PUB_TEST_CONFIG_DIR", None)
+
+            def run_dart(*args: str) -> str:
+                result = subprocess.run(
+                    ["dart", *args],
+                    env=env,
+                    cwd=REPO_ROOT,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout)
+                return result.stdout
+
+            def cleanup() -> None:
+                result = subprocess.run(
+                    ["bash", "-euo", "pipefail", "-c", command],
+                    env=env,
+                    cwd=REPO_ROOT,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout)
+
+            # Refuse token writes unless Dart confirms an isolated config path.
+            self.assertIn(tmp_dir, run_dart("pub", "token", "add", "--help"))
+            for host in ("https://pub.dev", "https://packages.example.test"):
+                run_dart(
+                    "pub", "token", "add", host,
+                    "--env-var", "CONNECTANUM_TEST_PUB_TOKEN",
+                )
+                self.assertEqual(
+                    len(list(Path(tmp_dir).rglob("pub-tokens.json"))), 1
+                )
+            self.assertIn("https://pub.dev", run_dart("pub", "token", "list"))
+            cleanup()
+            remaining = run_dart("pub", "token", "list")
+            self.assertNotIn("https://pub.dev", remaining)
+            self.assertIn("https://packages.example.test", remaining)
+            cleanup()
+            self.assertEqual(remaining, run_dart("pub", "token", "list"))
+
     def test_core_shell_scripts_are_bash_syntax_clean(self) -> None:
         for script_path in [
             BOOTSTRAP,


### PR DESCRIPTION
## Why
PR #89 is merged into both master remotes at 04123953. Its post-merge CI passed Fast Checks, WampApp Consumer, and Full Verify, but coverage bootstrap failed twice because setup-dart automatically configured a pub.dev OIDC token when the job enabled OIDC for Codecov. Public dependency downloads were rejected before coverage ran.

## Fix
Remove only the ephemeral coverage runner pub.dev token before bootstrap, guarded so an absent token is safe. Keep Codecov OIDC, strict uploads, and all package publishing workflows unchanged.

## Verification
- Baseline bin/test-fast passes.
- Two fail-first regressions pass, including executing the exact workflow shell block against real Dart CLI tokens, preserving another registry and repeated cleanup.
- The test isolates HOME, APPDATA, XDG_CONFIG_HOME, and PUB_CACHE, and verifies the temporary token path before writes.
- All 22 verification-script tests pass.
- Full local bin/verify and hosted branch checks are running.

This is a CI-only repair. No versions, release tags, or pub.dev packages change.